### PR TITLE
[D3D12] Add XR depth swapchain and submit depth images each frame.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,8 +152,11 @@ include(GraphicsSample)
 # ------------------------------------------------------------------------------
 
 if(MSVC)
-    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} /MP")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /Zc:__cplusplus /std:c++20")
+    # Disable the following warnings:
+    # 26812: unscoped enums are widely used by the project and dependencies.
+    set(MSVC_DISABLED_WARNINGS "/wd26812")
+    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} ${MSVC_DISABLED_WARNINGS} /MP")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MSVC_DISABLED_WARNINGS} /MP /Zc:__cplusplus /std:c++20")
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -fdiagnostics-color=always")
 endif()

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -209,8 +209,25 @@ struct ApplicationSettings
     bool enableDisplay         = true;
     bool enableImGui           = false;
     bool allowThirdPartyAssets = false;
-    bool enableXR              = false;
-    bool enableXRDebugCapture  = false;
+
+    struct
+    {
+        bool enable             = false;
+        bool enableDebugCapture = false;
+
+        float depthNearPlane = 0.001f;
+        float depthFarPlane  = 10000.0f;
+
+        // OpenXR uses a right-handed system.
+        // The `pos` here is the center position in view space.
+        // A detailed description can be found here:
+        // https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrCompositionLayerQuad.html
+        struct
+        {
+            float3 pos;
+            float2 size;
+        } ui;
+    } xr;
 
     struct
     {
@@ -242,18 +259,6 @@ struct ApplicationSettings
             grfx::Format depthFormat = grfx::FORMAT_UNDEFINED;
             uint32_t     imageCount  = 2;
         } swapchain;
-
-#if defined(PPX_BUILD_XR)
-        // OpenXR is having a right handed system.
-        // The pos here is the center position in view space.
-        // Detailed description can be found here:
-        // https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrCompositionLayerQuad.html
-        struct
-        {
-            XrVector3f  pos;
-            XrExtent2Df size;
-        } ui;
-#endif
     } grfx;
 };
 
@@ -366,6 +371,12 @@ public:
 
     const KeyState& GetKeyState(KeyCode code) const;
     float2          GetNormalizedDeviceCoordinates(int32_t x, int32_t y) const;
+
+    bool IsXrEnabled() const
+    {
+        return mSettings.xr.enable;
+    }
+
 #if defined(PPX_BUILD_XR)
     const XrComponent& GetXrComponent() const
     {

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -215,8 +215,9 @@ struct ApplicationSettings
         bool enable             = false;
         bool enableDebugCapture = false;
 
-        float depthNearPlane = 0.001f;
-        float depthFarPlane  = 10000.0f;
+        // Whether to create depth swapchains in addition to color swapchains,
+        // and submit the depth info to the runtime as an additional layer.
+        bool enableDepthSwapchain = false;
 
         // OpenXR uses a right-handed system.
         // The `pos` here is the center position in view space.
@@ -378,7 +379,7 @@ public:
     }
 
 #if defined(PPX_BUILD_XR)
-    const XrComponent& GetXrComponent() const
+    XrComponent& GetXrComponent()
     {
         return mXrComponent;
     }

--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -145,9 +145,13 @@ public:
         return mCreateInfo.pXrComponent != nullptr;
     }
 
-    XrSwapchain GetXrSwapchain() const
+    XrSwapchain GetXrColorSwapchain() const
     {
-        return mXrSwapchain;
+        return mXrColorSwapchain;
+    }
+    XrSwapchain GetXrDepthSwapchain() const
+    {
+        return mXrDepthSwapchain;
     }
 #endif
 protected:
@@ -167,9 +171,12 @@ protected:
     std::vector<grfx::ImagePtr>      mColorImages;
     std::vector<grfx::RenderPassPtr> mClearRenderPasses;
     std::vector<grfx::RenderPassPtr> mLoadRenderPasses;
+
 #if defined(PPX_BUILD_XR)
-    XrSwapchain mXrSwapchain = XR_NULL_HANDLE;
+    XrSwapchain mXrColorSwapchain = XR_NULL_HANDLE;
+    XrSwapchain mXrDepthSwapchain = XR_NULL_HANDLE;
 #endif
+
     // Keeps track of the image index returned by the
     // last AcquireNextImage call.
     uint32_t currentImageIndex = 0;

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -36,6 +36,8 @@
 #include <openxr/openxr_platform.h>
 #include <ppx/grfx/grfx_config.h>
 
+#include <optional>
+
 #define CHECK_XR_CALL(cmd) \
     PPX_ASSERT_MSG(cmd == XR_SUCCESS, "XR call failed!");
 
@@ -53,18 +55,17 @@ enum struct XrRefSpace
 //!
 struct XrComponentCreateInfo
 {
-    grfx::Api               api             = grfx::API_UNDEFINED; // Direct3D or Vulkan.
-    std::string             appName         = "";
-    grfx::Format            colorFormat     = grfx::FORMAT_B8G8R8A8_SRGB;
-    grfx::Format            depthFormat     = grfx::FORMAT_D32_FLOAT;
-    float                   depthNearPlane  = 0.001f;
-    float                   depthFarPlane   = 10000.0f;
-    XrRefSpace              refSpaceType    = XrRefSpace::XR_STAGE;
-    XrViewConfigurationType viewConfigType  = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
-    XrVector3f              quadLayerPos    = {0, 0, 0};
-    XrExtent2Df             quadLayerSize   = {1.f, 1.f};
-    bool                    enableDebug     = false;
-    bool                    enableQuadLayer = false;
+    grfx::Api               api                  = grfx::API_UNDEFINED; // Direct3D or Vulkan.
+    std::string             appName              = "";
+    grfx::Format            colorFormat          = grfx::FORMAT_B8G8R8A8_SRGB;
+    grfx::Format            depthFormat          = grfx::FORMAT_D32_FLOAT;
+    XrRefSpace              refSpaceType         = XrRefSpace::XR_STAGE;
+    XrViewConfigurationType viewConfigType       = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
+    XrVector3f              quadLayerPos         = {0, 0, 0};
+    XrExtent2Df             quadLayerSize        = {1.f, 1.f};
+    bool                    enableDebug          = false;
+    bool                    enableQuadLayer      = false;
+    bool                    enableDepthSwapchain = false;
 };
 
 //! @class XrComponent
@@ -77,11 +78,12 @@ public:
 
     void PollEvents(bool& exitRenderLoop);
 
-    void BeginFrame(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t layerProjStartIndex, uint32_t layerQuadStartIndex);
-    void EndFrame();
+    void BeginFrame();
+    void EndFrame(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t layerProjStartIndex, uint32_t layerQuadStartIndex);
 
     grfx::Format GetColorFormat() const { return mCreateInfo.colorFormat; }
     grfx::Format GetDepthFormat() const { return mCreateInfo.depthFormat; }
+    bool         UsesDepthSwapchains() const { return mCreateInfo.enableDepthSwapchain; }
 
     // This is a hack that assumes both views have the same width/height/sample count
     uint32_t GetWidth() const
@@ -108,9 +110,14 @@ public:
     XrSession  GetSession() const { return mSession; }
     void       SetCurrentViewIndex(uint32_t index) { mCurrentViewIndex = index; }
     uint32_t   GetCurrentViewIndex() const { return mCurrentViewIndex; }
-    glm::mat4  GetViewMatrixForCurrentView() const;
-    glm::mat4  GetProjectionMatrixForCurrentView() const;
-    XrPosef    GetCurrentPose() const;
+
+    // Computes the projection matrix for the current view given the near and
+    // far frustum planes. The values for the frustum planes will be sent to
+    // the OpenXR runtime as part of the frame depth info submission, and the
+    // caller must ensure that the values do not change within a frame.
+    glm::mat4 GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(float nearZ, float farZ);
+    glm::mat4 GetViewMatrixForCurrentView() const;
+    XrPosef   GetPoseForCurrentView() const;
 
     bool IsSessionRunning() const { return mIsSessionRunning; }
     bool ShouldRender() const { return mShouldRender; }
@@ -123,28 +130,27 @@ private:
     XrSystemId mSystemId = XR_NULL_SYSTEM_ID;
     XrSession  mSession  = XR_NULL_HANDLE;
 
-    std::vector<XrViewConfigurationView>          mConfigViews;
-    std::vector<XrCompositionLayerProjectionView> mCompositionLayerProjectionViews;
-    std::vector<XrCompositionLayerDepthInfoKHR>   mCompositionLayerDepthInfos;
-    std::vector<XrView>                           mViews;
+    std::vector<XrViewConfigurationView> mConfigViews;
+    std::vector<XrView>                  mViews;
+    uint32_t                             mCurrentViewIndex = 0;
 
-    XrSpace                  mRefSpace              = XR_NULL_HANDLE;
-    XrSpace                  mUISpace               = XR_NULL_HANDLE;
-    XrSessionState           mSessionState          = XR_SESSION_STATE_UNKNOWN;
-    XrEnvironmentBlendMode   mBlend                 = XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM;
-    XrDebugUtilsMessengerEXT mDebugUtilMessenger    = XR_NULL_HANDLE;
-    bool                     mIsSessionRunning      = false;
-    bool                     mShouldRender          = false;
-    bool                     mShouldSubmitDepthInfo = false;
+    XrSpace                  mRefSpace           = XR_NULL_HANDLE;
+    XrSpace                  mUISpace            = XR_NULL_HANDLE;
+    XrSessionState           mSessionState       = XR_SESSION_STATE_UNKNOWN;
+    XrEnvironmentBlendMode   mBlend              = XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM;
+    XrDebugUtilsMessengerEXT mDebugUtilMessenger = XR_NULL_HANDLE;
+    bool                     mIsSessionRunning   = false;
+    bool                     mShouldRender       = false;
+
+    std::optional<float> mNearPlaneForFrame     = std::nullopt;
+    std::optional<float> mFarPlaneForFrame      = std::nullopt;
+    bool                 mShouldSubmitDepthInfo = false;
 
     XrFrameState mFrameState = {
         .type = XR_TYPE_FRAME_STATE,
     };
 
-    XrEventDataBuffer            mEventDataBuffer;
-    XrCompositionLayerProjection mCompositionLayerProjection = {XR_TYPE_COMPOSITION_LAYER_PROJECTION};
-    XrCompositionLayerQuad       mCompositionLayerQuad       = {XR_TYPE_COMPOSITION_LAYER_QUAD};
-    uint32_t                     mCurrentViewIndex           = 0;
+    XrEventDataBuffer mEventDataBuffer;
 
     XrComponentCreateInfo mCreateInfo = {};
 };

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -57,6 +57,8 @@ struct XrComponentCreateInfo
     std::string             appName         = "";
     grfx::Format            colorFormat     = grfx::FORMAT_B8G8R8A8_SRGB;
     grfx::Format            depthFormat     = grfx::FORMAT_D32_FLOAT;
+    float                   depthNearPlane  = 0.001f;
+    float                   depthFarPlane   = 10000.0f;
     XrRefSpace              refSpaceType    = XrRefSpace::XR_STAGE;
     XrViewConfigurationType viewConfigType  = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
     XrVector3f              quadLayerPos    = {0, 0, 0};
@@ -107,7 +109,7 @@ public:
     void       SetCurrentViewIndex(uint32_t index) { mCurrentViewIndex = index; }
     uint32_t   GetCurrentViewIndex() const { return mCurrentViewIndex; }
     glm::mat4  GetViewMatrixForCurrentView() const;
-    glm::mat4  GetProjectionMatrixForCurrentView(float nearZ, float farZ) const;
+    glm::mat4  GetProjectionMatrixForCurrentView() const;
     XrPosef    GetCurrentPose() const;
 
     bool IsSessionRunning() const { return mIsSessionRunning; }
@@ -123,15 +125,17 @@ private:
 
     std::vector<XrViewConfigurationView>          mConfigViews;
     std::vector<XrCompositionLayerProjectionView> mCompositionLayerProjectionViews;
+    std::vector<XrCompositionLayerDepthInfoKHR>   mCompositionLayerDepthInfos;
     std::vector<XrView>                           mViews;
 
-    XrSpace                  mRefSpace           = XR_NULL_HANDLE;
-    XrSpace                  mUISpace            = XR_NULL_HANDLE;
-    XrSessionState           mSessionState       = XR_SESSION_STATE_UNKNOWN;
-    XrEnvironmentBlendMode   mBlend              = XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM;
-    XrDebugUtilsMessengerEXT mDebugUtilMessenger = XR_NULL_HANDLE;
-    bool                     mIsSessionRunning   = false;
-    bool                     mShouldRender       = false;
+    XrSpace                  mRefSpace              = XR_NULL_HANDLE;
+    XrSpace                  mUISpace               = XR_NULL_HANDLE;
+    XrSessionState           mSessionState          = XR_SESSION_STATE_UNKNOWN;
+    XrEnvironmentBlendMode   mBlend                 = XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM;
+    XrDebugUtilsMessengerEXT mDebugUtilMessenger    = XR_NULL_HANDLE;
+    bool                     mIsSessionRunning      = false;
+    bool                     mShouldRender          = false;
+    bool                     mShouldSubmitDepthInfo = false;
 
     XrFrameState mFrameState = {
         .type = XR_TYPE_FRAME_STATE,

--- a/projects/04_cube_xr/main.cpp
+++ b/projects/04_cube_xr/main.cpp
@@ -318,7 +318,7 @@ void ProjApp::Render()
         float4x4 V = glm::lookAt(float3(0, 0, 0), float3(0, 0, 1), float3(0, 1, 0));
 
         if (IsXrEnabled()) {
-            P = GetXrComponent().GetProjectionMatrixForCurrentView();
+            P = GetXrComponent().GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(0.001f, 10000.0f);
             V = GetXrComponent().GetViewMatrixForCurrentView();
         }
         float4x4 M   = glm::translate(float3(0, 0, -3)) * glm::rotate(t, float3(0, 0, 1)) * glm::rotate(t, float3(0, 1, 0)) * glm::rotate(t, float3(1, 0, 0));

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -135,12 +135,12 @@ void FishTornadoApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.numFramesInFlight     = 2;
     settings.grfx.enableDebug           = false;
     settings.grfx.pacedFrameRate        = 0;
-    settings.enableXR                   = true;
-    settings.enableXRDebugCapture       = true;
+    settings.xr.enable                  = true;
+    settings.xr.enableDebugCapture      = true;
     settings.grfx.swapchain.imageCount  = 3;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.ui.pos                = {0.2f, -0.3f, -0.5f};
-    settings.grfx.ui.size               = {1.f, 1.f};
+    settings.xr.ui.pos                  = {0.2f, -0.3f, -0.5f};
+    settings.xr.ui.size                 = {1.f, 1.f};
 #if defined(USE_DXIL)
     settings.grfx.enableDXIL = true;
 #endif
@@ -317,7 +317,7 @@ void FishTornadoApp::SetupPerFrame()
         PPX_CHECKED_CALL(frame.sceneShadowSet->UpdateSampledImage(RENDER_SHADOW_TEXTURE_REGISTER, 0, m1x1BlackTexture));
         PPX_CHECKED_CALL(frame.sceneShadowSet->UpdateSampler(RENDER_SHADOW_SAMPLER_REGISTER, 0, mClampedSampler));
 
-        if (GetSettings()->enableXR) {
+        if (IsXrEnabled()) {
             PPX_CHECKED_CALL(GetGraphicsQueue()->CreateCommandBuffer(&frame.uiCmd));
             PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.uiRenderCompleteFence));
         }
@@ -481,11 +481,11 @@ void FishTornadoApp::UpdateScene(uint32_t frameIndex)
     pSceneData->usePCF                     = static_cast<uint32_t>(mUsePCF);
 
     // no need to wait for imageAcquiredFence since xrWaitSwapchainImage is called in AcquireNextImage
-    if (GetSettings()->enableXR) {
+    if (IsXrEnabled()) {
         const XrVector3f& pos            = GetXrComponent().GetCurrentPose().position;
         pSceneData->eyePosition          = {pos.x, pos.y, pos.z};
         const glm::mat4 v                = GetXrComponent().GetViewMatrixForCurrentView();
-        const glm::mat4 p                = GetXrComponent().GetProjectionMatrixForCurrentView(PPX_CAMERA_DEFAULT_NEAR_CLIP, PPX_CAMERA_DEFAULT_FAR_CLIP);
+        const glm::mat4 p                = GetXrComponent().GetProjectionMatrixForCurrentView();
         pSceneData->viewMatrix           = v;
         pSceneData->projectionMatrix     = p;
         pSceneData->viewProjectionMatrix = p * v;
@@ -536,7 +536,7 @@ void FishTornadoApp::RenderSceneUsingSingleCommandBuffer(
         // -----------------------------------------------------------------------------------------
         bool updateFlocking = true;
         // only need to update flocking once per frame
-        if (GetSettings()->enableXR) {
+        if (IsXrEnabled()) {
             if (GetXrComponent().GetCurrentViewIndex() == 1) {
                 updateFlocking = false;
             }
@@ -575,7 +575,7 @@ void FishTornadoApp::RenderSceneUsingSingleCommandBuffer(
         beginInfo.RTVClearCount             = 1;
         beginInfo.RTVClearValues[0]         = {{kFogColor.r, kFogColor.g, kFogColor.b, 1.0f}};
 
-        if (!GetSettings()->enableXR) {
+        if (!IsXrEnabled()) {
             frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
         }
         frame.cmd->BeginRenderPass(&beginInfo);
@@ -598,7 +598,7 @@ void FishTornadoApp::RenderSceneUsingSingleCommandBuffer(
 
             mOcean.DrawForward(frameIndex, frame.cmd);
 
-            if (!GetSettings()->enableXR) {
+            if (!IsXrEnabled()) {
                 // Draw ImGui
                 DrawDebugInfo([this]() { this->DrawGui(); });
 #if defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
@@ -608,7 +608,7 @@ void FishTornadoApp::RenderSceneUsingSingleCommandBuffer(
             }
         }
         frame.cmd->EndRenderPass();
-        if (!GetSettings()->enableXR) {
+        if (!IsXrEnabled()) {
             frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_RENDER_TARGET, grfx::RESOURCE_STATE_PRESENT);
         }
 
@@ -635,7 +635,7 @@ void FishTornadoApp::RenderSceneUsingSingleCommandBuffer(
     submitInfo.commandBufferCount = 1;
     submitInfo.ppCommandBuffers   = &frame.cmd;
     // no need to use semaphore when XR is enabled
-    if (GetSettings()->enableXR) {
+    if (IsXrEnabled()) {
         submitInfo.waitSemaphoreCount   = 0;
         submitInfo.ppWaitSemaphores     = nullptr;
         submitInfo.signalSemaphoreCount = 0;
@@ -728,7 +728,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
     // ---------------------------------------------------------------------------------------------
     bool updateFlocking = true;
     // only need to update flocking once per frame
-    if (GetSettings()->enableXR) {
+    if (IsXrEnabled()) {
         if (GetXrComponent().GetCurrentViewIndex() == 1) {
             updateFlocking = false;
         }
@@ -817,7 +817,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         beginInfo.RTVClearCount             = 1;
         beginInfo.RTVClearValues[0]         = {{kFogColor.r, kFogColor.g, kFogColor.b, 1.0f}};
 
-        if (!GetSettings()->enableXR) {
+        if (!IsXrEnabled()) {
             frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
         }
         frame.cmd->BeginRenderPass(&beginInfo);
@@ -840,7 +840,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
 
             mOcean.DrawForward(frameIndex, frame.cmd);
 
-            if (!GetSettings()->enableXR) {
+            if (!IsXrEnabled()) {
                 // Draw ImGui
                 DrawDebugInfo([this]() { this->DrawGui(); });
 #if defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
@@ -850,7 +850,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
             }
         }
         frame.cmd->EndRenderPass();
-        if (!GetSettings()->enableXR) {
+        if (!IsXrEnabled()) {
             frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_RENDER_TARGET, grfx::RESOURCE_STATE_PRESENT);
         }
 
@@ -860,7 +860,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
 
     // Submit render work
     // no need to use semaphore when XR is enabled
-    if (GetSettings()->enableXR) {
+    if (IsXrEnabled()) {
         const grfx::Semaphore* pWaitSemaphores    = frame.shadowCompleteSemaphore;
         uint32_t               waitSemaphoreCount = 1;
 
@@ -917,7 +917,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.pFence               = frame.frameCompleteFence;
 
         // no need to use semaphore when XR is enabled
-        if (GetSettings()->enableXR) {
+        if (IsXrEnabled()) {
             submitInfo.signalSemaphoreCount = 0;
             submitInfo.ppSignalSemaphores   = nullptr;
         }
@@ -934,7 +934,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.ppSignalSemaphores   = &frame.frameCompleteSemaphore;
         submitInfo.pFence               = frame.frameCompleteFence;
         // no need to use semaphore when XR is enabled
-        if (GetSettings()->enableXR) {
+        if (IsXrEnabled()) {
             submitInfo.signalSemaphoreCount = 0;
             submitInfo.ppSignalSemaphores   = nullptr;
         }
@@ -953,12 +953,12 @@ void FishTornadoApp::Render()
 
     uint32_t imageIndex       = UINT32_MAX;
     uint32_t currentViewIndex = 0;
-    if (GetSettings()->enableXR) {
+    if (IsXrEnabled()) {
         currentViewIndex = GetXrComponent().GetCurrentViewIndex();
     }
 
     // Render UI into a different composition layer.
-    if (GetSettings()->enableXR && (currentViewIndex == 0) && GetSettings()->enableImGui) {
+    if (IsXrEnabled() && (currentViewIndex == 0) && GetSettings()->enableImGui) {
         grfx::SwapchainPtr uiSwapchain = GetUISwapchain();
         PPX_CHECKED_CALL(uiSwapchain->AcquireNextImage(UINT64_MAX, nullptr, nullptr, &imageIndex));
         PPX_CHECKED_CALL(frame.uiRenderCompleteFence->WaitAndReset());
@@ -1046,11 +1046,11 @@ void FishTornadoApp::Render()
     mLastFrameWasAsyncCompute = mUseAsyncCompute;
 
     // No need to present when XR is enabled.
-    if (!GetSettings()->enableXR) {
+    if (!IsXrEnabled()) {
         PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.frameCompleteSemaphore));
     }
     else {
-        if (GetSettings()->enableXRDebugCapture && (currentViewIndex == 1)) {
+        if (GetSettings()->xr.enableDebugCapture && (currentViewIndex == 1)) {
             // We could use semaphore to sync to have better performance,
             // but this requires modifying the submission code.
             // For debug capture we don't care about the performance,

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -480,12 +480,11 @@ void FishTornadoApp::UpdateScene(uint32_t frameIndex)
     pSceneData->shadowTextureDim           = float2(kShadowRes);
     pSceneData->usePCF                     = static_cast<uint32_t>(mUsePCF);
 
-    // no need to wait for imageAcquiredFence since xrWaitSwapchainImage is called in AcquireNextImage
     if (IsXrEnabled()) {
-        const XrVector3f& pos            = GetXrComponent().GetCurrentPose().position;
+        const XrVector3f& pos            = GetXrComponent().GetPoseForCurrentView().position;
         pSceneData->eyePosition          = {pos.x, pos.y, pos.z};
         const glm::mat4 v                = GetXrComponent().GetViewMatrixForCurrentView();
-        const glm::mat4 p                = GetXrComponent().GetProjectionMatrixForCurrentView();
+        const glm::mat4 p                = GetXrComponent().GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(PPX_CAMERA_DEFAULT_NEAR_CLIP, PPX_CAMERA_DEFAULT_FAR_CLIP);
         pSceneData->viewMatrix           = v;
         pSceneData->projectionMatrix     = p;
         pSceneData->viewProjectionMatrix = p * v;

--- a/projects/fishtornado_xr/Flocking.cpp
+++ b/projects/fishtornado_xr/Flocking.cpp
@@ -344,12 +344,10 @@ void Flocking::Update(uint32_t frameIndex)
         pFlockingData->timeDelta          = dt;
         pFlockingData->predPos            = pApp->GetShark()->GetPosition();
         pFlockingData->camPos             = pApp->GetCamera()->GetEyePosition();
-#if defined(PPX_BUILD_XR)
-        if (pApp->GetSettings()->enableXR) {
+        if (pApp->IsXrEnabled()) {
             const XrVector3f& pos = pApp->GetXrComponent().GetCurrentPose().position;
             pFlockingData->camPos = {pos.x, pos.y, pos.z};
         }
-#endif
     }
 }
 

--- a/projects/fishtornado_xr/Flocking.cpp
+++ b/projects/fishtornado_xr/Flocking.cpp
@@ -345,7 +345,7 @@ void Flocking::Update(uint32_t frameIndex)
         pFlockingData->predPos            = pApp->GetShark()->GetPosition();
         pFlockingData->camPos             = pApp->GetCamera()->GetEyePosition();
         if (pApp->IsXrEnabled()) {
-            const XrVector3f& pos = pApp->GetXrComponent().GetCurrentPose().position;
+            const XrVector3f& pos = pApp->GetXrComponent().GetPoseForCurrentView().position;
             pFlockingData->camPos = {pos.x, pos.y, pos.z};
         }
     }

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1296,12 +1296,11 @@ int Application::Run(int argc, char** argv)
         createInfo.appName               = mSettings.appName;
         createInfo.colorFormat           = grfx::FORMAT_B8G8R8A8_SRGB;
         createInfo.depthFormat           = grfx::FORMAT_D32_FLOAT;
-        createInfo.depthNearPlane        = mSettings.xr.depthNearPlane;
-        createInfo.depthFarPlane         = mSettings.xr.depthFarPlane;
         createInfo.refSpaceType          = XrRefSpace::XR_STAGE;
         createInfo.viewConfigType        = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
         createInfo.enableDebug           = mSettings.grfx.enableDebug;
         createInfo.enableQuadLayer       = mSettings.enableImGui;
+        createInfo.enableDepthSwapchain  = mSettings.xr.enableDepthSwapchain;
         createInfo.quadLayerPos          = XrVector3f{mSettings.xr.ui.pos.x, mSettings.xr.ui.pos.y, mSettings.xr.ui.pos.z};
         createInfo.quadLayerSize         = XrExtent2Df{mSettings.xr.ui.size.x, mSettings.xr.ui.size.y};
 
@@ -1405,7 +1404,7 @@ int Application::Run(int argc, char** argv)
             }
 
             if (mXrComponent.IsSessionRunning()) {
-                mXrComponent.BeginFrame(mSwapchain, 0, mUISwapchainIndex);
+                mXrComponent.BeginFrame();
                 if (mXrComponent.ShouldRender()) {
                     XrSwapchainImageReleaseInfo releaseInfo = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
                     uint32_t                    viewCount   = static_cast<uint32_t>(mXrComponent.GetViewCount());
@@ -1432,7 +1431,7 @@ int Application::Run(int argc, char** argv)
                         }
                     }
                 }
-                mXrComponent.EndFrame();
+                mXrComponent.EndFrame(mSwapchain, 0, mUISwapchainIndex);
             }
         }
         else

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -653,7 +653,7 @@ Result Application::InitializeGrfxDevice()
         ci.engineName               = mSettings.appName;
         ci.useSoftwareRenderer      = mStandardOptions.use_software_renderer;
 #if defined(PPX_BUILD_XR)
-        ci.pXrComponent = mSettings.enableXR ? &mXrComponent : nullptr;
+        ci.pXrComponent = mSettings.xr.enable ? &mXrComponent : nullptr;
 #endif
 
         Result ppxres = grfx::CreateInstance(&ci, &mInstance);
@@ -690,7 +690,7 @@ Result Application::InitializeGrfxDevice()
         ci.pVulkanDeviceFeatures  = nullptr;
         ci.enableDXIL             = mSettings.grfx.enableDXIL;
 #if defined(PPX_BUILD_XR)
-        ci.pXrComponent = mSettings.enableXR ? &mXrComponent : nullptr;
+        ci.pXrComponent = mSettings.xr.enable ? &mXrComponent : nullptr;
 #endif
 
         PPX_LOG_INFO("Creating application graphics device using " << gpu->GetDeviceName());
@@ -717,11 +717,11 @@ Result Application::InitializeGrfxSurface()
     }
 
 #if defined(PPX_BUILD_XR)
-    // No need to create the surface when XR is enabled
-    // the swapchain can be created from the OpenXR functions directly
-    if (!mSettings.enableXR
-        // surface is required for debug capture
-        || (mSettings.enableXR && mSettings.enableXRDebugCapture))
+    // No need to create the surface when XR is enabled.
+    // The swapchain will be created from the OpenXR functions directly.
+    if (!mSettings.xr.enable
+        // Surface is required for debug capture.
+        || (mSettings.xr.enable && mSettings.xr.enableDebugCapture))
 #endif
     // Surface
     {
@@ -747,7 +747,7 @@ Result Application::InitializeGrfxSurface()
     }
 
 #if defined(PPX_BUILD_XR)
-    if (mSettings.enableXR) {
+    if (mSettings.xr.enable) {
         const size_t viewCount = mXrComponent.GetViewCount();
         PPX_ASSERT_MSG(viewCount != 0, "The config views should be already created at this point!");
 
@@ -758,11 +758,11 @@ Result Application::InitializeGrfxSurface()
         ci.height                    = mSettings.window.height;
         ci.colorFormat               = mXrComponent.GetColorFormat();
         ci.depthFormat               = mXrComponent.GetDepthFormat();
-        ci.imageCount                = 0;                            // this will be derived from XrSwapchain
-        ci.presentMode               = grfx::PRESENT_MODE_UNDEFINED; // No present for XR
+        ci.imageCount                = 0;                            // This will be derived from XrSwapchain.
+        ci.presentMode               = grfx::PRESENT_MODE_UNDEFINED; // No present for XR.
         ci.pXrComponent              = &mXrComponent;
 
-        // the +1 is for UI
+        // We have one swapchain for each view, and one swapchain for the UI.
         const size_t swapchainCount = viewCount + 1;
         mStereoscopicSwapchainIndex = 0;
         mUISwapchainIndex           = static_cast<uint32_t>(viewCount);
@@ -779,9 +779,9 @@ Result Application::InitializeGrfxSurface()
         mSettings.grfx.swapchain.imageCount = mSwapchain[0]->GetImageCount();
     }
 
-    if (!mSettings.enableXR
-        // extra swapchain for capture XR frames
-        || (mSettings.enableXR && mSettings.enableXRDebugCapture))
+    if (!mSettings.xr.enable
+        // Extra swapchain for XR debug capture.
+        || (mSettings.xr.enable && mSettings.xr.enableDebugCapture))
 #endif
     // Swapchain
     {
@@ -839,7 +839,7 @@ Result Application::InitializeGrfxSurface()
             return ppxres;
         }
 #if defined(PPX_BUILD_XR)
-        if (mSettings.enableXR && mSettings.enableXRDebugCapture) {
+        if (mSettings.xr.enable && mSettings.xr.enableDebugCapture) {
             mDebugCaptureSwapchainIndex = static_cast<uint32_t>(mSwapchain.size());
             // The window size could be smaller than the requested one in glfwCreateWindow
             // So the final swapchain size for window needs to be adjusted
@@ -1290,18 +1290,20 @@ int Application::Run(int argc, char** argv)
     }
 
 #if defined(PPX_BUILD_XR)
-    if (mSettings.enableXR) {
+    if (mSettings.xr.enable) {
         XrComponentCreateInfo createInfo = {};
         createInfo.api                   = mSettings.grfx.api;
         createInfo.appName               = mSettings.appName;
         createInfo.colorFormat           = grfx::FORMAT_B8G8R8A8_SRGB;
         createInfo.depthFormat           = grfx::FORMAT_D32_FLOAT;
+        createInfo.depthNearPlane        = mSettings.xr.depthNearPlane;
+        createInfo.depthFarPlane         = mSettings.xr.depthFarPlane;
         createInfo.refSpaceType          = XrRefSpace::XR_STAGE;
         createInfo.viewConfigType        = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
         createInfo.enableDebug           = mSettings.grfx.enableDebug;
         createInfo.enableQuadLayer       = mSettings.enableImGui;
-        createInfo.quadLayerPos          = mSettings.grfx.ui.pos;
-        createInfo.quadLayerSize         = mSettings.grfx.ui.size;
+        createInfo.quadLayerPos          = XrVector3f{mSettings.xr.ui.pos.x, mSettings.xr.ui.pos.y, mSettings.xr.ui.pos.z};
+        createInfo.quadLayerSize         = XrExtent2Df{mSettings.xr.ui.size.x, mSettings.xr.ui.size.y};
 
         mXrComponent.InitializeBeforeGrfxDeviceInit(createInfo);
     }
@@ -1314,7 +1316,7 @@ int Application::Run(int argc, char** argv)
     }
 
 #if defined(PPX_BUILD_XR)
-    if (mSettings.enableXR) {
+    if (mSettings.xr.enable) {
         mXrComponent.InitializeAfterGrfxDeviceInit(mInstance);
         mSettings.window.width  = mXrComponent.GetWidth();
         mSettings.window.height = mXrComponent.GetHeight();
@@ -1347,7 +1349,7 @@ int Application::Run(int argc, char** argv)
             return EXIT_FAILURE;
         }
 
-        if (!mSettings.enableXR) {
+        if (!mSettings.xr.enable) {
             // Update the window size if the settings got changed due to surface requirements
             {
                 int windowWidth  = 0;
@@ -1395,7 +1397,7 @@ int Application::Run(int argc, char** argv)
         mFrameStartTime = static_cast<float>(mTimer.MillisSinceStart());
 
 #if defined(PPX_BUILD_XR)
-        if (mSettings.enableXR) {
+        if (mSettings.xr.enable) {
             bool exitRenderLoop = false;
             mXrComponent.PollEvents(exitRenderLoop);
             if (exitRenderLoop) {
@@ -1415,11 +1417,19 @@ int Application::Run(int argc, char** argv)
                         mSwapchainIndex = k;
                         mXrComponent.SetCurrentViewIndex(k);
                         DispatchRender();
-                        CHECK_XR_CALL(xrReleaseSwapchainImage(GetSwapchain(k + mStereoscopicSwapchainIndex)->GetXrSwapchain(), &releaseInfo));
+                        grfx::SwapchainPtr swapchain = GetSwapchain(k + mStereoscopicSwapchainIndex);
+                        CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrColorSwapchain(), &releaseInfo));
+                        if (swapchain->GetXrDepthSwapchain() != XR_NULL_HANDLE) {
+                            CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrDepthSwapchain(), &releaseInfo));
+                        }
                     }
 
                     if (GetSettings()->enableImGui) {
-                        CHECK_XR_CALL(xrReleaseSwapchainImage(GetSwapchain(mUISwapchainIndex)->GetXrSwapchain(), &releaseInfo));
+                        grfx::SwapchainPtr swapchain = GetSwapchain(mUISwapchainIndex);
+                        CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrColorSwapchain(), &releaseInfo));
+                        if (swapchain->GetXrDepthSwapchain() != XR_NULL_HANDLE) {
+                            CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrDepthSwapchain(), &releaseInfo));
+                        }
                     }
                 }
                 mXrComponent.EndFrame();
@@ -1508,7 +1518,7 @@ int Application::Run(int argc, char** argv)
 
 #if defined(PPX_BUILD_XR)
     // Destroy Xr
-    if (mSettings.enableXR) {
+    if (mSettings.xr.enable) {
         mXrComponent.Destroy();
     }
 #endif

--- a/src/ppx/grfx/dx11/dx11_swapchain.cpp
+++ b/src/ppx/grfx/dx11/dx11_swapchain.cpp
@@ -102,6 +102,10 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
         for (uint32_t i = 0; i < imageCount; i++) {
             images.push_back(surfaceImages[i].texture);
         }
+
+        if (xrComponent.GetDepthFormat() != grfx::FORMAT_UNDEFINED && xrComponent.UsesDepthSwapchains()) {
+            PPX_ASSERT_MSG(false, "XR depth swapchain not implemented for D3D11 yet.");
+        }
     }
     else
 #endif

--- a/src/ppx/grfx/dx11/dx11_swapchain.cpp
+++ b/src/ppx/grfx/dx11/dx11_swapchain.cpp
@@ -91,14 +91,14 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
         info.height                = xrComponent.GetHeight();
         info.sampleCount           = xrComponent.GetSampleCount();
         info.usageFlags            = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
-        CHECK_XR_CALL(xrCreateSwapchain(xrComponent.GetSession(), &info, &mXrSwapchain));
+        CHECK_XR_CALL(xrCreateSwapchain(xrComponent.GetSession(), &info, &mXrColorSwapchain));
 
         // Find out how many textures were generated for the swapchain.
         uint32_t imageCount = 0;
-        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrSwapchain, 0, &imageCount, nullptr));
+        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrColorSwapchain, 0, &imageCount, nullptr));
         std::vector<XrSwapchainImageD3D11KHR> surfaceImages;
         surfaceImages.resize(imageCount, {XR_TYPE_SWAPCHAIN_IMAGE_D3D11_KHR});
-        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrSwapchain, imageCount, &imageCount, (XrSwapchainImageBaseHeader*)surfaceImages.data()));
+        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrColorSwapchain, imageCount, &imageCount, (XrSwapchainImageBaseHeader*)surfaceImages.data()));
         for (uint32_t i = 0; i < imageCount; i++) {
             images.push_back(surfaceImages[i].texture);
         }

--- a/src/ppx/grfx/dx12/dx12_swapchain.cpp
+++ b/src/ppx/grfx/dx12/dx12_swapchain.cpp
@@ -78,7 +78,7 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
             colorImages.push_back(surfaceImages[i].texture);
         }
 
-        if (xrComponent.GetDepthFormat() != grfx::FORMAT_UNDEFINED) {
+        if (xrComponent.GetDepthFormat() != grfx::FORMAT_UNDEFINED && xrComponent.UsesDepthSwapchains()) {
             PPX_ASSERT_MSG(xrComponent.GetDepthFormat() == pCreateInfo->depthFormat, "XR depth format differs from requested swapchain format");
 
             XrSwapchainCreateInfo info = {XR_TYPE_SWAPCHAIN_CREATE_INFO};

--- a/src/ppx/grfx/dx12/dx12_swapchain.cpp
+++ b/src/ppx/grfx/dx12/dx12_swapchain.cpp
@@ -47,12 +47,15 @@ void Surface::DestroyApiObjects()
 // -------------------------------------------------------------------------------------------------
 Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
 {
-    std::vector<ID3D12Resource*> images;
+    std::vector<ID3D12Resource*> colorImages;
+    std::vector<ID3D12Resource*> depthImages;
 
 #if defined(PPX_BUILD_XR)
     const bool isXREnabled = (mCreateInfo.pXrComponent != nullptr);
     if (isXREnabled) {
         const XrComponent& xrComponent = *mCreateInfo.pXrComponent;
+
+        PPX_ASSERT_MSG(xrComponent.GetColorFormat() == pCreateInfo->colorFormat, "XR color format differs from requested swapchain format");
 
         XrSwapchainCreateInfo info = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
         info.arraySize             = 1;
@@ -63,16 +66,42 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
         info.height                = xrComponent.GetHeight();
         info.sampleCount           = xrComponent.GetSampleCount();
         info.usageFlags            = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
-        CHECK_XR_CALL(xrCreateSwapchain(xrComponent.GetSession(), &info, &mXrSwapchain));
+        CHECK_XR_CALL(xrCreateSwapchain(xrComponent.GetSession(), &info, &mXrColorSwapchain));
 
         // Find out how many textures were generated for the swapchain.
         uint32_t imageCount = 0;
-        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrSwapchain, 0, &imageCount, nullptr));
+        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrColorSwapchain, 0, &imageCount, nullptr));
         std::vector<XrSwapchainImageD3D12KHR> surfaceImages;
         surfaceImages.resize(imageCount, {XR_TYPE_SWAPCHAIN_IMAGE_D3D12_KHR});
-        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrSwapchain, imageCount, &imageCount, (XrSwapchainImageBaseHeader*)surfaceImages.data()));
+        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrColorSwapchain, imageCount, &imageCount, (XrSwapchainImageBaseHeader*)surfaceImages.data()));
         for (uint32_t i = 0; i < imageCount; i++) {
-            images.push_back(surfaceImages[i].texture);
+            colorImages.push_back(surfaceImages[i].texture);
+        }
+
+        if (xrComponent.GetDepthFormat() != grfx::FORMAT_UNDEFINED) {
+            PPX_ASSERT_MSG(xrComponent.GetDepthFormat() == pCreateInfo->depthFormat, "XR depth format differs from requested swapchain format");
+
+            XrSwapchainCreateInfo info = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
+            info.arraySize             = 1;
+            info.mipCount              = 1;
+            info.faceCount             = 1;
+            info.format                = dx::ToDxgiFormat(xrComponent.GetDepthFormat());
+            info.width                 = xrComponent.GetWidth();
+            info.height                = xrComponent.GetHeight();
+            info.sampleCount           = xrComponent.GetSampleCount();
+            info.usageFlags            = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+            CHECK_XR_CALL(xrCreateSwapchain(xrComponent.GetSession(), &info, &mXrDepthSwapchain));
+
+            imageCount = 0;
+            CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrDepthSwapchain, 0, &imageCount, nullptr));
+            std::vector<XrSwapchainImageD3D12KHR> swapchainDepthImages;
+            swapchainDepthImages.resize(imageCount, {XR_TYPE_SWAPCHAIN_IMAGE_D3D12_KHR});
+            CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrDepthSwapchain, imageCount, &imageCount, (XrSwapchainImageBaseHeader*)swapchainDepthImages.data()));
+            for (uint32_t i = 0; i < imageCount; i++) {
+                depthImages.push_back(swapchainDepthImages[i].texture);
+            }
+
+            PPX_ASSERT_MSG(depthImages.size() == colorImages.size(), "XR depth and color swapchains have different number of images");
         }
     }
     else
@@ -201,14 +230,14 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
                 if (FAILED(hr)) {
                     return ppx::ERROR_API_FAILURE;
                 }
-                images.push_back(resource);
+                colorImages.push_back(resource);
             }
         }
     }
 
     // Create images.
     {
-        for (size_t i = 0; i < images.size(); ++i) {
+        for (size_t i = 0; i < colorImages.size(); ++i) {
             grfx::ImageCreateInfo imageCreateInfo           = {};
             imageCreateInfo.type                            = grfx::IMAGE_TYPE_2D;
             imageCreateInfo.width                           = pCreateInfo->width;
@@ -223,7 +252,7 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
             imageCreateInfo.usageFlags.bits.sampled         = true;
             imageCreateInfo.usageFlags.bits.storage         = true;
             imageCreateInfo.usageFlags.bits.colorAttachment = true;
-            imageCreateInfo.pApiObject                      = images[i];
+            imageCreateInfo.pApiObject                      = colorImages[i];
 
             grfx::ImagePtr image;
             Result         ppxres = GetDevice()->CreateImage(&imageCreateInfo, &image);
@@ -233,6 +262,20 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
             }
 
             mColorImages.push_back(image);
+        }
+
+        for (size_t i = 0; i < depthImages.size(); ++i) {
+            grfx::ImageCreateInfo imageCreateInfo = grfx::ImageCreateInfo::DepthStencilTarget(pCreateInfo->width, pCreateInfo->height, pCreateInfo->depthFormat, grfx::SAMPLE_COUNT_1);
+            imageCreateInfo.pApiObject            = depthImages[i];
+
+            grfx::ImagePtr image;
+            Result         ppxres = GetDevice()->CreateImage(&imageCreateInfo, &image);
+            if (Failed(ppxres)) {
+                PPX_ASSERT_MSG(false, "image create failed");
+                return ppxres;
+            }
+
+            mDepthImages.push_back(image);
         }
     }
 

--- a/src/ppx/grfx/vk/vk_swapchain.cpp
+++ b/src/ppx/grfx/vk/vk_swapchain.cpp
@@ -221,14 +221,14 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
         info.height                = xrComponent.GetHeight();
         info.sampleCount           = xrComponent.GetSampleCount();
         info.usageFlags            = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
-        CHECK_XR_CALL(xrCreateSwapchain(xrComponent.GetSession(), &info, &mXrSwapchain));
+        CHECK_XR_CALL(xrCreateSwapchain(xrComponent.GetSession(), &info, &mXrColorSwapchain));
 
         // Find out how many textures were generated for the swapchain
-        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrSwapchain, 0, &imageCount, nullptr));
+        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrColorSwapchain, 0, &imageCount, nullptr));
         images.resize(imageCount);
         std::vector<XrSwapchainImageVulkanKHR> surfaceImages;
         surfaceImages.resize(imageCount, {XR_TYPE_SWAPCHAIN_IMAGE_VULKAN_KHR});
-        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrSwapchain, imageCount, &imageCount, (XrSwapchainImageBaseHeader*)surfaceImages.data()));
+        CHECK_XR_CALL(xrEnumerateSwapchainImages(mXrColorSwapchain, imageCount, &imageCount, (XrSwapchainImageBaseHeader*)surfaceImages.data()));
         for (uint32_t i = 0; i < imageCount; i++) {
             images[i] = surfaceImages[i].image;
         }

--- a/src/ppx/grfx/vk/vk_swapchain.cpp
+++ b/src/ppx/grfx/vk/vk_swapchain.cpp
@@ -232,6 +232,10 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
         for (uint32_t i = 0; i < imageCount; i++) {
             images[i] = surfaceImages[i].image;
         }
+
+        if (xrComponent.GetDepthFormat() != grfx::FORMAT_UNDEFINED && xrComponent.UsesDepthSwapchains()) {
+            PPX_ASSERT_MSG(false, "XR depth swapchain not implemented for Vulkan yet.");
+        }
     }
     else
 #endif

--- a/src/ppx/xr_component.cpp
+++ b/src/ppx/xr_component.cpp
@@ -73,9 +73,15 @@ void XrComponent::InitializeBeforeGrfxDeviceInit(const XrComponentCreateInfo& cr
     }
 
     // Optional extensions.
-    if (createInfo.depthFormat != grfx::FORMAT_UNDEFINED && IsXrExtensionSupported(xrExts, XR_KHR_COMPOSITION_LAYER_DEPTH_EXTENSION_NAME)) {
-        xrInstanceExtensions.push_back(XR_KHR_COMPOSITION_LAYER_DEPTH_EXTENSION_NAME);
-        mShouldSubmitDepthInfo = true;
+    if (createInfo.depthFormat != grfx::FORMAT_UNDEFINED && UsesDepthSwapchains()) {
+        if (IsXrExtensionSupported(xrExts, XR_KHR_COMPOSITION_LAYER_DEPTH_EXTENSION_NAME)) {
+            xrInstanceExtensions.push_back(XR_KHR_COMPOSITION_LAYER_DEPTH_EXTENSION_NAME);
+            mShouldSubmitDepthInfo = true;
+        }
+        else {
+            PPX_LOG_WARN("XR depth swapchains are enabled but the " XR_KHR_COMPOSITION_LAYER_DEPTH_EXTENSION_NAME
+                         " extension is not supported. Depth info will not be submitted to the runtime.");
+        }
     }
 
     // Layers (Optional)
@@ -292,7 +298,7 @@ void XrComponent::HandleSessionStateChangedEvent(const XrEventDataSessionStateCh
     }
 }
 
-void XrComponent::BeginFrame(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t layerProjStartIndex, uint32_t layerQuadStartIndex)
+void XrComponent::BeginFrame()
 {
     XrFrameWaitInfo frameWaitInfo = {
         .type = XR_TYPE_FRAME_WAIT_INFO,
@@ -301,7 +307,11 @@ void XrComponent::BeginFrame(const std::vector<grfx::SwapchainPtr>& swapchains, 
     CHECK_XR_CALL(xrWaitFrame(mSession, &frameWaitInfo, &mFrameState));
     mShouldRender = mFrameState.shouldRender;
 
-    // --- Create projection matrices and view matrices for each eye
+    // Reset near and far plane values for this frame.
+    mNearPlaneForFrame = std::nullopt;
+    mFarPlaneForFrame  = std::nullopt;
+
+    // Create projection matrices and view matrices for each eye.
     XrViewLocateInfo viewLocateInfo = {
         .type                  = XR_TYPE_VIEW_LOCATE_INFO,
         .viewConfigurationType = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO,
@@ -320,44 +330,7 @@ void XrComponent::BeginFrame(const std::vector<grfx::SwapchainPtr>& swapchains, 
         mShouldRender = false;
     }
 
-    mCompositionLayerProjectionViews.resize(viewCount);
-    mCompositionLayerDepthInfos.resize(viewCount);
-    PPX_ASSERT_MSG(swapchains.size() >= viewCount, "Number of swapchains needs to be larger than or equal to the number of views!");
-    for (uint32_t i = 0; i < viewCount; ++i) {
-        mCompositionLayerProjectionViews[i]                           = {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW};
-        mCompositionLayerProjectionViews[i].pose                      = mViews[i].pose;
-        mCompositionLayerProjectionViews[i].fov                       = mViews[i].fov;
-        mCompositionLayerProjectionViews[i].subImage.swapchain        = swapchains[layerProjStartIndex + i]->GetXrColorSwapchain();
-        mCompositionLayerProjectionViews[i].subImage.imageRect.offset = {0, 0};
-        mCompositionLayerProjectionViews[i].subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
-
-        if (mShouldSubmitDepthInfo && swapchains[layerProjStartIndex + i]->GetXrDepthSwapchain() != XR_NULL_HANDLE) {
-            mCompositionLayerDepthInfos[i]                           = {XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR};
-            mCompositionLayerDepthInfos[i].minDepth                  = 0.0f;
-            mCompositionLayerDepthInfos[i].maxDepth                  = 1.0f;
-            mCompositionLayerDepthInfos[i].nearZ                     = mCreateInfo.depthNearPlane;
-            mCompositionLayerDepthInfos[i].farZ                      = mCreateInfo.depthFarPlane;
-            mCompositionLayerDepthInfos[i].subImage.swapchain        = swapchains[layerProjStartIndex + i]->GetXrDepthSwapchain();
-            mCompositionLayerDepthInfos[i].subImage.imageRect.offset = {0, 0};
-            mCompositionLayerDepthInfos[i].subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
-
-            mCompositionLayerProjectionViews[i].next = &mCompositionLayerDepthInfos[i];
-        }
-    }
-
-    // UI composition layer
-    if (mCreateInfo.enableQuadLayer) {
-        mCompositionLayerQuad.layerFlags                = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
-        mCompositionLayerQuad.space                     = mUISpace;
-        mCompositionLayerQuad.eyeVisibility             = XR_EYE_VISIBILITY_BOTH;
-        mCompositionLayerQuad.subImage.swapchain        = swapchains[layerQuadStartIndex]->GetXrColorSwapchain();
-        mCompositionLayerQuad.subImage.imageRect.offset = {0, 0};
-        mCompositionLayerQuad.subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
-        mCompositionLayerQuad.pose                      = {{0, 0, 0, 1}, mCreateInfo.quadLayerPos};
-        mCompositionLayerQuad.size                      = mCreateInfo.quadLayerSize;
-    }
-
-    // Begin frame
+    // Begin frame.
     XrFrameBeginInfo frameBeginInfo = {
         .type = XR_TYPE_FRAME_BEGIN_INFO,
     };
@@ -377,20 +350,67 @@ void XrComponent::BeginFrame(const std::vector<grfx::SwapchainPtr>& swapchains, 
     }
 }
 
-void XrComponent::EndFrame()
+void XrComponent::EndFrame(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t layerProjStartIndex, uint32_t layerQuadStartIndex)
 {
-    mCompositionLayerProjection.layerFlags = 0;
-    mCompositionLayerProjection.space      = mRefSpace;
-    mCompositionLayerProjection.viewCount  = static_cast<uint32_t>(GetViewCount());
-    mCompositionLayerProjection.views      = mCompositionLayerProjectionViews.data();
-    std::vector<XrCompositionLayerBaseHeader*> layers;
+    size_t viewCount = mViews.size();
+    PPX_ASSERT_MSG(swapchains.size() >= viewCount, "Number of swapchains needs to be larger than or equal to the number of views!");
+
+    std::vector<XrCompositionLayerProjectionView> compositionLayerProjectionViews(viewCount);
+    std::vector<XrCompositionLayerDepthInfoKHR>   compositionLayerDepthInfos(viewCount);
+    XrCompositionLayerQuad                        compositionLayerQuad = {XR_TYPE_COMPOSITION_LAYER_QUAD};
     if (mShouldRender) {
-        layers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&mCompositionLayerProjection));
+        // Projection and (optional) depth info layer from color+depth swapchains.
+        for (size_t i = 0; i < viewCount; ++i) {
+            compositionLayerProjectionViews[i]                           = {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW};
+            compositionLayerProjectionViews[i].pose                      = mViews[i].pose;
+            compositionLayerProjectionViews[i].fov                       = mViews[i].fov;
+            compositionLayerProjectionViews[i].subImage.swapchain        = swapchains[layerProjStartIndex + i]->GetXrColorSwapchain();
+            compositionLayerProjectionViews[i].subImage.imageRect.offset = {0, 0};
+            compositionLayerProjectionViews[i].subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
+
+            if (mShouldSubmitDepthInfo && swapchains[layerProjStartIndex + i]->GetXrDepthSwapchain() != XR_NULL_HANDLE) {
+                PPX_ASSERT_MSG(mNearPlaneForFrame.has_value() && mFarPlaneForFrame.has_value(), "Depth info layer cannot be submitted because near and far plane values are not set. "
+                                                                                                "Call GetProjectionMatrixForCurrentViewAndSetFrustumPlanes to set per-frame values.");
+                compositionLayerDepthInfos[i]                           = {XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR};
+                compositionLayerDepthInfos[i].minDepth                  = 0.0f;
+                compositionLayerDepthInfos[i].maxDepth                  = 1.0f;
+                compositionLayerDepthInfos[i].nearZ                     = *mNearPlaneForFrame;
+                compositionLayerDepthInfos[i].farZ                      = *mFarPlaneForFrame;
+                compositionLayerDepthInfos[i].subImage.swapchain        = swapchains[layerProjStartIndex + i]->GetXrDepthSwapchain();
+                compositionLayerDepthInfos[i].subImage.imageRect.offset = {0, 0};
+                compositionLayerDepthInfos[i].subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
+
+                compositionLayerProjectionViews[i].next = &compositionLayerDepthInfos[i];
+            }
+        }
+
+        // Optional UI composition layer.
         if (mCreateInfo.enableQuadLayer) {
-            layers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&mCompositionLayerQuad));
+            compositionLayerQuad.layerFlags                = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+            compositionLayerQuad.space                     = mUISpace;
+            compositionLayerQuad.eyeVisibility             = XR_EYE_VISIBILITY_BOTH;
+            compositionLayerQuad.subImage.swapchain        = swapchains[layerQuadStartIndex]->GetXrColorSwapchain();
+            compositionLayerQuad.subImage.imageRect.offset = {0, 0};
+            compositionLayerQuad.subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
+            compositionLayerQuad.pose                      = {{0, 0, 0, 1}, mCreateInfo.quadLayerPos};
+            compositionLayerQuad.size                      = mCreateInfo.quadLayerSize;
         }
     }
 
+    std::vector<XrCompositionLayerBaseHeader*> layers;
+    XrCompositionLayerProjection               compositionLayerProjection = {XR_TYPE_COMPOSITION_LAYER_PROJECTION};
+    compositionLayerProjection.layerFlags                                 = 0;
+    compositionLayerProjection.space                                      = mRefSpace;
+    compositionLayerProjection.viewCount                                  = static_cast<uint32_t>(GetViewCount());
+    compositionLayerProjection.views                                      = compositionLayerProjectionViews.data();
+    if (mShouldRender) {
+        layers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&compositionLayerProjection));
+        if (mCreateInfo.enableQuadLayer) {
+            layers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&compositionLayerQuad));
+        }
+    }
+
+    // Submit layers and end frame.
     XrFrameEndInfo frameEndInfo = {
         .type                 = XR_TYPE_FRAME_END_INFO,
         .displayTime          = mFrameState.predictedDisplayTime,
@@ -417,13 +437,19 @@ glm::mat4 XrComponent::GetViewMatrixForCurrentView() const
     return view_glm_inv;
 }
 
-glm::mat4 XrComponent::GetProjectionMatrixForCurrentView() const
+glm::mat4 XrComponent::GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(float nearZ, float farZ)
 {
     PPX_ASSERT_MSG((mCurrentViewIndex < mViews.size()), "Invalid view index!");
-    const XrView& view  = mViews[mCurrentViewIndex];
-    const XrFovf& fov   = view.fov;
-    const float   nearZ = mCreateInfo.depthNearPlane;
-    const float   farZ  = mCreateInfo.depthFarPlane;
+    const XrView& view = mViews[mCurrentViewIndex];
+    const XrFovf& fov  = view.fov;
+
+    // Save near and far plane values so that they can be referenced
+    // in EndFrame(), as part of the depth layer info submission.
+    // They can only be set once per frame.
+    PPX_ASSERT_MSG(!mNearPlaneForFrame.has_value() || *mNearPlaneForFrame == nearZ, "GetProjectionMatrixForCurrentViewAndSetFrustumPlanes was already called this frame with a different nearZ value.");
+    PPX_ASSERT_MSG(!mFarPlaneForFrame.has_value() || *mFarPlaneForFrame == farZ, "GetProjectionMatrixForCurrentViewAndSetFrustumPlanes was already called this frame with a different farZ value.");
+    mNearPlaneForFrame = nearZ;
+    mFarPlaneForFrame  = farZ;
 
     const float tan_left  = tanf(fov.angleLeft);
     const float tan_right = tanf(fov.angleRight);
@@ -455,7 +481,7 @@ glm::mat4 XrComponent::GetProjectionMatrixForCurrentView() const
     return glm::make_mat4(mat);
 }
 
-XrPosef XrComponent::GetCurrentPose() const
+XrPosef XrComponent::GetPoseForCurrentView() const
 {
     PPX_ASSERT_MSG((mCurrentViewIndex < mViews.size()), "Invalid view index!");
     return mViews[mCurrentViewIndex].pose;


### PR DESCRIPTION
Vulkan and D3D11 coming next.

Some misc fixes too:
- Comments and formatting.
- Put all the XR settings into its own `xr` struct.
- Disabled annoying warning with MSVC for unscoped enums. They're used everywhere also due to dependencies.