### PR TITLE
materials: add flags to select default aspect

### DIFF
--- a/projects/15_basic_material/main.cpp
+++ b/projects/15_basic_material/main.cpp
@@ -481,11 +481,11 @@ void ProjApp::Setup()
     }
 
     const auto& cl_options = GetExtraOptions();
-    mMaterialIndex         = cl_options.GetExtraOptionValueOrDefault<int32_t>("material-index", 0);
+    mMaterialIndex         = cl_options.GetExtraOptionValueOrDefault<uint32_t>("material-index", 0);
     PPX_ASSERT_MSG(mMaterialIndex < mMaterialNames.size(), "Material index out-of-range.");
-    mMeshIndex = cl_options.GetExtraOptionValueOrDefault<int32_t>("mesh-index", 0);
+    mMeshIndex = cl_options.GetExtraOptionValueOrDefault<uint32_t>("mesh-index", 0);
     PPX_ASSERT_MSG(mMeshIndex < mMeshes.size(), "Mesh index out-of-range.");
-    mShaderIndex = cl_options.GetExtraOptionValueOrDefault<int32_t>("shader-index", 0);
+    mShaderIndex = cl_options.GetExtraOptionValueOrDefault<uint32_t>("shader-index", 0);
     PPX_ASSERT_MSG(mShaderIndex < mShaderNames.size(), "Shader index out-of-range.");
 
     // Scene data


### PR DESCRIPTION
The sample can show some models using different shaders/materials. This commit adds command line options to define the default selection of shader/material/mesh to render.
This is useful to control the behavior of the app in headless mode.