### PR TITLE
Fix use of a sample's ImGui commands when it could be disabled

### DIFF
--- a/projects/20_camera_motion/main.cpp
+++ b/projects/20_camera_motion/main.cpp
@@ -745,8 +745,7 @@ void ProjApp::Render()
             }
 
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawCameraInfo(); });
-            DrawInstructions();
+            DrawDebugInfo([this]() { DrawCameraInfo(); DrawInstructions(); });
             DrawImGui(frame.cmd);
         }
         frame.cmd->EndRenderPass();


### PR DESCRIPTION
`DrawInstructions` uses ImGui commands without checking whether it's disabled. 

It should be called within the standard `DrawDebugInfo` that checks for that.