### PR TITLE
build: add deterministic build flavor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Options.
 # ------------------------------------------------------------------------------
 option(PPX_BUILD_PROJECTS "Build sample projets" ON)
+option(PPX_DETERMINISTIC "Makes BigWheels deterministic" OFF)
 
 # ------------------------------------------------------------------------------
 # Detect DXC presence. This is REQUIRED to compile DXIL and SPIR-V shaders.
@@ -155,6 +156,11 @@ else()
         -Wno-nullability-completeness \
         -Wno-deprecated-anon-enum-enum-conversion")
 endif()
+
+if (PPX_DETERMINISTIC)
+    message("Building deterministic flavor of ${PROJECT_NAME}")
+    add_definitions("-DDETERMINISTIC")
+endif ()
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1682,7 +1682,11 @@ Result Application::CreateShader(const std::filesystem::path& baseDir, const std
 
 float Application::GetElapsedSeconds() const
 {
+#if defined(DETERMINICTIC)
+    return static_cast<float>(mFrameCount * (1.f / 60.f));
+#else
     return static_cast<float>(mTimer.SecondsSinceStart());
+#endif
 }
 
 const KeyState& Application::GetKeyState(KeyCode code) const


### PR DESCRIPTION
Samples relies on time to compute animations. This means the actual output might vary slightly between runs, adding noise to any measure. This commits adds a build flavor to only allow deterministic behaviors.

Right now, only the timer seem to be a source of non-determinism. Replaced with `frame_count / 60.f` (60fps target) on such builds.