### PR TITLE
Fix OpenXR include directory and CMake dependency

### DIFF
--- a/cmake/GraphicsSample.cmake
+++ b/cmake/GraphicsSample.cmake
@@ -29,14 +29,14 @@ function(_add_sample_internal)
 
     target_link_libraries("${TARGET_NAME}" PUBLIC ppx glfw)
 
-#OpenXR libs
-if (PPX_BUILD_XR)
-    if (PPX_MSW OR PPX_LINUX)
-        target_link_libraries(${TARGET_NAME} PUBLIC openxr_loader)
-    else ()
-        message(FATAL_ERROR "OpenXR not supported on GGP")
-    endif ()
-endif()
+    # OpenXR libs
+    if (PPX_BUILD_XR)
+        if (PPX_MSW OR PPX_LINUX)
+            target_link_libraries(${TARGET_NAME} PUBLIC openxr_loader)
+        else ()
+            message(FATAL_ERROR "OpenXR not supported on GGP")
+        endif ()
+    endif()
 
     add_dependencies("${TARGET_NAME}" ppx_assets)
     if (DEFINED ARG_DEPENDENCIES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -491,11 +491,14 @@ if (PPX_VULKAN)
     )
 endif()
 
-# Include OpenXR directories if OpenXR is enabled
+# Include OpenXR directories if OpenXR is enabled.
+# The OpenXR headers are generated at build time, so introduce a dependency
+# and look for headers in the build directory.
 if (PPX_BUILD_XR)
+    add_dependencies(${PROJECT_NAME} generate_openxr_header)
     target_include_directories(
         ${PROJECT_NAME}
-        PUBLIC ${PPX_DIR}/build/third_party/OpenXR-SDK-Source/include
+        PUBLIC ${CMAKE_BINARY_DIR}/third_party/OpenXR-SDK-Source/include
     )
 endif()
 
@@ -533,7 +536,7 @@ endif()
 if (PPX_BUILD_XR)
 	target_compile_definitions(
         ${PROJECT_NAME}
-        PUBLIC  PPX_BUILD_XR
+        PUBLIC PPX_BUILD_XR
     )
 endif()
 


### PR DESCRIPTION
Since we're using `OpenXR-SDK-Source`, headers are generated at build time. We must look for them in the build directory, and add a dependency to the target that generates them.

The dependency was missing and the build directory was hardcoded.  Also fixed some formatting.