### PR TITLE
Add an option to run an application in headless mode.

### DIFF
--- a/benchmarks/headless_compute/main.cpp
+++ b/benchmarks/headless_compute/main.cpp
@@ -88,7 +88,7 @@ private:
 void ProjApp::Config(ppx::ApplicationSettings& settings)
 {
     settings.appName                        = "compute_operations";
-    settings.enableDisplay                  = false;
+    settings.headless                       = true;
     settings.enableImGui                    = false;
     settings.grfx.api                       = kApi;
     settings.grfx.enableDebug               = false;

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -203,12 +203,10 @@ struct KeyState
 //!
 struct ApplicationSettings
 {
-    std::string appName = "";
-    // If display is not enabled, then we don't need a swapchain, and there is
-    // no event loop: run a single frame.
-    bool enableDisplay         = true;
-    bool enableImGui           = false;
-    bool allowThirdPartyAssets = false;
+    std::string appName               = "";
+    bool        headless              = false;
+    bool        enableImGui           = false;
+    bool        allowThirdPartyAssets = false;
 
     struct
     {
@@ -400,6 +398,7 @@ private:
     Result InitializePlatform();
     Result InitializeGrfxDevice();
     Result InitializeGrfxSurface();
+    Result InitializeGrfxSwapchain();
     Result InitializeImGui();
     void   ShutdownImGui();
     void   StopGrfx();
@@ -436,7 +435,7 @@ private:
     KeyState                        mKeyStates[TOTAL_KEY_COUNT] = {false, 0.0f};
     int32_t                         mPreviousMouseX             = INT32_MAX;
     int32_t                         mPreviousMouseY             = INT32_MAX;
-    bool                            mRunningWithoutDisplay      = false;
+    bool                            mRunningHeadless            = false;
     grfx::InstancePtr               mInstance                   = nullptr;
     grfx::DevicePtr                 mDevice                     = nullptr;
     grfx::SurfacePtr                mSurface                    = nullptr; // Requires enableDisplay

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -33,11 +33,12 @@ struct StandardOptions
     bool help                  = false;
     bool list_gpus             = false;
     bool use_software_renderer = false;
+    bool headless              = false;
 
     // Options
-    int                 gpu_index   = -1;
-    std::pair<int, int> resolution  = {-1, -1};
-    int                 frame_count = -1;
+    int                 gpu_index          = -1;
+    std::pair<int, int> resolution         = {-1, -1};
+    int                 frame_count        = -1;
     uint32_t            stats_frame_window = 300;
 
     int         screenshot_frame_number                  = -1;

--- a/include/ppx/grfx/dx11/dx11_swapchain.h
+++ b/include/ppx/grfx/dx11/dx11_swapchain.h
@@ -55,7 +55,7 @@ public:
     Swapchain() {}
     virtual ~Swapchain() {}
 
-    virtual Result Present(
+    virtual Result PresentInternal(
         uint32_t                      imageIndex,
         uint32_t                      waitSemaphoreCount,
         const grfx::Semaphore* const* ppWaitSemaphores) override;

--- a/include/ppx/grfx/dx12/dx12_swapchain.h
+++ b/include/ppx/grfx/dx12/dx12_swapchain.h
@@ -55,7 +55,7 @@ public:
     Swapchain() {}
     virtual ~Swapchain() {}
 
-    virtual Result Present(
+    virtual Result PresentInternal(
         uint32_t                      imageIndex,
         uint32_t                      waitSemaphoreCount,
         const grfx::Semaphore* const* ppWaitSemaphores) override;

--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -111,6 +111,7 @@ public:
     Swapchain() {}
     virtual ~Swapchain() {}
 
+    bool         IsHeadless() const { return mCreateInfo.pSurface == nullptr; }
     uint32_t     GetWidth() const { return mCreateInfo.width; }
     uint32_t     GetHeight() const { return mCreateInfo.height; }
     uint32_t     GetImageCount() const { return mCreateInfo.imageCount; }
@@ -132,10 +133,10 @@ public:
         grfx::Fence*     pFence,     // Wait fence
         uint32_t*        pImageIndex);
 
-    virtual Result Present(
+    Result Present(
         uint32_t                      imageIndex,
         uint32_t                      waitSemaphoreCount,
-        const grfx::Semaphore* const* ppWaitSemaphores) = 0;
+        const grfx::Semaphore* const* ppWaitSemaphores);
 
     uint32_t GetCurrentImageIndex() const { return currentImageIndex; }
 
@@ -164,6 +165,25 @@ protected:
         grfx::Semaphore* pSemaphore, // Wait sempahore
         grfx::Fence*     pFence,     // Wait fence
         uint32_t*        pImageIndex) = 0;
+
+    virtual Result PresentInternal(
+        uint32_t                      imageIndex,
+        uint32_t                      waitSemaphoreCount,
+        const grfx::Semaphore* const* ppWaitSemaphores) = 0;
+
+private:
+    Result AcquireNextImageHeadless(
+        uint64_t         timeout,
+        grfx::Semaphore* pSemaphore,
+        grfx::Fence*     pFence,
+        uint32_t*        pImageIndex);
+
+    Result PresentHeadless(
+        uint32_t                      imageIndex,
+        uint32_t                      waitSemaphoreCount,
+        const grfx::Semaphore* const* ppWaitSemaphores);
+
+    std::vector<grfx::CommandBufferPtr> mHeadlessCommandBuffers;
 
 protected:
     grfx::QueuePtr                   mQueue;

--- a/include/ppx/grfx/vk/vk_swapchain.h
+++ b/include/ppx/grfx/vk/vk_swapchain.h
@@ -70,7 +70,7 @@ public:
 
     VkSwapchainPtr GetVkSwapchain() const { return mSwapchain; }
 
-    virtual Result Present(
+    virtual Result PresentInternal(
         uint32_t                      imageIndex,
         uint32_t                      waitSemaphoreCount,
         const grfx::Semaphore* const* ppWaitSemaphores) override;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,8 @@ elseif(PPX_LINUX_XLIB)
     set(PPX_LINUX_VULKAN_SURFACE "PPX_LINUX_XLIB")
 elseif(PPX_LINUX_WAYLAND)
     set(PPX_LINUX_VULKAN_SURFACE "PPX_LINUX_WAYLAND")
+elseif(PPX_LINUX_HEADLESS)
+    set(PPX_LINUX_VULKAN_SURFACE "PPX_LINUX_HEADLESS")
 else()
     set(PPX_LINUX_VULKAN_SURFACE "PPX_LINUX_XCB")
 endif()
@@ -592,7 +594,6 @@ if (PPX_VULKAN)
                    -Werror=return-type
 		)
     elseif (PPX_LINUX)
-
         target_compile_definitions(
             ${PROJECT_NAME}
             PUBLIC ${PPX_LINUX_VULKAN_SURFACE}
@@ -654,10 +655,13 @@ if (PPX_VULKAN)
             PROPERTIES OUTPUT_NAME PPX
                        LINKER_LANGUAGE CXX
         )
-        # Link libraries
-        target_link_libraries(${PROJECT_NAME}
-            PUBLIC xcb X11-xcb
-        )
+
+        # Link XCB libraries if needed
+        if (${PPX_LINUX_VULKAN_SURFACE} STREQUAL "PPX_LINUX_XCB")
+            target_link_libraries(${PROJECT_NAME}
+                PUBLIC xcb X11-xcb
+            )
+        endif()
     # Windows
     elseif (PPX_MSW)
         target_link_libraries(${PROJECT_NAME}
@@ -669,7 +673,6 @@ endif()
 # ------------------------------------------------------------------------------
 # Profiling
 # ------------------------------------------------------------------------------
-
 if (PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
     target_compile_definitions(
         ${PROJECT_NAME}

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -77,6 +77,9 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
         else if (opt.GetName() == "use-software-renderer") {
             mOpts.standardOptions.use_software_renderer = true;
         }
+        else if (opt.GetName() == "headless") {
+            mOpts.standardOptions.headless = true;
+        }
         else if (opt.GetName() == "gpu") {
             if (!opt.HasValue()) {
                 return std::string("Command-line option --gpu requires a parameter");

--- a/src/ppx/grfx/dx11/dx11_swapchain.cpp
+++ b/src/ppx/grfx/dx11/dx11_swapchain.cpp
@@ -75,6 +75,10 @@ uint32_t Surface::GetMaxImageCount() const
 // -------------------------------------------------------------------------------------------------
 Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
 {
+    if (IsHeadless()) {
+        return ppx::SUCCESS;
+    }
+
     std::vector<ID3D11Resource*> colorImages;
     std::vector<ID3D11Resource*> depthImages;
 
@@ -377,7 +381,7 @@ Result Swapchain::AcquireNextImageInternal(
     return ppx::SUCCESS;
 }
 
-Result Swapchain::Present(
+Result Swapchain::PresentInternal(
     uint32_t                      imageIndex,
     uint32_t                      waitSemaphoreCount,
     const grfx::Semaphore* const* ppWaitSemaphores)

--- a/src/ppx/grfx/dx12/dx12_swapchain.cpp
+++ b/src/ppx/grfx/dx12/dx12_swapchain.cpp
@@ -47,6 +47,10 @@ void Surface::DestroyApiObjects()
 // -------------------------------------------------------------------------------------------------
 Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
 {
+    if (IsHeadless()) {
+        return ppx::SUCCESS;
+    }
+
     std::vector<ID3D12Resource*> colorImages;
     std::vector<ID3D12Resource*> depthImages;
 
@@ -349,7 +353,7 @@ Result Swapchain::AcquireNextImageInternal(
     return ppx::SUCCESS;
 }
 
-Result Swapchain::Present(
+Result Swapchain::PresentInternal(
     uint32_t                      imageIndex,
     uint32_t                      waitSemaphoreCount,
     const grfx::Semaphore* const* ppWaitSemaphores)

--- a/src/ppx/grfx/vk/vk_swapchain.cpp
+++ b/src/ppx/grfx/vk/vk_swapchain.cpp
@@ -30,6 +30,7 @@ namespace vk {
 // -------------------------------------------------------------------------------------------------
 Result Surface::CreateApiObjects(const grfx::SurfaceCreateInfo* pCreateInfo)
 {
+    VkResult vkres = VK_SUCCESS;
 #if defined(PPX_GGP)
     VkStreamDescriptorSurfaceCreateInfoGGP vkci = {VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP};
     vkci.streamDescriptor                       = GgpStreamDescriptorConstants::kGgpPrimaryStreamDescriptor;
@@ -38,7 +39,7 @@ Result Surface::CreateApiObjects(const grfx::SurfaceCreateInfo* pCreateInfo)
         vkGetInstanceProcAddr(ToApi(GetInstance())->GetVkInstance(), "vkCreateStreamDescriptorSurfaceGGP"));
     PPX_ASSERT_MSG(vkCreateStreamDescriptorSurfaceGGP != nullptr, "Error getting function vkCreateStreamDescriptorSurfaceGGP");
 
-    VkResult vkres = vkCreateStreamDescriptorSurfaceGGP(
+    vkres = vkCreateStreamDescriptorSurfaceGGP(
         ToApi(GetInstance())->GetVkInstance(),
         &vkci,
         nullptr,
@@ -48,7 +49,7 @@ Result Surface::CreateApiObjects(const grfx::SurfaceCreateInfo* pCreateInfo)
     vkci.connection                = pCreateInfo->connection;
     vkci.window                    = pCreateInfo->window;
 
-    VkResult vkres = vkCreateXcbSurfaceKHR(
+    vkres = vkCreateXcbSurfaceKHR(
         ToApi(GetInstance())->GetVkInstance(),
         &vkci,
         nullptr,
@@ -62,7 +63,7 @@ Result Surface::CreateApiObjects(const grfx::SurfaceCreateInfo* pCreateInfo)
     vkci.hinstance                   = pCreateInfo->hinstance;
     vkci.hwnd                        = pCreateInfo->hwnd;
 
-    VkResult vkres = vkCreateWin32SurfaceKHR(
+    vkres = vkCreateWin32SurfaceKHR(
         ToApi(GetInstance())->GetVkInstance(),
         &vkci,
         nullptr,
@@ -203,6 +204,10 @@ uint32_t Surface::GetMaxImageCount() const
 // -------------------------------------------------------------------------------------------------
 Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
 {
+    if (IsHeadless()) {
+        return ppx::SUCCESS;
+    }
+
     std::vector<VkImage> colorImages;
     std::vector<VkImage> depthImages;
 
@@ -543,7 +548,7 @@ Result Swapchain::AcquireNextImageInternal(
     return ppx::SUCCESS;
 }
 
-Result Swapchain::Present(
+Result Swapchain::PresentInternal(
     uint32_t                      imageIndex,
     uint32_t                      waitSemaphoreCount,
     const grfx::Semaphore* const* ppWaitSemaphores)


### PR DESCRIPTION
To run an application in headless mode, pass the `--headless` flag. All APIs are supported. Software rendering also supports this mode.

In headless mode, no window or graphics surface is created. The graphics swapchain is created and managed manually, i.e. the render targets (color images) and depth images are created explicitly. The `Present` and `AcquireNextImage` calls are also handled manually by submitting empty command buffers that signal or wait for semaphores as needed.

Additional changes:
* Explicitly set severity of D3D12 debug message, and ignore the non-matching clear value warnings that cannot be avoided in headless mode. They are noisy, performance-only warnings.
* Add a CMake option to the Linux build to avoid linking to XCB if only headless execution is desired (`-DPPX_LINUX_HEADLESS`).