### PR TITLE
Load mipmaps from DDS files

### DIFF
--- a/include/ppx/grfx/grfx_constants.h
+++ b/include/ppx/grfx/grfx_constants.h
@@ -64,7 +64,8 @@
 // D3D12 requires buffer to image copies to have a row pitch that's
 // aligned to D3D12_TEXTURE_DATA_PITCH_ALIGNMENT(256).
 //
-#define PPX_D3D12_TEXTURE_DATA_PITCH_ALIGNMENT 256
+#define PPX_D3D12_TEXTURE_DATA_PITCH_ALIGNMENT     256
+#define PPX_D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT 512
 
 // PPX standard attribute semantic names
 #define PPX_SEMANTIC_NAME_POSITION  "POSITION"

--- a/src/ppx/graphics_util.cpp
+++ b/src/ppx/graphics_util.cpp
@@ -639,8 +639,8 @@ Result CreateImageFromCompressedImage(
     ci.usageFlags.bits.transferSrc = true;
     ci.memoryUsage                 = grfx::MEMORY_USAGE_CPU_TO_GPU;
 
-    std::vector<MipLevel> levelSizes(image.levels());
-    for (gli::texture::size_type level = 0; level < image.levels(); level++) {
+    std::vector<MipLevel> levelSizes(mipLevelCount);
+    for (gli::texture::size_type level = 0; level < mipLevelCount; level++) {
         auto& ls = levelSizes[level];
 
         ls.width  = static_cast<uint32_t>(image.extent(level)[0]);

--- a/src/ppx/grfx/dx11/dx11_command_list.cpp
+++ b/src/ppx/grfx/dx11/dx11_command_list.cpp
@@ -1178,8 +1178,8 @@ static void ExecuteCopyBufferToImage(
         dstBox.left      = args.dstImage.x;
         dstBox.top       = args.dstImage.y;
         dstBox.front     = args.dstImage.z;
-        dstBox.right     = args.dstImage.x + args.dstImage.width;
-        dstBox.bottom    = args.dstImage.y + args.dstImage.height;
+        dstBox.right     = args.dstImage.x + args.srcBuffer.footprintWidth;
+        dstBox.bottom    = args.dstImage.y + args.srcBuffer.footprintHeight;
         dstBox.back      = args.dstImage.z + args.dstImage.depth;
 
         const char* pSrcData = pMappedAddress + args.srcBuffer.footprintOffset;

--- a/src/ppx/grfx/dx12/dx12_command.cpp
+++ b/src/ppx/grfx/dx12/dx12_command.cpp
@@ -637,7 +637,6 @@ void CommandBuffer::CopyBufferToImage(
         UINT   numRows         = 0;
         UINT64 rowSizeInBytes  = 0;
         UINT64 totalBytes      = 0;
-
         // Grab the format
         device->GetCopyableFootprints(
             &resouceDesc,


### PR DESCRIPTION
This loads all mipmap levels in a DDS file into a single staging buffer and then copies those into an image from there. There's a slight optimization possible where Vulkan's `CopyBufferToImage` lets you use copy all regions using only a single command; for readability I've split that into a separate PR that I'll follow up with.

Fixes #32