### PR TITLE
cli: add --screenshot-filepath option

### DIFF
--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -42,8 +42,7 @@ struct StandardOptions
     uint32_t            stats_frame_window = 300;
 
     int         screenshot_frame_number                  = -1;
-    std::string screenshot_out_dir                       = "";
-    std::string screenshot_filepath                      = "";
+    std::string screenshot_path                          = "";
     bool        operator==(const StandardOptions&) const = default;
 };
 
@@ -170,15 +169,14 @@ private:
 --gpu <index>                 Select the gpu with the given index. To determine the set of valid indices use --list-gpus.
 --resolution <Width>x<Height> Specify the main window resolution in pixels. Width and Height must be two positive integers greater or equal to 1.
 --frame-count <N>             Shutdown the application after successfully rendering N frames.
---stats-frame-window <N>      Calculate frame statistics over the last N frames only. 
+--stats-frame-window <N>      Calculate frame statistics over the last N frames only.
                               Set to 0 to use all frames since the beginning of the application.
---screenshot-frame-number <N> Take a screenshot of frame number N and save it in PPM format, in the directory specified by --screenshot-out-dir.
-                              The file name will be "screenshot_frameN".
---screenshot-out-dir <path>   The path to the directory where the screenshot will be saved in (see --screenshot-frame-number).
-                              Default: working directory. Ignored if `--screenshot-filepath` is set.
+--screenshot-frame-number <N> Take a screenshot of frame number N and save it in PPM format.
+                              See also `--screenshot-path`.
 --use-software-renderer       Use a software renderer instead of a hardware device, if available.
 --headless                    Run the sample without creating windows.
---screenshot-filepath         Save the screenshot to this specif path. If is ignored `--screenshot-out-dir` if also set.
+--screenshot-path             Save the screenshot to this path. If not specified, BigWheels will create a
+                              "screenshot_frameN" file in the current working directory.
 )";
 };
 } // namespace ppx

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -43,6 +43,7 @@ struct StandardOptions
 
     int         screenshot_frame_number                  = -1;
     std::string screenshot_out_dir                       = "";
+    std::string screenshot_filepath                      = "";
     bool        operator==(const StandardOptions&) const = default;
 };
 
@@ -174,8 +175,10 @@ private:
 --screenshot-frame-number <N> Take a screenshot of frame number N and save it in PPM format, in the directory specified by --screenshot-out-dir.
                               The file name will be "screenshot_frameN".
 --screenshot-out-dir <path>   The path to the directory where the screenshot will be saved in (see --screenshot-frame-number).
-                              Default: working directory.
+                              Default: working directory. Ignored if `--screenshot-filepath` is set.
 --use-software-renderer       Use a software renderer instead of a hardware device, if available.
+--headless                    Run the sample without creating windows.
+--screenshot-filepath         Save the screenshot to this specif path. If is ignored `--screenshot-out-dir` if also set.
 )";
 };
 } // namespace ppx

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1128,8 +1128,14 @@ void Application::TakeScreenshot()
     unsigned char* texels = nullptr;
     screenshotBuf->MapMemory(0, (void**)&texels);
 
-    std::string filename = "screenshot_frame" + std::to_string(mFrameCount) + ".ppm";
-    std::string filepath = (std::filesystem::path(mStandardOptions.screenshot_out_dir) / filename).string();
+    std::string filepath;
+    if (mStandardOptions.screenshot_filepath.empty()) {
+        std::string filename = "screenshot_frame" + std::to_string(mFrameCount) + ".ppm";
+        filepath             = (std::filesystem::path(mStandardOptions.screenshot_out_dir) / filename).string();
+    }
+    else {
+        filepath = std::filesystem::path(mStandardOptions.screenshot_filepath).string();
+    }
     PPX_CHECKED_CALL(ExportToPPM(filepath, swapchainImg->GetFormat(), texels, width, height, outPitch.rowPitch));
 
     screenshotBuf->UnmapMemory();

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1128,14 +1128,9 @@ void Application::TakeScreenshot()
     unsigned char* texels = nullptr;
     screenshotBuf->MapMemory(0, (void**)&texels);
 
-    std::string filepath;
-    if (mStandardOptions.screenshot_filepath.empty()) {
-        std::string filename = "screenshot_frame" + std::to_string(mFrameCount) + ".ppm";
-        filepath             = (std::filesystem::path(mStandardOptions.screenshot_out_dir) / filename).string();
-    }
-    else {
-        filepath = std::filesystem::path(mStandardOptions.screenshot_filepath).string();
-    }
+    std::string filepath = mStandardOptions.screenshot_path.empty()
+                               ? "screenshot_frame" + std::to_string(mFrameCount) + ".ppm"
+                               : mStandardOptions.screenshot_path;
     PPX_CHECKED_CALL(ExportToPPM(filepath, swapchainImg->GetFormat(), texels, width, height, outPitch.rowPitch));
 
     screenshotBuf->UnmapMemory();

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -127,17 +127,11 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             }
             mOpts.standardOptions.screenshot_frame_number = opt.GetValueOrDefault<int>(-1);
         }
-        else if (opt.GetName() == "screenshot-out-dir") {
+        else if (opt.GetName() == "screenshot-path") {
             if (!opt.HasValue()) {
-                return std::string("Command-line option --screenshot-out-dir requires a parameter");
+                return std::string("Command-line option --screenshot-path requires a parameter");
             }
-            mOpts.standardOptions.screenshot_out_dir = opt.GetValueOrDefault<std::string>("");
-        }
-        else if (opt.GetName() == "screenshot-filepath") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --screenshot-filepath requires a parameter");
-            }
-            mOpts.standardOptions.screenshot_filepath = opt.GetValueOrDefault<std::string>("");
+            mOpts.standardOptions.screenshot_path = opt.GetValueOrDefault<std::string>("");
         }
         else {
             // Non-standard option.
@@ -145,9 +139,6 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
         }
     }
 
-    if (!mOpts.standardOptions.screenshot_filepath.empty()) {
-        mOpts.standardOptions.screenshot_out_dir.clear();
-    }
     return std::nullopt;
 }
 

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -133,12 +133,21 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             }
             mOpts.standardOptions.screenshot_out_dir = opt.GetValueOrDefault<std::string>("");
         }
+        else if (opt.GetName() == "screenshot-filepath") {
+            if (!opt.HasValue()) {
+                return std::string("Command-line option --screenshot-filepath requires a parameter");
+            }
+            mOpts.standardOptions.screenshot_filepath = opt.GetValueOrDefault<std::string>("");
+        }
         else {
             // Non-standard option.
             mOpts.AddExtraOption(opt);
         }
     }
 
+    if (!mOpts.standardOptions.screenshot_filepath.empty()) {
+        mOpts.standardOptions.screenshot_out_dir.clear();
+    }
     return std::nullopt;
 }
 

--- a/src/test/command_line_parser_test.cpp
+++ b/src/test/command_line_parser_test.cpp
@@ -44,7 +44,7 @@ TEST(CommandLineParserTest, FirstArgumentIgnored)
 TEST(CommandLineParserTest, StandardOptionsSuccessfullyParsed)
 {
     CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--help", "--list-gpus", "--gpu", "5", "--resolution", "1920x1080", "--frame-count", "11", "--use-software-renderer", "--screenshot-frame-number", "321", "--screenshot-out-dir", "/path/to/screenshot/dir"};
+    const char*       args[] = {"/path/to/executable", "--help", "--list-gpus", "--gpu", "5", "--resolution", "1920x1080", "--frame-count", "11", "--use-software-renderer", "--screenshot-frame-number", "321", "--screenshot-path", "/path/to/screenshot/dir/filename"};
     EXPECT_FALSE(parser.Parse(14, args));
 
     StandardOptions wantOptions;
@@ -55,7 +55,7 @@ TEST(CommandLineParserTest, StandardOptionsSuccessfullyParsed)
     wantOptions.frame_count           = 11;
     wantOptions.use_software_renderer = true;
     wantOptions.screenshot_frame_number = 321;
-    wantOptions.screenshot_out_dir      = "/path/to/screenshot/dir";
+    wantOptions.screenshot_path         = "/path/to/screenshot/dir/filename";
 
     EXPECT_EQ(parser.GetOptions().GetStandardOptions(), wantOptions);
     EXPECT_EQ(parser.GetOptions().GetNumExtraOptions(), 0);


### PR DESCRIPTION
BigWheels allow setting the output directory, but generates the filename.
This limits our options as we cannot write to arbitrary files (memfd?) to integrate bigwheels into other applications.