### PR TITLE
Independent blending in Vulkan

### DIFF
--- a/include/ppx/grfx/dx11/dx11_device.h
+++ b/include/ppx/grfx/dx11/dx11_device.h
@@ -36,6 +36,7 @@ public:
 
     virtual bool PipelineStatsAvailable() const override;
     virtual bool DynamicRenderingSupported() const override;
+    virtual bool IndependentBlendingSupported() const override;
 
     Result GetStructuredBufferSRV(
         const grfx::Buffer*                                  pBuffer,

--- a/include/ppx/grfx/dx12/dx12_device.h
+++ b/include/ppx/grfx/dx12/dx12_device.h
@@ -63,6 +63,7 @@ public:
 
     virtual bool PipelineStatsAvailable() const override;
     virtual bool DynamicRenderingSupported() const override;
+    virtual bool IndependentBlendingSupported() const override;
 
 protected:
     virtual Result AllocateObject(grfx::Buffer** ppObject) override;

--- a/include/ppx/grfx/grfx_device.h
+++ b/include/ppx/grfx/grfx_device.h
@@ -183,6 +183,7 @@ public:
 
     virtual bool PipelineStatsAvailable() const    = 0;
     virtual bool DynamicRenderingSupported() const = 0;
+    virtual bool IndependentBlendingSupported() const = 0;
 
 protected:
     virtual Result Create(const grfx::DeviceCreateInfo* pCreateInfo) override;

--- a/include/ppx/grfx/vk/vk_device.h
+++ b/include/ppx/grfx/vk/vk_device.h
@@ -42,6 +42,7 @@ public:
 
     virtual bool PipelineStatsAvailable() const override;
     virtual bool DynamicRenderingSupported() const override;
+    virtual bool IndependentBlendingSupported() const override;
 
     void ResetQueryPoolEXT(
         VkQueryPool queryPool,

--- a/src/ppx/grfx/dx11/dx11_device.cpp
+++ b/src/ppx/grfx/dx11/dx11_device.cpp
@@ -382,6 +382,11 @@ bool Device::DynamicRenderingSupported() const
     return false;
 }
 
+bool Device::IndependentBlendingSupported() const
+{
+    return true;
+}
+
 Result Device::GetStructuredBufferSRV(
     const grfx::Buffer*                                  pBuffer,
     UINT                                                 numElements,

--- a/src/ppx/grfx/dx12/dx12_device.cpp
+++ b/src/ppx/grfx/dx12/dx12_device.cpp
@@ -688,6 +688,11 @@ bool Device::DynamicRenderingSupported() const
     return mRenderPassTier > D3D12_RENDER_PASS_TIER_0;
 }
 
+bool Device::IndependentBlendingSupported() const
+{
+    return true;
+}
+
 } // namespace dx12
 } // namespace grfx
 } // namespace ppx

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -197,6 +197,7 @@ Result Device::ConfigureFeatures(const grfx::DeviceCreateInfo* pCreateInfo, VkPh
     features                                      = {};
     features.fullDrawIndexUint32                  = VK_TRUE;
     features.imageCubeArray                       = VK_TRUE;
+    features.independentBlend                     = foundFeatures.independentBlend;
     features.pipelineStatisticsQuery              = foundFeatures.pipelineStatisticsQuery;
     features.geometryShader                       = foundFeatures.geometryShader;
     features.tessellationShader                   = foundFeatures.tessellationShader;

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -677,6 +677,11 @@ bool Device::DynamicRenderingSupported() const
     return mHasDynamicRendering;
 }
 
+bool Device::IndependentBlendingSupported() const
+{
+    return mDeviceFeatures.independentBlend == VK_TRUE;
+}
+
 void Device::ResetQueryPoolEXT(
     VkQueryPool queryPool,
     uint32_t    firstQuery,


### PR DESCRIPTION
Independent blending is automatically enabled in DX11 and DX12 at pipeline creation when using blend states (see GraphicsPipeline::InitializeBlendState in dx12_pipeline.cpp).
In Vulkan, independent blending is handled at device creation (via vkPhysicalDeviceFeatures), and is never enabled, which creates a discrepancy of behavior between Vulkan and DirectX.
This discrepancy is fixed by the current PR in the following way.

* Enabled independent blending in Vulkan when available
* Added a new method to the device class to check whether independent blending is supported or not
