### PR TITLE
Fix the crash when enable XR debug capture.

### DIFF
--- a/include/ppx/grfx/grfx_instance.h
+++ b/include/ppx/grfx/grfx_instance.h
@@ -52,14 +52,7 @@ public:
     bool IsDebugEnabled() const { return mCreateInfo.enableDebug; }
     bool IsSwapchainEnabled() const
     {
-        return mCreateInfo.enableSwapchain
-#if defined(PPX_BUILD_XR)
-               // TODO(wangra): disable original swapchain when XR is enabled for now
-               // (the XR swapchain will be coming from OpenXR)
-               // the swapchain will be required for RenderDoc capture in the future implementation
-               && (mCreateInfo.pXrComponent == nullptr)
-#endif
-            ;
+        return mCreateInfo.enableSwapchain;
     }
     bool ForceDxDiscreteAllocations() const
     {

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -33,7 +33,7 @@
 
 // clang-format off
 #if defined(PPX_LINUX)
-#   define GLFW_EXPOSE_NATIVE_X11 
+#   define GLFW_EXPOSE_NATIVE_X11
 #elif defined(PPX_MSW)
 #   define GLFW_EXPOSE_NATIVE_WIN32
 #endif
@@ -654,6 +654,14 @@ Result Application::InitializeGrfxDevice()
         ci.useSoftwareRenderer      = mStandardOptions.use_software_renderer;
 #if defined(PPX_BUILD_XR)
         ci.pXrComponent = mSettings.xr.enable ? &mXrComponent : nullptr;
+        // Disable original swapchain when XR is enabled as the XR swapchain will be coming from OpenXR.
+        // Enable creating swapchain when enabling debug capture, as the swapchain can help tools to do capture (dummy present calls).
+        if (mSettings.xr.enable) {
+            ci.enableSwapchain = false;
+            if (mSettings.xr.enableDebugCapture) {
+                ci.enableSwapchain = true;
+            }
+        }
 #endif
 
         Result ppxres = grfx::CreateInstance(&ci, &mInstance);


### PR DESCRIPTION
The original crash comes from the device creation failed to load "VK_KHR_swapchain" extension, so the function call to create swapchain failed. This fix the issue which allows Nsight Graphics to do captures for the XR application.