### PR TITLE
Fixed shader array support in Vulkan

### DIFF
--- a/cmake/ShaderCompile.cmake
+++ b/cmake/ShaderCompile.cmake
@@ -109,7 +109,7 @@ function(internal_generate_rules_for_shader TARGET_NAME)
             SHADER_STAGE "${ARG_SHADER_STAGE}"
             OUTPUT_FORMAT "SPV_6_6"
             TARGET_FOLDER "${TARGET_NAME}"
-            COMPILER_FLAGS "-spirv" "-fspv-reflect" "-fvk-use-dx-layout" "-DPPX_VULKAN=1" "-T" "${ARG_SHADER_STAGE}_6_6" "-E" "${ARG_SHADER_STAGE}main")
+            COMPILER_FLAGS "-spirv" "-fspv-flatten-resource-arrays" "-fspv-reflect" "-fvk-use-dx-layout" "-DPPX_VULKAN=1" "-T" "${ARG_SHADER_STAGE}_6_6" "-E" "${ARG_SHADER_STAGE}main")
         add_dependencies("vk_${TARGET_NAME}" "vk_${TARGET_NAME}_${ARG_SHADER_STAGE}")
     endif ()
 endfunction()

--- a/src/ppx/grfx/vk/vk_descriptor.cpp
+++ b/src/ppx/grfx/vk/vk_descriptor.cpp
@@ -234,7 +234,7 @@ Result DescriptorSet::UpdateDescriptors(uint32_t writeCount, const grfx::WriteDe
         VkWriteDescriptorSet& vkWrite = mWriteStore[mWriteCount];
         vkWrite                       = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
         vkWrite.dstSet                = mDescriptorSet;
-        vkWrite.dstBinding            = srcWrite.binding;
+        vkWrite.dstBinding            = srcWrite.binding + srcWrite.arrayIndex;
         vkWrite.dstArrayElement       = 0;
         vkWrite.descriptorCount       = 1;
         vkWrite.descriptorType        = descriptorType;


### PR DESCRIPTION
In Vulkan, arrays are flattened at descriptor layout creation, i.e. they are turned into as many descriptors of size 1 as the size of the original array. However, flattened arrays were not fully supported in the rest of code. This PR addresses the issues with two following fixes.

* Added a compiler option to flatten arrays
* Took "arrayIndex" into account when updating the descriptor sets
