### PR TITLE
Change CopyBufferToImage signature to match other methods

### DIFF
--- a/include/ppx/grfx/dx11/dx11_command.h
+++ b/include/ppx/grfx/dx11/dx11_command.h
@@ -116,7 +116,7 @@ public:
         grfx::Image*                                    pDstImage) override;
 
     virtual void CopyBufferToImage(
-        const grfx::BufferToImageCopyInfo& pCopyInfo,
+        const grfx::BufferToImageCopyInfo* pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) override;
 

--- a/include/ppx/grfx/dx12/dx12_command.h
+++ b/include/ppx/grfx/dx12/dx12_command.h
@@ -114,7 +114,7 @@ public:
         grfx::Image*                                    pDstImage) override;
 
     virtual void CopyBufferToImage(
-        const grfx::BufferToImageCopyInfo& pCopyInfo,
+        const grfx::BufferToImageCopyInfo* pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) override;
 

--- a/include/ppx/grfx/grfx_command.h
+++ b/include/ppx/grfx/grfx_command.h
@@ -344,7 +344,7 @@ public:
         grfx::Image*                                    pDstImage) = 0;
 
     virtual void CopyBufferToImage(
-        const grfx::BufferToImageCopyInfo& pCopyInfo,
+        const grfx::BufferToImageCopyInfo* pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) = 0;
 

--- a/include/ppx/grfx/vk/vk_command.h
+++ b/include/ppx/grfx/vk/vk_command.h
@@ -114,7 +114,7 @@ public:
         grfx::Image*                                    pDstImage) override;
 
     virtual void CopyBufferToImage(
-        const grfx::BufferToImageCopyInfo& pCopyInfo,
+        const grfx::BufferToImageCopyInfo* pCopyInfo,
         grfx::Buffer*                      pSrcBuffer,
         grfx::Image*                       pDstImage) override;
 

--- a/src/ppx/grfx/dx11/dx11_command.cpp
+++ b/src/ppx/grfx/dx11/dx11_command.cpp
@@ -470,33 +470,33 @@ void CommandBuffer::CopyBufferToImage(
     grfx::Image*                                    pDstImage)
 {
     for (auto& pCopyInfo : pCopyInfos) {
-        CopyBufferToImage(pCopyInfo, pSrcBuffer, pDstImage);
+        CopyBufferToImage(&pCopyInfo, pSrcBuffer, pDstImage);
     }
 }
 
 void CommandBuffer::CopyBufferToImage(
-    const grfx::BufferToImageCopyInfo& pCopyInfo,
+    const grfx::BufferToImageCopyInfo* pCopyInfo,
     grfx::Buffer*                      pSrcBuffer,
     grfx::Image*                       pDstImage)
 {
     dx11::args::CopyBufferToImage copyArgs = {};
 
-    copyArgs.srcBuffer.imageWidth      = pCopyInfo.srcBuffer.imageWidth;
-    copyArgs.srcBuffer.imageHeight     = pCopyInfo.srcBuffer.imageHeight;
-    copyArgs.srcBuffer.imageRowStride  = pCopyInfo.srcBuffer.imageRowStride;
-    copyArgs.srcBuffer.footprintOffset = pCopyInfo.srcBuffer.footprintOffset;
-    copyArgs.srcBuffer.footprintWidth  = pCopyInfo.srcBuffer.footprintWidth;
-    copyArgs.srcBuffer.footprintHeight = pCopyInfo.srcBuffer.footprintHeight;
-    copyArgs.srcBuffer.footprintDepth  = pCopyInfo.srcBuffer.footprintDepth;
-    copyArgs.dstImage.mipLevel         = pCopyInfo.dstImage.mipLevel;
-    copyArgs.dstImage.arrayLayer       = pCopyInfo.dstImage.arrayLayer;
-    copyArgs.dstImage.arrayLayerCount  = pCopyInfo.dstImage.arrayLayerCount;
-    copyArgs.dstImage.x                = pCopyInfo.dstImage.x;
-    copyArgs.dstImage.y                = pCopyInfo.dstImage.y;
-    copyArgs.dstImage.z                = pCopyInfo.dstImage.z;
-    copyArgs.dstImage.width            = pCopyInfo.dstImage.width;
-    copyArgs.dstImage.height           = pCopyInfo.dstImage.height;
-    copyArgs.dstImage.depth            = pCopyInfo.dstImage.depth;
+    copyArgs.srcBuffer.imageWidth      = pCopyInfo->srcBuffer.imageWidth;
+    copyArgs.srcBuffer.imageHeight     = pCopyInfo->srcBuffer.imageHeight;
+    copyArgs.srcBuffer.imageRowStride  = pCopyInfo->srcBuffer.imageRowStride;
+    copyArgs.srcBuffer.footprintOffset = pCopyInfo->srcBuffer.footprintOffset;
+    copyArgs.srcBuffer.footprintWidth  = pCopyInfo->srcBuffer.footprintWidth;
+    copyArgs.srcBuffer.footprintHeight = pCopyInfo->srcBuffer.footprintHeight;
+    copyArgs.srcBuffer.footprintDepth  = pCopyInfo->srcBuffer.footprintDepth;
+    copyArgs.dstImage.mipLevel         = pCopyInfo->dstImage.mipLevel;
+    copyArgs.dstImage.arrayLayer       = pCopyInfo->dstImage.arrayLayer;
+    copyArgs.dstImage.arrayLayerCount  = pCopyInfo->dstImage.arrayLayerCount;
+    copyArgs.dstImage.x                = pCopyInfo->dstImage.x;
+    copyArgs.dstImage.y                = pCopyInfo->dstImage.y;
+    copyArgs.dstImage.z                = pCopyInfo->dstImage.z;
+    copyArgs.dstImage.width            = pCopyInfo->dstImage.width;
+    copyArgs.dstImage.height           = pCopyInfo->dstImage.height;
+    copyArgs.dstImage.depth            = pCopyInfo->dstImage.depth;
     copyArgs.mapType                   = ToApi(pSrcBuffer)->GetMapType();
     copyArgs.isCube                    = (pDstImage->GetType() == grfx::IMAGE_TYPE_CUBE);
     copyArgs.mipSpan                   = pDstImage->GetMipLevelCount();

--- a/src/ppx/grfx/dx12/dx12_command.cpp
+++ b/src/ppx/grfx/dx12/dx12_command.cpp
@@ -617,12 +617,12 @@ void CommandBuffer::CopyBufferToImage(
     grfx::Image*                                    pDstImage)
 {
     for (auto& pCopyInfo : pCopyInfos) {
-        CopyBufferToImage(pCopyInfo, pSrcBuffer, pDstImage);
+        CopyBufferToImage(&pCopyInfo, pSrcBuffer, pDstImage);
     }
 }
 
 void CommandBuffer::CopyBufferToImage(
-    const grfx::BufferToImageCopyInfo& pCopyInfo,
+    const grfx::BufferToImageCopyInfo* pCopyInfo,
     grfx::Buffer*                      pSrcBuffer,
     grfx::Image*                       pDstImage)
 {
@@ -638,10 +638,10 @@ void CommandBuffer::CopyBufferToImage(
     src.pResource                   = ToApi(pSrcBuffer)->GetDxResource();
     src.Type                        = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
 
-    for (uint32_t i = 0; i < pCopyInfo.dstImage.arrayLayerCount; ++i) {
-        uint32_t arrayLayer = pCopyInfo.dstImage.arrayLayer + i;
+    for (uint32_t i = 0; i < pCopyInfo->dstImage.arrayLayerCount; ++i) {
+        uint32_t arrayLayer = pCopyInfo->dstImage.arrayLayer + i;
 
-        dst.SubresourceIndex = static_cast<UINT>((arrayLayer * mipLevelCount) + pCopyInfo.dstImage.mipLevel);
+        dst.SubresourceIndex = static_cast<UINT>((arrayLayer * mipLevelCount) + pCopyInfo->dstImage.mipLevel);
 
         UINT   numSubresources = 1;
         UINT   numRows         = 0;
@@ -652,7 +652,7 @@ void CommandBuffer::CopyBufferToImage(
             &resouceDesc,
             dst.SubresourceIndex,
             numSubresources,
-            static_cast<UINT64>(pCopyInfo.srcBuffer.footprintOffset),
+            static_cast<UINT64>(pCopyInfo->srcBuffer.footprintOffset),
             &src.PlacedFootprint,
             &numRows,
             &rowSizeInBytes,
@@ -666,17 +666,17 @@ void CommandBuffer::CopyBufferToImage(
         //       But generally, we want to do this in the calling code
         //       and not here.
         //
-        src.PlacedFootprint.Offset             = static_cast<UINT64>(pCopyInfo.srcBuffer.footprintOffset);
-        src.PlacedFootprint.Footprint.Width    = static_cast<UINT>(pCopyInfo.srcBuffer.footprintWidth);
-        src.PlacedFootprint.Footprint.Height   = static_cast<UINT>(pCopyInfo.srcBuffer.footprintHeight);
-        src.PlacedFootprint.Footprint.Depth    = static_cast<UINT>(pCopyInfo.srcBuffer.footprintDepth);
-        src.PlacedFootprint.Footprint.RowPitch = static_cast<UINT>(pCopyInfo.srcBuffer.imageRowStride);
+        src.PlacedFootprint.Offset             = static_cast<UINT64>(pCopyInfo->srcBuffer.footprintOffset);
+        src.PlacedFootprint.Footprint.Width    = static_cast<UINT>(pCopyInfo->srcBuffer.footprintWidth);
+        src.PlacedFootprint.Footprint.Height   = static_cast<UINT>(pCopyInfo->srcBuffer.footprintHeight);
+        src.PlacedFootprint.Footprint.Depth    = static_cast<UINT>(pCopyInfo->srcBuffer.footprintDepth);
+        src.PlacedFootprint.Footprint.RowPitch = static_cast<UINT>(pCopyInfo->srcBuffer.imageRowStride);
 
         mCommandList->CopyTextureRegion(
             &dst,
-            static_cast<UINT>(pCopyInfo.dstImage.x),
-            static_cast<UINT>(pCopyInfo.dstImage.y),
-            static_cast<UINT>(pCopyInfo.dstImage.z),
+            static_cast<UINT>(pCopyInfo->dstImage.x),
+            static_cast<UINT>(pCopyInfo->dstImage.y),
+            static_cast<UINT>(pCopyInfo->dstImage.z),
             &src,
             nullptr);
     }

--- a/src/ppx/grfx/vk/vk_command.cpp
+++ b/src/ppx/grfx/vk/vk_command.cpp
@@ -565,11 +565,11 @@ void CommandBuffer::CopyBufferToImage(
 }
 
 void CommandBuffer::CopyBufferToImage(
-    const grfx::BufferToImageCopyInfo& pCopyInfo,
+    const grfx::BufferToImageCopyInfo* pCopyInfo,
     grfx::Buffer*                      pSrcBuffer,
     grfx::Image*                       pDstImage)
 {
-    return CopyBufferToImage({pCopyInfo}, pSrcBuffer, pDstImage);
+    return CopyBufferToImage(std::vector<grfx::BufferToImageCopyInfo>{*pCopyInfo}, pSrcBuffer, pDstImage);
 }
 
 grfx::ImageToBufferOutputPitch CommandBuffer::CopyImageToBuffer(


### PR DESCRIPTION
Take a pointer instead of a reference. Note: I agree that it's better to take a reference to protect against `nullptr`, but we should probably do that as a single mass refactor.

This also fixes a build problem in our internal build: `{pCopyInfo}` is not actually constructing a vector (and the function is called in an infinite loop).