### PR TITLE
Reduce API calls for CopyBufferToImage

### DIFF
--- a/include/ppx/grfx/dx11/dx11_command.h
+++ b/include/ppx/grfx/dx11/dx11_command.h
@@ -116,7 +116,7 @@ public:
         grfx::Image*                                    pDstImage) override;
 
     virtual void CopyBufferToImage(
-        const grfx::BufferToImageCopyInfo* pCopyInfo,
+        const grfx::BufferToImageCopyInfo& pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) override;
 

--- a/include/ppx/grfx/dx11/dx11_command.h
+++ b/include/ppx/grfx/dx11/dx11_command.h
@@ -111,6 +111,11 @@ public:
         grfx::Buffer*                       pDstBuffer) override;
 
     virtual void CopyBufferToImage(
+        const std::vector<grfx::BufferToImageCopyInfo>& pCopyInfos,
+        grfx::Buffer*                                   pSrcBuffer,
+        grfx::Image*                                    pDstImage) override;
+
+    virtual void CopyBufferToImage(
         const grfx::BufferToImageCopyInfo* pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) override;

--- a/include/ppx/grfx/dx12/dx12_command.h
+++ b/include/ppx/grfx/dx12/dx12_command.h
@@ -109,6 +109,11 @@ public:
         grfx::Buffer*                       pDstBuffer) override;
 
     virtual void CopyBufferToImage(
+        const std::vector<grfx::BufferToImageCopyInfo>& pCopyInfos,
+        grfx::Buffer*                                   pSrcBuffer,
+        grfx::Image*                                    pDstImage) override;
+
+    virtual void CopyBufferToImage(
         const grfx::BufferToImageCopyInfo* pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) override;
@@ -182,7 +187,7 @@ public:
     CommandPool() {}
     virtual ~CommandPool() {}
 
-    //typename D3D12CommandAllocatorPtr::InterfaceType* GetDxCommandAllocator() const { return mCommandAllocator.Get(); }
+    // typename D3D12CommandAllocatorPtr::InterfaceType* GetDxCommandAllocator() const { return mCommandAllocator.Get(); }
     D3D12_COMMAND_LIST_TYPE GetDxCommandType() const { return mCommandType; }
 
 protected:
@@ -190,7 +195,7 @@ protected:
     virtual void   DestroyApiObjects() override;
 
 private:
-    //D3D12CommandAllocatorPtr mCommandAllocator;
+    // D3D12CommandAllocatorPtr mCommandAllocator;
     D3D12_COMMAND_LIST_TYPE mCommandType = ppx::InvalidValue<D3D12_COMMAND_LIST_TYPE>();
 };
 

--- a/include/ppx/grfx/dx12/dx12_command.h
+++ b/include/ppx/grfx/dx12/dx12_command.h
@@ -114,7 +114,7 @@ public:
         grfx::Image*                                    pDstImage) override;
 
     virtual void CopyBufferToImage(
-        const grfx::BufferToImageCopyInfo* pCopyInfo,
+        const grfx::BufferToImageCopyInfo& pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) override;
 

--- a/include/ppx/grfx/grfx_command.h
+++ b/include/ppx/grfx/grfx_command.h
@@ -344,7 +344,7 @@ public:
         grfx::Image*                                    pDstImage) = 0;
 
     virtual void CopyBufferToImage(
-        const grfx::BufferToImageCopyInfo* pCopyInfo,
+        const grfx::BufferToImageCopyInfo& pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) = 0;
 

--- a/include/ppx/grfx/grfx_command.h
+++ b/include/ppx/grfx/grfx_command.h
@@ -339,6 +339,11 @@ public:
         grfx::Buffer*                       pDstBuffer) = 0;
 
     virtual void CopyBufferToImage(
+        const std::vector<grfx::BufferToImageCopyInfo>& pCopyInfos,
+        grfx::Buffer*                                   pSrcBuffer,
+        grfx::Image*                                    pDstImage) = 0;
+
+    virtual void CopyBufferToImage(
         const grfx::BufferToImageCopyInfo* pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) = 0;

--- a/include/ppx/grfx/grfx_queue.h
+++ b/include/ppx/grfx/grfx_queue.h
@@ -80,17 +80,17 @@ public:
         grfx::ResourceState                 stateBefore,
         grfx::ResourceState                 stateAfter);
 
-    // In pace copy of buffer to image
+    // In place copy of buffer to image
     Result CopyBufferToImage(
-        const grfx::BufferToImageCopyInfo* pCopyInfo,
-        grfx::Buffer*                      pSrcBuffer,
-        grfx::Image*                       pDstImage,
-        uint32_t                           mipLevel,
-        uint32_t                           mipLevelCount,
-        uint32_t                           arrayLayer,
-        uint32_t                           arrayLayerCount,
-        grfx::ResourceState                stateBefore,
-        grfx::ResourceState                stateAfter);
+        const std::vector<grfx::BufferToImageCopyInfo>& pCopyInfos,
+        grfx::Buffer*                                   pSrcBuffer,
+        grfx::Image*                                    pDstImage,
+        uint32_t                                        mipLevel,
+        uint32_t                                        mipLevelCount,
+        uint32_t                                        arrayLayer,
+        uint32_t                                        arrayLayerCount,
+        grfx::ResourceState                             stateBefore,
+        grfx::ResourceState                             stateAfter);
 
 private:
     struct CommandSet

--- a/include/ppx/grfx/vk/vk_command.h
+++ b/include/ppx/grfx/vk/vk_command.h
@@ -109,6 +109,11 @@ public:
         grfx::Buffer*                       pDstBuffer) override;
 
     virtual void CopyBufferToImage(
+        const std::vector<grfx::BufferToImageCopyInfo>& pCopyInfos,
+        grfx::Buffer*                                   pSrcBuffer,
+        grfx::Image*                                    pDstImage) override;
+
+    virtual void CopyBufferToImage(
         const grfx::BufferToImageCopyInfo* pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) override;

--- a/include/ppx/grfx/vk/vk_command.h
+++ b/include/ppx/grfx/vk/vk_command.h
@@ -114,7 +114,7 @@ public:
         grfx::Image*                                    pDstImage) override;
 
     virtual void CopyBufferToImage(
-        const grfx::BufferToImageCopyInfo* pCopyInfo,
+        const grfx::BufferToImageCopyInfo& pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) override;
 

--- a/src/ppx/grfx/dx11/dx11_command.cpp
+++ b/src/ppx/grfx/dx11/dx11_command.cpp
@@ -470,33 +470,33 @@ void CommandBuffer::CopyBufferToImage(
     grfx::Image*                                    pDstImage)
 {
     for (auto& pCopyInfo : pCopyInfos) {
-        CopyBufferToImage(&pCopyInfo, pSrcBuffer, pDstImage);
+        CopyBufferToImage(pCopyInfo, pSrcBuffer, pDstImage);
     }
 }
 
 void CommandBuffer::CopyBufferToImage(
-    const grfx::BufferToImageCopyInfo* pCopyInfo,
+    const grfx::BufferToImageCopyInfo& pCopyInfo,
     grfx::Buffer*                      pSrcBuffer,
     grfx::Image*                       pDstImage)
 {
     dx11::args::CopyBufferToImage copyArgs = {};
 
-    copyArgs.srcBuffer.imageWidth      = pCopyInfo->srcBuffer.imageWidth;
-    copyArgs.srcBuffer.imageHeight     = pCopyInfo->srcBuffer.imageHeight;
-    copyArgs.srcBuffer.imageRowStride  = pCopyInfo->srcBuffer.imageRowStride;
-    copyArgs.srcBuffer.footprintOffset = pCopyInfo->srcBuffer.footprintOffset;
-    copyArgs.srcBuffer.footprintWidth  = pCopyInfo->srcBuffer.footprintWidth;
-    copyArgs.srcBuffer.footprintHeight = pCopyInfo->srcBuffer.footprintHeight;
-    copyArgs.srcBuffer.footprintDepth  = pCopyInfo->srcBuffer.footprintDepth;
-    copyArgs.dstImage.mipLevel         = pCopyInfo->dstImage.mipLevel;
-    copyArgs.dstImage.arrayLayer       = pCopyInfo->dstImage.arrayLayer;
-    copyArgs.dstImage.arrayLayerCount  = pCopyInfo->dstImage.arrayLayerCount;
-    copyArgs.dstImage.x                = pCopyInfo->dstImage.x;
-    copyArgs.dstImage.y                = pCopyInfo->dstImage.y;
-    copyArgs.dstImage.z                = pCopyInfo->dstImage.z;
-    copyArgs.dstImage.width            = pCopyInfo->dstImage.width;
-    copyArgs.dstImage.height           = pCopyInfo->dstImage.height;
-    copyArgs.dstImage.depth            = pCopyInfo->dstImage.depth;
+    copyArgs.srcBuffer.imageWidth      = pCopyInfo.srcBuffer.imageWidth;
+    copyArgs.srcBuffer.imageHeight     = pCopyInfo.srcBuffer.imageHeight;
+    copyArgs.srcBuffer.imageRowStride  = pCopyInfo.srcBuffer.imageRowStride;
+    copyArgs.srcBuffer.footprintOffset = pCopyInfo.srcBuffer.footprintOffset;
+    copyArgs.srcBuffer.footprintWidth  = pCopyInfo.srcBuffer.footprintWidth;
+    copyArgs.srcBuffer.footprintHeight = pCopyInfo.srcBuffer.footprintHeight;
+    copyArgs.srcBuffer.footprintDepth  = pCopyInfo.srcBuffer.footprintDepth;
+    copyArgs.dstImage.mipLevel         = pCopyInfo.dstImage.mipLevel;
+    copyArgs.dstImage.arrayLayer       = pCopyInfo.dstImage.arrayLayer;
+    copyArgs.dstImage.arrayLayerCount  = pCopyInfo.dstImage.arrayLayerCount;
+    copyArgs.dstImage.x                = pCopyInfo.dstImage.x;
+    copyArgs.dstImage.y                = pCopyInfo.dstImage.y;
+    copyArgs.dstImage.z                = pCopyInfo.dstImage.z;
+    copyArgs.dstImage.width            = pCopyInfo.dstImage.width;
+    copyArgs.dstImage.height           = pCopyInfo.dstImage.height;
+    copyArgs.dstImage.depth            = pCopyInfo.dstImage.depth;
     copyArgs.mapType                   = ToApi(pSrcBuffer)->GetMapType();
     copyArgs.isCube                    = (pDstImage->GetType() == grfx::IMAGE_TYPE_CUBE);
     copyArgs.mipSpan                   = pDstImage->GetMipLevelCount();

--- a/src/ppx/grfx/dx11/dx11_command.cpp
+++ b/src/ppx/grfx/dx11/dx11_command.cpp
@@ -465,6 +465,16 @@ void CommandBuffer::CopyBufferToBuffer(
 }
 
 void CommandBuffer::CopyBufferToImage(
+    const std::vector<grfx::BufferToImageCopyInfo>& pCopyInfos,
+    grfx::Buffer*                                   pSrcBuffer,
+    grfx::Image*                                    pDstImage)
+{
+    for (auto& pCopyInfo : pCopyInfos) {
+        CopyBufferToImage(&pCopyInfo, pSrcBuffer, pDstImage);
+    }
+}
+
+void CommandBuffer::CopyBufferToImage(
     const grfx::BufferToImageCopyInfo* pCopyInfo,
     grfx::Buffer*                      pSrcBuffer,
     grfx::Image*                       pDstImage)

--- a/src/ppx/grfx/dx12/dx12_command.cpp
+++ b/src/ppx/grfx/dx12/dx12_command.cpp
@@ -612,6 +612,16 @@ void CommandBuffer::CopyBufferToBuffer(
 }
 
 void CommandBuffer::CopyBufferToImage(
+    const std::vector<grfx::BufferToImageCopyInfo>& pCopyInfos,
+    grfx::Buffer*                                   pSrcBuffer,
+    grfx::Image*                                    pDstImage)
+{
+    for (auto& pCopyInfo : pCopyInfos) {
+        CopyBufferToImage(&pCopyInfo, pSrcBuffer, pDstImage);
+    }
+}
+
+void CommandBuffer::CopyBufferToImage(
     const grfx::BufferToImageCopyInfo* pCopyInfo,
     grfx::Buffer*                      pSrcBuffer,
     grfx::Image*                       pDstImage)
@@ -647,6 +657,7 @@ void CommandBuffer::CopyBufferToImage(
             &numRows,
             &rowSizeInBytes,
             &totalBytes);
+
         //
         // Replace the values in case the footprint is a submimage
         //

--- a/src/ppx/grfx/dx12/dx12_command.cpp
+++ b/src/ppx/grfx/dx12/dx12_command.cpp
@@ -617,12 +617,12 @@ void CommandBuffer::CopyBufferToImage(
     grfx::Image*                                    pDstImage)
 {
     for (auto& pCopyInfo : pCopyInfos) {
-        CopyBufferToImage(&pCopyInfo, pSrcBuffer, pDstImage);
+        CopyBufferToImage(pCopyInfo, pSrcBuffer, pDstImage);
     }
 }
 
 void CommandBuffer::CopyBufferToImage(
-    const grfx::BufferToImageCopyInfo* pCopyInfo,
+    const grfx::BufferToImageCopyInfo& pCopyInfo,
     grfx::Buffer*                      pSrcBuffer,
     grfx::Image*                       pDstImage)
 {
@@ -638,10 +638,10 @@ void CommandBuffer::CopyBufferToImage(
     src.pResource                   = ToApi(pSrcBuffer)->GetDxResource();
     src.Type                        = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
 
-    for (uint32_t i = 0; i < pCopyInfo->dstImage.arrayLayerCount; ++i) {
-        uint32_t arrayLayer = pCopyInfo->dstImage.arrayLayer + i;
+    for (uint32_t i = 0; i < pCopyInfo.dstImage.arrayLayerCount; ++i) {
+        uint32_t arrayLayer = pCopyInfo.dstImage.arrayLayer + i;
 
-        dst.SubresourceIndex = static_cast<UINT>((arrayLayer * mipLevelCount) + pCopyInfo->dstImage.mipLevel);
+        dst.SubresourceIndex = static_cast<UINT>((arrayLayer * mipLevelCount) + pCopyInfo.dstImage.mipLevel);
 
         UINT   numSubresources = 1;
         UINT   numRows         = 0;
@@ -652,7 +652,7 @@ void CommandBuffer::CopyBufferToImage(
             &resouceDesc,
             dst.SubresourceIndex,
             numSubresources,
-            static_cast<UINT64>(pCopyInfo->srcBuffer.footprintOffset),
+            static_cast<UINT64>(pCopyInfo.srcBuffer.footprintOffset),
             &src.PlacedFootprint,
             &numRows,
             &rowSizeInBytes,
@@ -666,17 +666,17 @@ void CommandBuffer::CopyBufferToImage(
         //       But generally, we want to do this in the calling code
         //       and not here.
         //
-        src.PlacedFootprint.Offset             = static_cast<UINT64>(pCopyInfo->srcBuffer.footprintOffset);
-        src.PlacedFootprint.Footprint.Width    = static_cast<UINT>(pCopyInfo->srcBuffer.footprintWidth);
-        src.PlacedFootprint.Footprint.Height   = static_cast<UINT>(pCopyInfo->srcBuffer.footprintHeight);
-        src.PlacedFootprint.Footprint.Depth    = static_cast<UINT>(pCopyInfo->srcBuffer.footprintDepth);
-        src.PlacedFootprint.Footprint.RowPitch = static_cast<UINT>(pCopyInfo->srcBuffer.imageRowStride);
+        src.PlacedFootprint.Offset             = static_cast<UINT64>(pCopyInfo.srcBuffer.footprintOffset);
+        src.PlacedFootprint.Footprint.Width    = static_cast<UINT>(pCopyInfo.srcBuffer.footprintWidth);
+        src.PlacedFootprint.Footprint.Height   = static_cast<UINT>(pCopyInfo.srcBuffer.footprintHeight);
+        src.PlacedFootprint.Footprint.Depth    = static_cast<UINT>(pCopyInfo.srcBuffer.footprintDepth);
+        src.PlacedFootprint.Footprint.RowPitch = static_cast<UINT>(pCopyInfo.srcBuffer.imageRowStride);
 
         mCommandList->CopyTextureRegion(
             &dst,
-            static_cast<UINT>(pCopyInfo->dstImage.x),
-            static_cast<UINT>(pCopyInfo->dstImage.y),
-            static_cast<UINT>(pCopyInfo->dstImage.z),
+            static_cast<UINT>(pCopyInfo.dstImage.x),
+            static_cast<UINT>(pCopyInfo.dstImage.y),
+            static_cast<UINT>(pCopyInfo.dstImage.z),
             &src,
             nullptr);
     }

--- a/src/ppx/grfx/grfx_queue.cpp
+++ b/src/ppx/grfx/grfx_queue.cpp
@@ -131,15 +131,15 @@ Result Queue::CopyBufferToBuffer(
 }
 
 Result Queue::CopyBufferToImage(
-    const grfx::BufferToImageCopyInfo* pCopyInfo,
-    grfx::Buffer*                      pSrcBuffer,
-    grfx::Image*                       pDstImage,
-    uint32_t                           mipLevel,
-    uint32_t                           mipLevelCount,
-    uint32_t                           arrayLayer,
-    uint32_t                           arrayLayerCount,
-    grfx::ResourceState                stateBefore,
-    grfx::ResourceState                stateAfter)
+    const std::vector<grfx::BufferToImageCopyInfo>& pCopyInfos,
+    grfx::Buffer*                                   pSrcBuffer,
+    grfx::Image*                                    pDstImage,
+    uint32_t                                        mipLevel,
+    uint32_t                                        mipLevelCount,
+    uint32_t                                        arrayLayer,
+    uint32_t                                        arrayLayerCount,
+    grfx::ResourceState                             stateBefore,
+    grfx::ResourceState                             stateAfter)
 {
     grfx::ScopeDestroyer SCOPED_DESTROYER(GetDevice());
 
@@ -159,7 +159,7 @@ Result Queue::CopyBufferToImage(
         }
 
         cmd->TransitionImageLayout(pDstImage, PPX_ALL_SUBRESOURCES, stateBefore, grfx::RESOURCE_STATE_COPY_DST);
-        cmd->CopyBufferToImage(pCopyInfo, pSrcBuffer, pDstImage);
+        cmd->CopyBufferToImage(pCopyInfos, pSrcBuffer, pDstImage);
         cmd->TransitionImageLayout(pDstImage, PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_COPY_DST, stateAfter);
 
         ppxres = cmd->End();

--- a/src/ppx/grfx/vk/vk_command.cpp
+++ b/src/ppx/grfx/vk/vk_command.cpp
@@ -560,17 +560,15 @@ void CommandBuffer::CopyBufferToImage(
         ToApi(pSrcBuffer)->GetVkBuffer(),
         ToApi(pDstImage)->GetVkImage(),
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        pCopyInfos.size(),
+        static_cast<uint32_t>(pCopyInfos.size()),
         regions.data());
 }
 
 void CommandBuffer::CopyBufferToImage(
-    const grfx::BufferToImageCopyInfo* pCopyInfo,
+    const grfx::BufferToImageCopyInfo& pCopyInfo,
     grfx::Buffer*                      pSrcBuffer,
     grfx::Image*                       pDstImage)
 {
-    PPX_ASSERT_NULL_ARG(pCopyInfo);
-
     return CopyBufferToImage({pCopyInfo}, pSrcBuffer, pDstImage);
 }
 


### PR DESCRIPTION
Batch calls for `CopyBufferToImage`. This has the most apparent benefit in Vulkan, where `vkCmdCopyBufferToImage` takes a `regions` argument and can copy all mip levels from a single buffer into the image with a single API call. However, it also reduces the number of calls in DirectX 12, by going from something like

```
StartCommand()
TransitionImageLayout()
CopyTextureRegion()
TransitionImageLayout()
EndCommand()


StartCommand()
TransitionImageLayout()
CopyTextureRegion()
TransitionImageLayout()
EndCommand()


StartCommand()
TransitionImageLayout()
CopyTextureRegion()
TransitionImageLayout()
EndCommand()


StartCommand()
TransitionImageLayout()
CopyTextureRegion()
TransitionImageLayout()
EndCommand()
```

to



```
StartCommand()
TransitionImageLayout()
CopyTextureRegion()
CopyTextureRegion()
CopyTextureRegion()
CopyTextureRegion()
TransitionImageLayout()
EndCommand()
```

which copies all mip levels with a single command buffer.