### PR TITLE
Add support for debug capture for XR

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -210,6 +210,7 @@ struct ApplicationSettings
     bool enableImGui           = false;
     bool allowThirdPartyAssets = false;
     bool enableXR              = false;
+    bool enableXRDebugCapture  = false;
 
     struct
     {
@@ -358,6 +359,11 @@ public:
     {
         return mXrComponent;
     }
+
+    grfx::SwapchainPtr GetDebugCaptureSwapchain() const
+    {
+        return GetSwapchain(mDebugCaptureSwapchainIndex);
+    }
 #endif
 private:
     void   InternalCtor();
@@ -420,6 +426,7 @@ private:
 
 #if defined(PPX_BUILD_XR)
     XrComponent mXrComponent;
+    uint32_t    mDebugCaptureSwapchainIndex = 0;
 #endif
 };
 

--- a/src/ppx/xr_component.cpp
+++ b/src/ppx/xr_component.cpp
@@ -301,7 +301,7 @@ void XrComponent::BeginFrame(const std::vector<grfx::SwapchainPtr>& swapchains)
     }
 
     mCompositionLayerProjectionViews.resize(viewCount);
-    PPX_ASSERT_MSG(swapchains.size() == viewCount, "Swapchain needs to match number of views!");
+    PPX_ASSERT_MSG(swapchains.size() >= viewCount, "Number of swapchains needs to be larger than or equal to the number of views!");
     for (uint32_t i = 0; i < viewCount; ++i) {
         mCompositionLayerProjectionViews[i]                           = {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW};
         mCompositionLayerProjectionViews[i].pose                      = mViews[i].pose;


### PR DESCRIPTION
Create a swapchain that is only for debug capture purpose, and present graphics queue on this debug swapchain in order to allow gpu debug tools (like renderdoc) to make captures. 