### PR TITLE
Fixed a typo in the Texture class interface

### DIFF
--- a/benchmarks/primitive_assembly/main.cpp
+++ b/benchmarks/primitive_assembly/main.cpp
@@ -194,8 +194,8 @@ void ProjApp::Setup()
         gpCreateInfo.depthWriteEnable                   = false;
         gpCreateInfo.blendModes[0]                      = grfx::BLEND_MODE_NONE;
         gpCreateInfo.outputState.renderTargetCount      = 1;
-        gpCreateInfo.outputState.renderTargetFormats[0] = mDrawPass->GetRenderTargetTexture(0)->GeImageFormat();
-        gpCreateInfo.outputState.depthStencilFormat     = mDrawPass->GetDepthStencilTexture()->GeImageFormat();
+        gpCreateInfo.outputState.renderTargetFormats[0] = mDrawPass->GetRenderTargetTexture(0)->GetImageFormat();
+        gpCreateInfo.outputState.depthStencilFormat     = mDrawPass->GetDepthStencilTexture()->GetImageFormat();
         gpCreateInfo.pPipelineInterface                 = mPipelineInterface;
         PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mPipeline));
     }

--- a/benchmarks/render_target/main.cpp
+++ b/benchmarks/render_target/main.cpp
@@ -251,11 +251,11 @@ void ProjApp::SetupDrawToTexturePass()
         gpCreateInfo.blendModes[0]                     = grfx::BLEND_MODE_NONE;
         gpCreateInfo.outputState.renderTargetCount     = mRenderTargetCount;
         for (uint32_t i = 0; i < mRenderTargetCount; ++i) {
-            gpCreateInfo.outputState.renderTargetFormats[i] = mDrawPass->GetRenderTargetTexture(i)->GeImageFormat();
+            gpCreateInfo.outputState.renderTargetFormats[i] = mDrawPass->GetRenderTargetTexture(i)->GetImageFormat();
         }
         gpCreateInfo.depthReadEnable                = false;
         gpCreateInfo.depthWriteEnable               = false;
-        gpCreateInfo.outputState.depthStencilFormat = mDrawPass->GetDepthStencilTexture()->GeImageFormat();
+        gpCreateInfo.outputState.depthStencilFormat = mDrawPass->GetDepthStencilTexture()->GetImageFormat();
         gpCreateInfo.pPipelineInterface             = mPipelineInterface;
         PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mPipeline));
     }

--- a/include/ppx/grfx/grfx_texture.h
+++ b/include/ppx/grfx/grfx_texture.h
@@ -62,7 +62,7 @@ public:
     uint32_t                     GetWidth() const;
     uint32_t                     GetHeight() const;
     uint32_t                     GetDepth() const;
-    grfx::Format                 GeImageFormat() const;
+    grfx::Format                 GetImageFormat() const;
     grfx::SampleCount            GetSampleCount() const;
     uint32_t                     GetMipLevelCount() const;
     uint32_t                     GetArrayLayerCount() const;

--- a/projects/16_gbuffer/main.cpp
+++ b/projects/16_gbuffer/main.cpp
@@ -317,8 +317,8 @@ void ProjApp::SetupGBufferLightQuad()
     createInfo.sets[1].set                    = 1;
     createInfo.sets[1].pLayout                = mGBufferReadLayout;
     createInfo.renderTargetCount              = 1;
-    createInfo.renderTargetFormats[0]         = mGBufferLightPass->GetRenderTargetTexture(0)->GeImageFormat();
-    createInfo.depthStencilFormat             = mGBufferLightPass->GetDepthStencilTexture()->GeImageFormat();
+    createInfo.renderTargetFormats[0]         = mGBufferLightPass->GetRenderTargetTexture(0)->GetImageFormat();
+    createInfo.depthStencilFormat             = mGBufferLightPass->GetDepthStencilTexture()->GetImageFormat();
 
     PPX_CHECKED_CALL(GetDevice()->CreateFullscreenQuad(&createInfo, &mGBufferLightQuad));
 }
@@ -348,8 +348,8 @@ void ProjApp::SetupDebugDraw()
     createInfo.sets[1].set                    = 1;
     createInfo.sets[1].pLayout                = mGBufferReadLayout;
     createInfo.renderTargetCount              = 1;
-    createInfo.renderTargetFormats[0]         = mGBufferLightPass->GetRenderTargetTexture(0)->GeImageFormat();
-    createInfo.depthStencilFormat             = mGBufferLightPass->GetDepthStencilTexture()->GeImageFormat();
+    createInfo.renderTargetFormats[0]         = mGBufferLightPass->GetRenderTargetTexture(0)->GetImageFormat();
+    createInfo.depthStencilFormat             = mGBufferLightPass->GetDepthStencilTexture()->GetImageFormat();
 
     PPX_CHECKED_CALL(GetDevice()->CreateFullscreenQuad(&createInfo, &mDebugDrawQuad));
 }

--- a/src/ppx/grfx/grfx_draw_pass.cpp
+++ b/src/ppx/grfx/grfx_draw_pass.cpp
@@ -271,12 +271,12 @@ Result DrawPass::CreateApiObjects(const grfx::internal::DrawPassCreateInfo* pCre
             renderTargetLoadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR;
         }
         if ((clearMask & DRAW_PASS_CLEAR_FLAG_CLEAR_DEPTH) != 0) {
-            if (GetFormatDescription(mDepthStencilTexture->GeImageFormat())->aspect & FORMAT_ASPECT_DEPTH) {
+            if (GetFormatDescription(mDepthStencilTexture->GetImageFormat())->aspect & FORMAT_ASPECT_DEPTH) {
                 depthLoadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR;
             }
         }
         if ((clearMask & DRAW_PASS_CLEAR_FLAG_CLEAR_STENCIL) != 0) {
-            if (GetFormatDescription(mDepthStencilTexture->GeImageFormat())->aspect & FORMAT_ASPECT_STENCIL) {
+            if (GetFormatDescription(mDepthStencilTexture->GetImageFormat())->aspect & FORMAT_ASPECT_STENCIL) {
                 stencilLoadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR;
             }
         }

--- a/src/ppx/grfx/grfx_texture.cpp
+++ b/src/ppx/grfx/grfx_texture.cpp
@@ -195,7 +195,7 @@ uint32_t Texture::GetDepth() const
     return mImage->GetDepth();
 }
 
-grfx::Format Texture::GeImageFormat() const
+grfx::Format Texture::GetImageFormat() const
 {
     return mImage->GetFormat();
 }


### PR DESCRIPTION
**GetImageFormat** was mispelled as **GeImageFormat** (missing **t**).