### PR TITLE
Rework Bitmap::Fill to avoid undefined behavior

### DIFF
--- a/include/ppx/bitmap.h
+++ b/include/ppx/bitmap.h
@@ -86,7 +86,8 @@ public:
     Result Resize(uint32_t width, uint32_t height);
     Result ScaleTo(Bitmap* pTargetBitmap) const;
 
-    void Fill(float r, float g, float b, float a);
+    template <typename PixelDataType>
+    void Fill(PixelDataType r, PixelDataType g, PixelDataType b, PixelDataType a);
 
     // Returns byte address of pixel at (x,y)
     char*       GetPixelAddress(uint32_t x, uint32_t y);
@@ -194,6 +195,28 @@ private:
     char*             mData            = nullptr;
     std::vector<char> mInternalStorage = {};
 };
+
+template <typename PixelDataType>
+void Bitmap::Fill(PixelDataType r, PixelDataType g, PixelDataType b, PixelDataType a)
+{
+    PPX_ASSERT_MSG(mData != nullptr, "data is null");
+    PPX_ASSERT_MSG(mFormat != Bitmap::FORMAT_UNDEFINED, "format is undefined");
+
+    PixelDataType rgba[4] = {r, g, b, a};
+
+    const uint32_t channelCount = Bitmap::ChannelCount(mFormat);
+
+    char* pData = mData;
+    for (uint32_t y = 0; y < mHeight; ++y) {
+        for (uint32_t x = 0; x < mWidth; ++x) {
+            PixelDataType* pPixelData = reinterpret_cast<PixelDataType*>(pData);
+            for (uint32_t c = 0; c < channelCount; ++c) {
+                pPixelData[c] = rgba[c];
+            }
+            pData += mPixelStride;
+        }
+    }
+}
 
 } // namespace ppx
 

--- a/projects/15_basic_material/main.cpp
+++ b/projects/15_basic_material/main.cpp
@@ -418,8 +418,8 @@ void ProjApp::SetupMaterials()
 
 void ProjApp::Setup()
 {
-    PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(GetDevice()->GetGraphicsQueue(), float4(0), &m1x1BlackTexture));
-    PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(GetDevice()->GetGraphicsQueue(), float4(1), &m1x1WhiteTexture));
+    PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(GetDevice()->GetGraphicsQueue(), {0, 0, 0, 0}, &m1x1BlackTexture));
+    PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(GetDevice()->GetGraphicsQueue(), {255, 255, 255, 255}, &m1x1WhiteTexture));
     mF0Index = static_cast<uint32_t>(mF0Names.size() - 1);
 
     // Cameras

--- a/projects/16_gbuffer/Material.cpp
+++ b/projects/16_gbuffer/Material.cpp
@@ -204,8 +204,8 @@ ppx::Result Material::CreateMaterials(ppx::grfx::Queue* pQueue, ppx::grfx::Descr
 
     // Create 1x1 black and white textures
     {
-        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(pQueue, float4(0), &s1x1BlackTexture));
-        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(pQueue, float4(1), &s1x1WhiteTexture));
+        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(pQueue, {0, 0, 0, 0}, &s1x1BlackTexture));
+        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(pQueue, {255, 255, 255, 255}, &s1x1WhiteTexture));
     }
 
     // Create sampler

--- a/projects/16_gbuffer/main.cpp
+++ b/projects/16_gbuffer/main.cpp
@@ -494,7 +494,7 @@ void ProjApp::Setup()
         writes[3].pImageView            = mGBufferRenderPass->GetRenderTargetTexture(3)->GetSampledImageView();
         // Environment map and IBL are not currently used.
         // Create a 1x1 image for unused textures.
-        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(GetDevice()->GetGraphicsQueue(), float4(1), &m1x1WhiteTexture));
+        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(GetDevice()->GetGraphicsQueue(), {255, 255, 255, 255}, &m1x1WhiteTexture));
         writes[4].binding      = GBUFFER_ENV_REGISTER;
         writes[4].arrayIndex   = 0;
         writes[4].type         = grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE;

--- a/projects/fishtornado/FishTornado.cpp
+++ b/projects/fishtornado/FishTornado.cpp
@@ -201,7 +201,7 @@ void FishTornadoApp::SetupPipelineInterfaces()
 
 void FishTornadoApp::SetupTextures()
 {
-    PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(GetGraphicsQueue(), {0, 0, 0, 0}, &m1x1BlackTexture));
+    PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(GetGraphicsQueue(), {0, 0, 0, 0}, &m1x1BlackTexture));
 }
 
 void FishTornadoApp::SetupSamplers()

--- a/projects/fishtornado/Ocean.cpp
+++ b/projects/fishtornado/Ocean.cpp
@@ -90,8 +90,8 @@ void Ocean::Setup(uint32_t numFramesInFlight)
         TriMesh        mesh    = TriMesh::CreatePlane(TRI_MESH_PLANE_NEGATIVE_Y, float2(2500.0f), 10, 10, options);
         PPX_CHECKED_CALL(grfx_util::CreateMeshFromTriMesh(queue, &mesh, &mSurfaceMesh));
 
-        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(queue, float4(0, 0, 0, 0), &mSurfaceAlbedoTexture));
-        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(queue, float4(1, 1, 1, 1), &mSurfaceRoughnessTexture));
+        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(queue, {0, 0, 0, 0}, &mSurfaceAlbedoTexture));
+        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(queue, {255, 255, 255, 255}, &mSurfaceRoughnessTexture));
         PPX_CHECKED_CALL(grfx_util::CreateTextureFromFile(queue, pApp->GetAssetPath("fishtornado/textures/ocean/surfaceNormalMap.png"), &mSurfaceNormalMapTexture));
 
         PPX_CHECKED_CALL(mSurfaceMaterialConstants.Create(device, PPX_MINIMUM_CONSTANT_BUFFER_SIZE));

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -205,7 +205,7 @@ void FishTornadoApp::SetupPipelineInterfaces()
 
 void FishTornadoApp::SetupTextures()
 {
-    PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(GetGraphicsQueue(), {0, 0, 0, 0}, &m1x1BlackTexture));
+    PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(GetGraphicsQueue(), {0, 0, 0, 0}, &m1x1BlackTexture));
 }
 
 void FishTornadoApp::SetupSamplers()

--- a/projects/fishtornado_xr/Ocean.cpp
+++ b/projects/fishtornado_xr/Ocean.cpp
@@ -90,8 +90,8 @@ void Ocean::Setup(uint32_t numFramesInFlight)
         TriMesh        mesh    = TriMesh::CreatePlane(TRI_MESH_PLANE_NEGATIVE_Y, float2(2500.0f), 10, 10, options);
         PPX_CHECKED_CALL(grfx_util::CreateMeshFromTriMesh(queue, &mesh, &mSurfaceMesh));
 
-        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(queue, float4(0, 0, 0, 0), &mSurfaceAlbedoTexture));
-        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1(queue, float4(1, 1, 1, 1), &mSurfaceRoughnessTexture));
+        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(queue, {0, 0, 0, 0}, &mSurfaceAlbedoTexture));
+        PPX_CHECKED_CALL(grfx_util::CreateTexture1x1<uint8_t>(queue, {255, 255, 255, 255}, &mSurfaceRoughnessTexture));
         PPX_CHECKED_CALL(grfx_util::CreateTextureFromFile(queue, pApp->GetAssetPath("fishtornado/textures/ocean/surfaceNormalMap.png"), &mSurfaceNormalMapTexture));
 
         PPX_CHECKED_CALL(mSurfaceMaterialConstants.Create(device, PPX_MINIMUM_CONSTANT_BUFFER_SIZE));

--- a/src/ppx/bitmap.cpp
+++ b/src/ppx/bitmap.cpp
@@ -260,69 +260,6 @@ Result Bitmap::ScaleTo(Bitmap* pTargetBitmap) const
     return ppx::SUCCESS;
 }
 
-void Bitmap::Fill(float r, float g, float b, float a)
-{
-    PPX_ASSERT_MSG(mData != nullptr, "data is null");
-
-    if (mFormat == Bitmap::FORMAT_UNDEFINED) {
-        PPX_ASSERT_MSG(false, "format is undefined");
-        return;
-    }
-
-    uint8_t rgbaU8[4] = {
-        static_cast<uint8_t>(UINT8_MAX * std::min<float>(r, 1.0f)),
-        static_cast<uint8_t>(UINT8_MAX * std::min<float>(g, 1.0f)),
-        static_cast<uint8_t>(UINT8_MAX * std::min<float>(b, 1.0f)),
-        static_cast<uint8_t>(UINT8_MAX * std::min<float>(a, 1.0f)),
-    };
-
-    uint16_t rgbaU16[4] = {
-        static_cast<uint8_t>(UINT16_MAX * std::min<float>(r, 1.0f)),
-        static_cast<uint8_t>(UINT16_MAX * std::min<float>(g, 1.0f)),
-        static_cast<uint8_t>(UINT16_MAX * std::min<float>(b, 1.0f)),
-        static_cast<uint8_t>(UINT16_MAX * std::min<float>(a, 1.0f)),
-    };
-
-    uint16_t rgbaU32[4] = {
-        static_cast<uint8_t>(UINT32_MAX * std::min<float>(r, 1.0f)),
-        static_cast<uint8_t>(UINT32_MAX * std::min<float>(g, 1.0f)),
-        static_cast<uint8_t>(UINT32_MAX * std::min<float>(b, 1.0f)),
-        static_cast<uint8_t>(UINT32_MAX * std::min<float>(a, 1.0f)),
-    };
-
-    float rgbaF32[4] = {
-        r,
-        g,
-        b,
-        a,
-    };
-
-    const uint32_t         channelCount = Bitmap::ChannelCount(mFormat);
-    const Bitmap::DataType dataType     = Bitmap::ChannelDataType(mFormat);
-
-    char* pData = mData;
-    for (uint32_t y = 0; y < mHeight; ++y) {
-        for (uint32_t x = 0; x < mWidth; ++x) {
-            uint8_t*  pDataU8  = reinterpret_cast<uint8_t*>(pData);
-            uint16_t* pDataU16 = reinterpret_cast<uint16_t*>(pData);
-            uint32_t* pDataU32 = reinterpret_cast<uint32_t*>(pData);
-            float*    pDataF32 = reinterpret_cast<float*>(pData);
-            for (uint32_t c = 0; c < channelCount; ++c) {
-                // clang-format off
-                switch (dataType) {
-                    default: break;
-                    case Bitmap::DATA_TYPE_UINT8  : pDataU8[c]  = rgbaU8[c]; break;
-                    case Bitmap::DATA_TYPE_UINT16 : pDataU16[c] = rgbaU16[c]; break;
-                    case Bitmap::DATA_TYPE_UINT32 : pDataU32[c] = rgbaU32[c]; break;
-                    case Bitmap::DATA_TYPE_FLOAT  : pDataF32[c] = rgbaF32[c]; break;
-                }
-                // clang-format on
-            }
-            pData += mPixelStride;
-        }
-    }
-}
-
 char* Bitmap::GetPixelAddress(uint32_t x, uint32_t y)
 {
     char* pPixel = nullptr;

--- a/src/ppx/graphics_util.cpp
+++ b/src/ppx/graphics_util.cpp
@@ -992,36 +992,6 @@ Result CreateTextureFromFile(
 
 // -------------------------------------------------------------------------------------------------
 
-Result CreateTexture1x1(
-    grfx::Queue*          pQueue,
-    const float4&         color,
-    grfx::Texture**       ppTexture,
-    const TextureOptions& options)
-{
-    PPX_ASSERT_NULL_ARG(pQueue);
-    PPX_ASSERT_NULL_ARG(ppTexture);
-
-    Result ppxres = ppx::SUCCESS;
-
-    // Create bitmap
-    Bitmap bitmap = Bitmap::Create(1, 1, Bitmap::FORMAT_RGBA_UINT8, &ppxres);
-    if (Failed(ppxres)) {
-        return ppx::ERROR_BITMAP_CREATE_FAILED;
-    }
-
-    // Fill color
-    bitmap.Fill(color.r, color.g, color.b, color.a);
-
-    ppxres = CreateTextureFromBitmap(pQueue, &bitmap, ppTexture, options);
-    if (Failed(ppxres)) {
-        return ppxres;
-    }
-
-    return ppx::SUCCESS;
-}
-
-// -------------------------------------------------------------------------------------------------
-
 struct SubImage
 {
     uint32_t width        = 0;


### PR DESCRIPTION
Currently, `Bitmap::Fill` takes a float array and converts to integer when needed. This is undefined behavior as the desired integer value may not be representable in floating point.

This PR changes `Bitmap::Fill` to take a templated type instead. The helper `CreateTexture1x1` is also changed to allow the caller to specify the data type (which will be used to determine the type of the underlying texture too).