### PR TITLE
fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ if(MSVC)
     set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} ${MSVC_DISABLED_WARNINGS} /MP")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MSVC_DISABLED_WARNINGS} /MP /Zc:__cplusplus /std:c++20")
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -fdiagnostics-color=always")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -fdiagnostics-color=always -Wno-nullability-completeness -Wno-deprecated-anon-enum-enum-conversion")
 endif()
 
 set(CMAKE_CXX_STANDARD 20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,11 @@ if(MSVC)
     set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} ${MSVC_DISABLED_WARNINGS} /MP")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MSVC_DISABLED_WARNINGS} /MP /Zc:__cplusplus /std:c++20")
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -fdiagnostics-color=always -Wno-nullability-completeness -Wno-deprecated-anon-enum-enum-conversion")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -std=c++20 \
+        -fdiagnostics-color=always \
+        -Wno-nullability-completeness \
+        -Wno-deprecated-anon-enum-enum-conversion")
 endif()
 
 set(CMAKE_CXX_STANDARD 20)

--- a/benchmarks/render_target/main.cpp
+++ b/benchmarks/render_target/main.cpp
@@ -139,7 +139,7 @@ void ProjApp::Setup()
     mRenderTargetCount = cl_options.GetExtraOptionValueOrDefault<uint32_t>("render-target-count", 1);
     if (mRenderTargetCount != 1 && mRenderTargetCount != 4) {
         mRenderTargetCount = 1;
-        PPX_LOG_WARN("Render Target count must be either 1 or 4, defaulting to: " + mRenderTargetCount);
+        PPX_LOG_WARN("Render Target count must be either 1 or 4, defaulting to: " + std::to_string(mRenderTargetCount));
     }
 
     // Create descriptor pool (for both pipelines)

--- a/projects/16_gbuffer/Material.cpp
+++ b/projects/16_gbuffer/Material.cpp
@@ -259,7 +259,7 @@ ppx::Result Material::CreateMaterials(ppx::grfx::Queue* pQueue, ppx::grfx::Descr
         MaterialCreateInfo createInfo   = {};
         createInfo.F0                   = F0_Generic;
         createInfo.albedo               = F0_DiletricCrystal;
-        createInfo.roughness            = 0.4;
+        createInfo.roughness            = 0.4f;
         createInfo.metalness            = 0;
         createInfo.iblStrength          = 0;
         createInfo.envStrength          = 0.0f;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -445,8 +445,6 @@ add_library(
     ${XXHASH_FILES}
 )
 
-set_source_files_properties(${PPX_DIR}/third_party/xxHash/xxhash.c PROPERTIES LANGUAGE CXX)
-
 if (PPX_LINUX OR PPX_GGP)
     set_target_properties(
         ${PROJECT_NAME} PROPERTIES PREFIX "lib"


### PR DESCRIPTION
Fixing some warning on the linux version:
-  `-Wnullability-completness` disabled, from third-party code.
-  `-Wdeprecated-anon-enum-enum-conversion` disabled, from third-party code.
- fix uint32_t bad append to a string.
- compile xxHash C code as C, not C++. (this was done a long time ago because some buildsystem was complaining).