### PR TITLE
Fix fishtornado bug of having descriptor pool of insufficient size

### DIFF
--- a/projects/fishtornado/FishTornado.cpp
+++ b/projects/fishtornado/FishTornado.cpp
@@ -151,6 +151,7 @@ void FishTornadoApp::SetupDescriptorPool()
     createInfo.uniformBuffer                  = 1000;
     createInfo.structuredBuffer               = 1000;
     createInfo.storageTexelBuffer             = 1000;
+    createInfo.storageImage                   = 1000;
 
     PPX_CHECKED_CALL(GetDevice()->CreateDescriptorPool(&createInfo, &mDescriptorPool));
 }


### PR DESCRIPTION
Storage images are used by the flocking code. This bug seems only to trigger on Pixel 6 Pro ICDs and not on PC desktop ICDs