### PR TITLE
Disable XRDebug capture by default 

### DIFF
--- a/projects/04_cube_xr/main.cpp
+++ b/projects/04_cube_xr/main.cpp
@@ -69,7 +69,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
     settings.grfx.enableDebug           = false;
     settings.enableXR                   = true;
-    settings.enableXRDebugCapture       = true;
+    settings.enableXRDebugCapture       = false;
     settings.grfx.ui.pos                = {0.1f, -0.2f, -0.5f};
     settings.grfx.ui.size               = {1.f, 1.f};
 #if defined(USE_DXIL)

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -135,7 +135,7 @@ void FishTornadoApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.numFramesInFlight     = 2;
     settings.grfx.enableDebug           = false;
     settings.enableXR                   = true;
-    settings.enableXRDebugCapture       = true;
+    settings.enableXRDebugCapture       = false;
     settings.grfx.swapchain.imageCount  = 3;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
     settings.grfx.ui.pos                = {0.2f, -0.3f, -0.5f};


### PR DESCRIPTION
Disable XRDebug capture by default since it causes crashes while using Monado OpenXR Runtime on Windows PC