### PR TITLE
Fix Vulkan 1.3 ifdef

### DIFF
--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -295,9 +295,9 @@ Result Device::CreateApiObjects(const grfx::DeviceCreateInfo* pCreateInfo)
 #if defined(VK_KHR_dynamic_rendering)
 
 #ifndef VK_API_VERSION_1_3
-    VkPhysicalDeviceDynamicRenderingFeatures dynamicRenderingFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES};
-#else
     VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamicRenderingFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR};
+#else
+    VkPhysicalDeviceDynamicRenderingFeatures dynamicRenderingFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES};
 #endif
 
     if (mHasDynamicRendering) {


### PR DESCRIPTION
The condition was inverted. I kept `ifndef` instead of just `ifdef` because of consistency with others in the same file.

This problem only caused a build failure with old SDKs.