### PR TITLE
Added a new algorithm to the OIT sample

### DIFF
--- a/assets/oit_demo/shaders/BufferBucketsCombine.hlsl
+++ b/assets/oit_demo/shaders/BufferBucketsCombine.hlsl
@@ -1,0 +1,85 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define IS_SHADER
+#include "Common.hlsli"
+#include "FullscreenVS.hlsli"
+
+RWTexture2D<uint>  CountTexture    : register(CUSTOM_UAV_0_REGISTER);
+RWTexture2D<uint2> FragmentTexture : register(CUSTOM_UAV_1_REGISTER);
+
+float4 UnpackColor(uint data)
+{
+    const float red   = float((data >> 24) & 0xFF) / 255.0f;
+    const float green = float((data >> 16) & 0xFF) / 255.0f;
+    const float blue  = float((data >> 8) & 0xFF) / 255.0f;
+    const float alpha = float(data & 0xFF) / 255.0f;
+    return float4(red, green, blue, alpha);
+}
+
+void MergeColor(inout float4 outColor, float4 fragmentColor)
+{
+    outColor.rgb = lerp(outColor.rgb, fragmentColor.rgb, fragmentColor.a);
+    outColor.a *= 1.0f - fragmentColor.a;
+}
+
+float4 psmain(VSOutput input) : SV_TARGET
+{
+    const uint2 bucketIndex   = (uint2)input.position.xy;
+    const int fragmentCount   = min(min((int)CountTexture[bucketIndex], g_Globals.bufferFragmentsMaxCount), BUFFER_BUCKET_SIZE_PER_PIXEL);
+    CountTexture[bucketIndex] = 0U; // Reset fragment count for the next frame
+
+    uint2 sortedEntries[BUFFER_BUCKET_SIZE_PER_PIXEL];
+
+    // Copy the fragments into local memory for sorting
+    {
+        uint2 fragmentIndex = bucketIndex;
+        fragmentIndex.y *= BUFFER_BUCKET_SIZE_PER_PIXEL;
+        for(int i = 0; i < fragmentCount; ++i)
+        {
+            sortedEntries[i] = FragmentTexture[fragmentIndex];
+            fragmentIndex.y += 1U;
+        }
+    }
+
+    if(fragmentCount <= 0)
+    {
+        return (float4)0.0f;
+    }
+
+    // Sort the fragments by depth (back to front)
+    {
+        for(int i = 0; i < fragmentCount - 1; ++i)
+        {
+            for(int j = i + 1; j < fragmentCount; ++j)
+            {
+                if(sortedEntries[j].y > sortedEntries[i].y)
+                {
+                    const uint2 tmp  = sortedEntries[i];
+                    sortedEntries[i] = sortedEntries[j];
+                    sortedEntries[j] = tmp;
+                }
+            }
+        }
+    }
+
+    // Merge the fragments to get the final color
+    float4 color = float4(0.0f, 0.0f, 0.0f, 1.0f);
+    for(int i = 0; i < fragmentCount; ++i)
+    {
+        MergeColor(color, UnpackColor(sortedEntries[i].x));
+    }
+    color.a = 1.0f - color.a;
+    return color;
+}

--- a/assets/oit_demo/shaders/BufferBucketsGather.hlsl
+++ b/assets/oit_demo/shaders/BufferBucketsGather.hlsl
@@ -1,0 +1,53 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define IS_SHADER
+#include "Common.hlsli"
+#include "TransparencyVS.hlsli"
+
+Texture2D          OpaqueDepthTexture : register(CUSTOM_TEXTURE_0_REGISTER);
+RWTexture2D<uint>  CountTexture       : register(CUSTOM_UAV_0_REGISTER);
+RWTexture2D<uint2> FragmentTexture    : register(CUSTOM_UAV_1_REGISTER);
+
+uint PackColor(float4 color)
+{
+    const uint4 ci = (uint4)(clamp(color, 0.0f, 1.0f) * 255.0f);
+    return (ci.r << 24) | (ci.g << 16) | (ci.b << 8) | ci.a;
+}
+
+void psmain(VSOutput input)
+{
+    // Test fragment against opaque depth
+    {
+        const float opaqueDepth = OpaqueDepthTexture.Load(int3(input.position.xy, 0)).r;
+        clip(input.position.z < opaqueDepth ? 1.0f : -1.0f);
+    }
+
+    // Find the next fragment index in the bucket
+    const uint2 bucketIndex = (uint2)input.position.xy;
+    uint nextBucketFragmentIndex = 0;
+    InterlockedAdd(CountTexture[bucketIndex], 1U, nextBucketFragmentIndex);
+
+    // Ignore the fragment if the bucket is already full
+    if(nextBucketFragmentIndex >= BUFFER_BUCKET_SIZE_PER_PIXEL)
+    {
+        clip(-1.0f);
+    }
+
+    // Add the fragment to the bucket
+    uint2 textureFragmentIndex = bucketIndex;
+    textureFragmentIndex.y *= BUFFER_BUCKET_SIZE_PER_PIXEL;
+    textureFragmentIndex.y += nextBucketFragmentIndex;
+    FragmentTexture[textureFragmentIndex] = uint2(PackColor(float4(input.color, g_Globals.meshOpacity)), asuint(input.position.z));
+}

--- a/assets/oit_demo/shaders/CMakeLists.txt
+++ b/assets/oit_demo/shaders/CMakeLists.txt
@@ -103,6 +103,18 @@ generate_rules_for_shader(
     INCLUDES ${FULLSCREEN_INCLUDE_FILES}
     STAGES "ps" "vs")
 
+generate_rules_for_shader(
+    "buffer_buckets_gather"
+    SOURCE "${PPX_DIR}/assets/oit_demo/shaders/BufferBucketsGather.hlsl"
+    INCLUDES ${TRANSPARENCY_INCLUDE_FILES}
+    STAGES "ps" "vs")
+
+generate_rules_for_shader(
+    "buffer_buckets_combine"
+    SOURCE "${PPX_DIR}/assets/oit_demo/shaders/BufferBucketsCombine.hlsl"
+    INCLUDES ${FULLSCREEN_INCLUDE_FILES}
+    STAGES "ps" "vs")
+
 ################################################################################
 
 generate_group_rule_for_shader(
@@ -118,6 +130,8 @@ generate_group_rule_for_shader(
     "depth_peeling_layer_first"
     "depth_peeling_layer_others"
     "depth_peeling_combine"
+    "buffer_buckets_gather"
+    "buffer_buckets_combine"
     "composite"
 )
 

--- a/assets/oit_demo/shaders/Common.hlsli
+++ b/assets/oit_demo/shaders/Common.hlsli
@@ -29,11 +29,17 @@
 #define CUSTOM_TEXTURE_5_REGISTER     SHADER_REGISTER(t, 8)
 #define CUSTOM_TEXTURE_6_REGISTER     SHADER_REGISTER(t, 9)
 #define CUSTOM_TEXTURE_7_REGISTER     SHADER_REGISTER(t, 10)
+#define CUSTOM_UAV_0_REGISTER         SHADER_REGISTER(u, 11)
+#define CUSTOM_UAV_1_REGISTER         SHADER_REGISTER(u, 12)
+#define CUSTOM_UAV_2_REGISTER         SHADER_REGISTER(u, 13)
+#define CUSTOM_UAV_3_REGISTER         SHADER_REGISTER(u, 14)
 
 #define EPSILON 0.0001f
 
 #define DEPTH_PEELING_LAYERS_COUNT          8
 #define DEPTH_PEELING_DEPTH_TEXTURES_COUNT  2
+
+#define BUFFER_BUCKET_SIZE_PER_PIXEL        8
 
 struct ShaderGlobals
 {
@@ -41,13 +47,13 @@ struct ShaderGlobals
     float4   backgroundColor;
     float4x4 meshMVP;
     float    meshOpacity;
-    float    meshParametersUnused0;
-    float    meshParametersUnused1;
-    float    meshParametersUnused2;
+    float    _floatUnused0;
+    float    _floatUnused1;
+    float    _floatUnused2;
     int      depthPeelingFrontLayerIndex;
     int      depthPeelingBackLayerIndex;
-    int      depthPeelingParametersUnused0;
-    int      depthPeelingParametersUnused1;
+    int      bufferFragmentsMaxCount;
+    int      _intUnused0;
 };
 
 #if defined(IS_SHADER)

--- a/include/ppx/grfx/dx12/dx12_device.h
+++ b/include/ppx/grfx/dx12/dx12_device.h
@@ -64,6 +64,7 @@ public:
     virtual bool PipelineStatsAvailable() const override;
     virtual bool DynamicRenderingSupported() const override;
     virtual bool IndependentBlendingSupported() const override;
+    virtual bool FragmentStoresAndAtomicsSupported() const override;
 
 protected:
     virtual Result AllocateObject(grfx::Buffer** ppObject) override;

--- a/include/ppx/grfx/grfx_device.h
+++ b/include/ppx/grfx/grfx_device.h
@@ -184,6 +184,7 @@ public:
     virtual bool PipelineStatsAvailable() const    = 0;
     virtual bool DynamicRenderingSupported() const = 0;
     virtual bool IndependentBlendingSupported() const = 0;
+    virtual bool FragmentStoresAndAtomicsSupported() const = 0;
 
 protected:
     virtual Result Create(const grfx::DeviceCreateInfo* pCreateInfo) override;

--- a/include/ppx/grfx/vk/vk_device.h
+++ b/include/ppx/grfx/vk/vk_device.h
@@ -43,6 +43,7 @@ public:
     virtual bool PipelineStatsAvailable() const override;
     virtual bool DynamicRenderingSupported() const override;
     virtual bool IndependentBlendingSupported() const override;
+    virtual bool FragmentStoresAndAtomicsSupported() const override;
 
     void ResetQueryPoolEXT(
         VkQueryPool queryPool,

--- a/projects/oit_demo/Buffer.cpp
+++ b/projects/oit_demo/Buffer.cpp
@@ -1,0 +1,294 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "OITDemoApplication.h"
+
+void OITDemoApp::SetupBuffer()
+{
+    // Count texture
+    {
+        grfx::TextureCreateInfo createInfo         = {};
+        createInfo.imageType                       = grfx::IMAGE_TYPE_2D;
+        createInfo.width                           = mTransparencyTexture->GetWidth();
+        createInfo.height                          = mTransparencyTexture->GetHeight();
+        createInfo.depth                           = 1;
+        createInfo.imageFormat                     = grfx::FORMAT_R32_UINT;
+        createInfo.sampleCount                     = grfx::SAMPLE_COUNT_1;
+        createInfo.mipLevelCount                   = 1;
+        createInfo.arrayLayerCount                 = 1;
+        createInfo.usageFlags.bits.colorAttachment = true;
+        createInfo.usageFlags.bits.storage         = true;
+        createInfo.memoryUsage                     = grfx::MEMORY_USAGE_GPU_ONLY;
+        createInfo.initialState                    = grfx::RESOURCE_STATE_SHADER_RESOURCE;
+
+        PPX_CHECKED_CALL(GetDevice()->CreateTexture(&createInfo, &mBuffer.countTexture));
+    }
+
+    // Fragment texture
+    {
+        grfx::TextureCreateInfo createInfo = {};
+        createInfo.imageType               = grfx::IMAGE_TYPE_2D;
+        createInfo.width                   = mBuffer.countTexture->GetWidth();
+        createInfo.height                  = mBuffer.countTexture->GetHeight() * BUFFER_BUCKET_SIZE_PER_PIXEL;
+        createInfo.depth                   = 1;
+        createInfo.imageFormat             = grfx::FORMAT_R32G32_UINT;
+        createInfo.sampleCount             = grfx::SAMPLE_COUNT_1;
+        createInfo.mipLevelCount           = 1;
+        createInfo.arrayLayerCount         = 1;
+        createInfo.usageFlags.bits.storage = true;
+        createInfo.memoryUsage             = grfx::MEMORY_USAGE_GPU_ONLY;
+        createInfo.initialState            = grfx::RESOURCE_STATE_SHADER_RESOURCE;
+
+        PPX_CHECKED_CALL(GetDevice()->CreateTexture(&createInfo, &mBuffer.fragmentTexture));
+    }
+
+    // Clear pass
+    {
+        grfx::DrawPassCreateInfo2 createInfo  = {};
+        createInfo.width                      = mBuffer.countTexture->GetWidth();
+        createInfo.height                     = mBuffer.countTexture->GetHeight();
+        createInfo.renderTargetCount          = 1;
+        createInfo.pRenderTargetImages[0]     = mBuffer.countTexture->GetImage();
+        createInfo.pDepthStencilImage         = nullptr;
+        createInfo.renderTargetClearValues[0] = {0, 0, 0, 0};
+        PPX_CHECKED_CALL(GetDevice()->CreateDrawPass(&createInfo, &mBuffer.clearPass));
+    }
+
+    // Gather pass
+    {
+        grfx::DrawPassCreateInfo2 createInfo  = {};
+        createInfo.width                      = mBuffer.countTexture->GetWidth();
+        createInfo.height                     = mBuffer.countTexture->GetHeight();
+        createInfo.renderTargetCount          = 0;
+        createInfo.pDepthStencilImage         = nullptr;
+        createInfo.renderTargetClearValues[0] = {0, 0, 0, 0};
+        PPX_CHECKED_CALL(GetDevice()->CreateDrawPass(&createInfo, &mBuffer.gatherPass));
+    }
+
+    ////////////////////////////////////////
+    // Gather
+    ////////////////////////////////////////
+
+    // Descriptor
+    {
+        grfx::DescriptorSetLayoutCreateInfo layoutCreateInfo = {};
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{SHADER_GLOBALS_REGISTER, grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_TEXTURE_0_REGISTER, grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_0_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_1_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mBuffer.gatherDescriptorSetLayout));
+
+        PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mBuffer.gatherDescriptorSetLayout, &mBuffer.gatherDescriptorSet));
+
+        grfx::WriteDescriptor writes[4] = {};
+
+        writes[0].binding      = SHADER_GLOBALS_REGISTER;
+        writes[0].type         = grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        writes[0].bufferOffset = 0;
+        writes[0].bufferRange  = PPX_WHOLE_SIZE;
+        writes[0].pBuffer      = mShaderGlobalsBuffer;
+
+        writes[1].binding    = CUSTOM_TEXTURE_0_REGISTER;
+        writes[1].arrayIndex = 0;
+        writes[1].type       = grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+        writes[1].pImageView = mOpaquePass->GetDepthStencilTexture()->GetSampledImageView();
+
+        writes[2].binding    = CUSTOM_UAV_0_REGISTER;
+        writes[2].arrayIndex = 0;
+        writes[2].type       = grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        writes[2].pImageView = mBuffer.countTexture->GetStorageImageView();
+
+        writes[3].binding    = CUSTOM_UAV_1_REGISTER;
+        writes[3].arrayIndex = 0;
+        writes[3].type       = grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        writes[3].pImageView = mBuffer.fragmentTexture->GetStorageImageView();
+
+        PPX_CHECKED_CALL(mBuffer.gatherDescriptorSet->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
+    }
+
+    // Pipeline
+    {
+        grfx::PipelineInterfaceCreateInfo piCreateInfo = {};
+        piCreateInfo.setCount                          = 1;
+        piCreateInfo.sets[0].set                       = 0;
+        piCreateInfo.sets[0].pLayout                   = mBuffer.gatherDescriptorSetLayout;
+        PPX_CHECKED_CALL(GetDevice()->CreatePipelineInterface(&piCreateInfo, &mBuffer.gatherPipelineInterface));
+
+        grfx::ShaderModulePtr VS, PS;
+        PPX_CHECKED_CALL(CreateShader("oit_demo/shaders", "BufferBucketsGather.vs", &VS));
+        PPX_CHECKED_CALL(CreateShader("oit_demo/shaders", "BufferBucketsGather.ps", &PS));
+
+        grfx::GraphicsPipelineCreateInfo2 gpCreateInfo = {};
+        gpCreateInfo.VS                                = {VS, "vsmain"};
+        gpCreateInfo.PS                                = {PS, "psmain"};
+        gpCreateInfo.vertexInputState.bindingCount     = 1;
+        gpCreateInfo.vertexInputState.bindings[0]      = GetTransparentMesh()->GetDerivedVertexBindings()[0];
+        gpCreateInfo.topology                          = grfx::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        gpCreateInfo.polygonMode                       = grfx::POLYGON_MODE_FILL;
+        gpCreateInfo.cullMode                          = grfx::CULL_MODE_NONE;
+        gpCreateInfo.frontFace                         = grfx::FRONT_FACE_CCW;
+        gpCreateInfo.depthReadEnable                   = false;
+        gpCreateInfo.depthWriteEnable                  = false;
+        gpCreateInfo.blendModes[0]                     = grfx::BLEND_MODE_NONE;
+        gpCreateInfo.outputState.renderTargetCount     = 0;
+        gpCreateInfo.pPipelineInterface                = mBuffer.gatherPipelineInterface;
+        PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mBuffer.gatherPipeline));
+
+        GetDevice()->DestroyShaderModule(VS);
+        GetDevice()->DestroyShaderModule(PS);
+    }
+
+    ////////////////////////////////////////
+    // Combine
+    ////////////////////////////////////////
+
+    // Descriptor
+    {
+        grfx::DescriptorSetLayoutCreateInfo layoutCreateInfo = {};
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{SHADER_GLOBALS_REGISTER, grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_0_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_1_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mBuffer.combineDescriptorSetLayout));
+
+        PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mBuffer.combineDescriptorSetLayout, &mBuffer.combineDescriptorSet));
+
+        grfx::WriteDescriptor writes[3] = {};
+
+        writes[0].binding      = SHADER_GLOBALS_REGISTER;
+        writes[0].type         = grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        writes[0].bufferOffset = 0;
+        writes[0].bufferRange  = PPX_WHOLE_SIZE;
+        writes[0].pBuffer      = mShaderGlobalsBuffer;
+
+        writes[1].binding    = CUSTOM_UAV_0_REGISTER;
+        writes[1].arrayIndex = 0;
+        writes[1].type       = grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        writes[1].pImageView = mBuffer.countTexture->GetStorageImageView();
+
+        writes[2].binding    = CUSTOM_UAV_1_REGISTER;
+        writes[2].arrayIndex = 0;
+        writes[2].type       = grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        writes[2].pImageView = mBuffer.fragmentTexture->GetStorageImageView();
+
+        PPX_CHECKED_CALL(mBuffer.combineDescriptorSet->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
+    }
+
+    // Pipeline
+    {
+        grfx::PipelineInterfaceCreateInfo piCreateInfo = {};
+        piCreateInfo.setCount                          = 1;
+        piCreateInfo.sets[0].set                       = 0;
+        piCreateInfo.sets[0].pLayout                   = mBuffer.combineDescriptorSetLayout;
+        PPX_CHECKED_CALL(GetDevice()->CreatePipelineInterface(&piCreateInfo, &mBuffer.combinePipelineInterface));
+
+        grfx::ShaderModulePtr VS, PS;
+        PPX_CHECKED_CALL(CreateShader("oit_demo/shaders", "BufferBucketsCombine.vs", &VS));
+        PPX_CHECKED_CALL(CreateShader("oit_demo/shaders", "BufferBucketsCombine.ps", &PS));
+
+        grfx::GraphicsPipelineCreateInfo2 gpCreateInfo  = {};
+        gpCreateInfo.VS                                 = {VS, "vsmain"};
+        gpCreateInfo.PS                                 = {PS, "psmain"};
+        gpCreateInfo.vertexInputState.bindingCount      = 0;
+        gpCreateInfo.topology                           = grfx::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        gpCreateInfo.polygonMode                        = grfx::POLYGON_MODE_FILL;
+        gpCreateInfo.cullMode                           = grfx::CULL_MODE_BACK;
+        gpCreateInfo.frontFace                          = grfx::FRONT_FACE_CCW;
+        gpCreateInfo.depthReadEnable                    = false;
+        gpCreateInfo.depthWriteEnable                   = false;
+        gpCreateInfo.blendModes[0]                      = grfx::BLEND_MODE_NONE;
+        gpCreateInfo.outputState.renderTargetCount      = 1;
+        gpCreateInfo.outputState.renderTargetFormats[0] = mTransparencyPass->GetRenderTargetTexture(0)->GetImageFormat();
+        gpCreateInfo.outputState.depthStencilFormat     = mTransparencyPass->GetDepthStencilTexture()->GetImageFormat();
+        gpCreateInfo.pPipelineInterface                 = mBuffer.combinePipelineInterface;
+        PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mBuffer.combinePipeline));
+
+        GetDevice()->DestroyShaderModule(VS);
+        GetDevice()->DestroyShaderModule(PS);
+    }
+}
+
+void OITDemoApp::RecordBuffer()
+{
+    static bool sTextureNeedClear = true;
+    if (sTextureNeedClear) {
+        mCommandBuffer->TransitionImageLayout(
+            mBuffer.clearPass,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_RENDER_TARGET,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE);
+        mCommandBuffer->BeginRenderPass(mBuffer.clearPass, grfx::DRAW_PASS_CLEAR_FLAG_CLEAR_ALL);
+
+        mCommandBuffer->SetScissors(mBuffer.clearPass->GetScissor());
+        mCommandBuffer->SetViewports(mBuffer.clearPass->GetViewport());
+
+        mCommandBuffer->EndRenderPass();
+        mCommandBuffer->TransitionImageLayout(
+            mBuffer.clearPass,
+            grfx::RESOURCE_STATE_RENDER_TARGET,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE);
+
+        sTextureNeedClear = false;
+    }
+
+    {
+        mCommandBuffer->TransitionImageLayout(mBuffer.countTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
+        mCommandBuffer->TransitionImageLayout(mBuffer.fragmentTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
+        mCommandBuffer->BeginRenderPass(mBuffer.gatherPass, 0);
+
+        mCommandBuffer->SetScissors(mBuffer.gatherPass->GetScissor());
+        mCommandBuffer->SetViewports(mBuffer.gatherPass->GetViewport());
+
+        mCommandBuffer->BindGraphicsDescriptorSets(mBuffer.gatherPipelineInterface, 1, &mBuffer.gatherDescriptorSet);
+        mCommandBuffer->BindGraphicsPipeline(mBuffer.gatherPipeline);
+        mCommandBuffer->BindIndexBuffer(GetTransparentMesh());
+        mCommandBuffer->BindVertexBuffers(GetTransparentMesh());
+        mCommandBuffer->DrawIndexed(GetTransparentMesh()->GetIndexCount());
+
+        mCommandBuffer->EndRenderPass();
+        mCommandBuffer->TransitionImageLayout(mBuffer.countTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+        mCommandBuffer->TransitionImageLayout(mBuffer.fragmentTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+    }
+
+    {
+        mCommandBuffer->TransitionImageLayout(mBuffer.countTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
+        mCommandBuffer->TransitionImageLayout(mBuffer.fragmentTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
+        mCommandBuffer->TransitionImageLayout(
+            mTransparencyPass,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_RENDER_TARGET,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_DEPTH_STENCIL_WRITE);
+        mCommandBuffer->BeginRenderPass(mTransparencyPass, grfx::DRAW_PASS_CLEAR_FLAG_CLEAR_RENDER_TARGETS);
+
+        mCommandBuffer->SetScissors(mTransparencyPass->GetScissor());
+        mCommandBuffer->SetViewports(mTransparencyPass->GetViewport());
+
+        mCommandBuffer->BindGraphicsDescriptorSets(mBuffer.combinePipelineInterface, 1, &mBuffer.combineDescriptorSet);
+        mCommandBuffer->BindGraphicsPipeline(mBuffer.combinePipeline);
+        mCommandBuffer->Draw(3);
+
+        mCommandBuffer->EndRenderPass();
+        mCommandBuffer->TransitionImageLayout(
+            mTransparencyPass,
+            grfx::RESOURCE_STATE_RENDER_TARGET,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_DEPTH_STENCIL_WRITE,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE);
+        mCommandBuffer->TransitionImageLayout(mBuffer.countTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+        mCommandBuffer->TransitionImageLayout(mBuffer.fragmentTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+    }
+}

--- a/projects/oit_demo/CMakeLists.txt
+++ b/projects/oit_demo/CMakeLists.txt
@@ -24,6 +24,7 @@ add_samples_for_all_apis(
         "WeightedSum.cpp"
         "WeightedAverage.cpp"
         "DepthPeeling.cpp"
+        "Buffer.cpp"
         "main.cpp"
     SHADER_DEPENDENCIES "shader_oit_demo"
     ADDITIONAL_INCLUDE_DIRECTORIES "${PPX_DIR}/assets/oit_demo"

--- a/projects/oit_demo/DepthPeeling.cpp
+++ b/projects/oit_demo/DepthPeeling.cpp
@@ -20,8 +20,8 @@ void OITDemoApp::SetupDepthPeeling()
     {
         grfx::TextureCreateInfo createInfo         = {};
         createInfo.imageType                       = grfx::IMAGE_TYPE_2D;
-        createInfo.width                           = GetSwapchain()->GetWidth();
-        createInfo.height                          = GetSwapchain()->GetHeight();
+        createInfo.width                           = mTransparencyTexture->GetWidth();
+        createInfo.height                          = mTransparencyTexture->GetHeight();
         createInfo.depth                           = 1;
         createInfo.imageFormat                     = grfx::FORMAT_B8G8R8A8_UNORM;
         createInfo.sampleCount                     = grfx::SAMPLE_COUNT_1;
@@ -114,7 +114,7 @@ void OITDemoApp::SetupDepthPeeling()
             writes[3].type       = grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE;
             writes[3].pImageView = mDepthPeeling.depthTextures[(i + 1) % DEPTH_PEELING_DEPTH_TEXTURES_COUNT]->GetSampledImageView();
 
-            PPX_CHECKED_CALL(mDepthPeeling.layerDescriptorSets[i]->UpdateDescriptors(4, writes));
+            PPX_CHECKED_CALL(mDepthPeeling.layerDescriptorSets[i]->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
         }
     }
 
@@ -174,7 +174,7 @@ void OITDemoApp::SetupDepthPeeling()
 
         PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mDepthPeeling.combineDescriptorSetLayout, &mDepthPeeling.combineDescriptorSet));
 
-        grfx::WriteDescriptor writes[10] = {};
+        grfx::WriteDescriptor writes[2 + DEPTH_PEELING_LAYERS_COUNT] = {};
 
         writes[0].binding      = SHADER_GLOBALS_REGISTER;
         writes[0].type         = grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -193,7 +193,7 @@ void OITDemoApp::SetupDepthPeeling()
             writes[2 + i].pImageView = mDepthPeeling.layerTextures[i]->GetSampledImageView();
         }
 
-        PPX_CHECKED_CALL(mDepthPeeling.combineDescriptorSet->UpdateDescriptors(10, writes));
+        PPX_CHECKED_CALL(mDepthPeeling.combineDescriptorSet->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
     }
 
     // Pipeline

--- a/projects/oit_demo/DepthPeeling.cpp
+++ b/projects/oit_demo/DepthPeeling.cpp
@@ -92,7 +92,7 @@ void OITDemoApp::SetupDepthPeeling()
         for (uint32_t i = 0; i < DEPTH_PEELING_DEPTH_TEXTURES_COUNT; ++i) {
             PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mDepthPeeling.layerDescriptorSetLayout, &mDepthPeeling.layerDescriptorSets[i]));
 
-            grfx::WriteDescriptor writes[4] = {};
+            std::array<grfx::WriteDescriptor, 4> writes = {};
 
             writes[0].binding      = SHADER_GLOBALS_REGISTER;
             writes[0].type         = grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -114,7 +114,7 @@ void OITDemoApp::SetupDepthPeeling()
             writes[3].type       = grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE;
             writes[3].pImageView = mDepthPeeling.depthTextures[(i + 1) % DEPTH_PEELING_DEPTH_TEXTURES_COUNT]->GetSampledImageView();
 
-            PPX_CHECKED_CALL(mDepthPeeling.layerDescriptorSets[i]->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
+            PPX_CHECKED_CALL(mDepthPeeling.layerDescriptorSets[i]->UpdateDescriptors(static_cast<uint32_t>(writes.size()), writes.data()));
         }
     }
 
@@ -174,7 +174,7 @@ void OITDemoApp::SetupDepthPeeling()
 
         PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mDepthPeeling.combineDescriptorSetLayout, &mDepthPeeling.combineDescriptorSet));
 
-        grfx::WriteDescriptor writes[2 + DEPTH_PEELING_LAYERS_COUNT] = {};
+        std::array<grfx::WriteDescriptor, 2 + DEPTH_PEELING_LAYERS_COUNT> writes = {};
 
         writes[0].binding      = SHADER_GLOBALS_REGISTER;
         writes[0].type         = grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -193,7 +193,7 @@ void OITDemoApp::SetupDepthPeeling()
             writes[2 + i].pImageView = mDepthPeeling.layerTextures[i]->GetSampledImageView();
         }
 
-        PPX_CHECKED_CALL(mDepthPeeling.combineDescriptorSet->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
+        PPX_CHECKED_CALL(mDepthPeeling.combineDescriptorSet->UpdateDescriptors(static_cast<uint32_t>(writes.size()), writes.data()));
     }
 
     // Pipeline

--- a/projects/oit_demo/OITDemoApplication.cpp
+++ b/projects/oit_demo/OITDemoApplication.cpp
@@ -239,7 +239,7 @@ void OITDemoApp::SetupCommon()
         PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mCompositeDescriptorSetLayout));
         PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mCompositeDescriptorSetLayout, &mCompositeDescriptorSet));
 
-        grfx::WriteDescriptor writes[3] = {};
+        std::array<grfx::WriteDescriptor, 3> writes = {};
 
         writes[0].binding  = CUSTOM_SAMPLER_0_REGISTER;
         writes[0].type     = grfx::DESCRIPTOR_TYPE_SAMPLER;
@@ -255,7 +255,7 @@ void OITDemoApp::SetupCommon()
         writes[2].type       = grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE;
         writes[2].pImageView = mTransparencyTexture->GetSampledImageView();
 
-        PPX_CHECKED_CALL(mCompositeDescriptorSet->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
+        PPX_CHECKED_CALL(mCompositeDescriptorSet->UpdateDescriptors(static_cast<uint32_t>(writes.size()), writes.data()));
     }
 
     // Pipeline

--- a/projects/oit_demo/OITDemoApplication.cpp
+++ b/projects/oit_demo/OITDemoApplication.cpp
@@ -317,7 +317,7 @@ void OITDemoApp::FillSupportedAlgorithmData()
     }
     addSupportedAlgorithm("Depth peeling", ALGORITHM_DEPTH_PEELING);
     if (GetDevice()->FragmentStoresAndAtomicsSupported()) {
-        addSupportedAlgorithm("Buffer", "Buffer");
+        addSupportedAlgorithm("Buffer", ALGORITHM_BUFFER);
     }
 }
 

--- a/projects/oit_demo/OITDemoApplication.h
+++ b/projects/oit_demo/OITDemoApplication.h
@@ -250,5 +250,7 @@ private:
         grfx::DescriptorSetPtr       combineDescriptorSet;
         grfx::PipelineInterfacePtr   combinePipelineInterface;
         grfx::GraphicsPipelinePtr    combinePipeline;
+
+        bool textureNeedClear;
     } mBuffer;
 };

--- a/projects/oit_demo/OITDemoApplication.h
+++ b/projects/oit_demo/OITDemoApplication.h
@@ -33,6 +33,7 @@ private:
         ALGORITHM_WEIGHTED_SUM,
         ALGORITHM_WEIGHTED_AVERAGE,
         ALGORITHM_DEPTH_PEELING,
+        ALGORITHM_BUFFER,
         ALGORITHMS_COUNT,
     };
 
@@ -94,6 +95,11 @@ private:
             int32_t startLayer;
             int32_t layersCount;
         } depthPeeling;
+
+        struct
+        {
+            int32_t fragmentsMaxCount;
+        } buffer;
     };
 
     std::vector<const char*> mSupportedAlgorithmNames;
@@ -105,6 +111,7 @@ private:
     void SetupWeightedSum();
     void SetupWeightedAverage();
     void SetupDepthPeeling();
+    void SetupBuffer();
 
     void FillSupportedAlgorithmData();
     void ParseCommandLineOptions();
@@ -120,6 +127,7 @@ private:
     void RecordWeightedSum();
     void RecordWeightedAverage();
     void RecordDepthPeeling();
+    void RecordBuffer();
     void RecordTransparency();
     void RecordComposite(grfx::RenderPassPtr renderPass);
 
@@ -225,4 +233,22 @@ private:
         grfx::PipelineInterfacePtr   combinePipelineInterface;
         grfx::GraphicsPipelinePtr    combinePipeline;
     } mDepthPeeling;
+
+    struct
+    {
+        grfx::TexturePtr  countTexture;
+        grfx::TexturePtr  fragmentTexture;
+        grfx::DrawPassPtr clearPass;
+        grfx::DrawPassPtr gatherPass;
+
+        grfx::DescriptorSetLayoutPtr gatherDescriptorSetLayout;
+        grfx::DescriptorSetPtr       gatherDescriptorSet;
+        grfx::PipelineInterfacePtr   gatherPipelineInterface;
+        grfx::GraphicsPipelinePtr    gatherPipeline;
+
+        grfx::DescriptorSetLayoutPtr combineDescriptorSetLayout;
+        grfx::DescriptorSetPtr       combineDescriptorSet;
+        grfx::PipelineInterfacePtr   combinePipelineInterface;
+        grfx::GraphicsPipelinePtr    combinePipeline;
+    } mBuffer;
 };

--- a/projects/oit_demo/OITDemoApplication.h
+++ b/projects/oit_demo/OITDemoApplication.h
@@ -251,6 +251,6 @@ private:
         grfx::PipelineInterfacePtr   combinePipelineInterface;
         grfx::GraphicsPipelinePtr    combinePipeline;
 
-        bool textureNeedClear;
+        bool countTextureNeedClear;
     } mBuffer;
 };

--- a/projects/oit_demo/README.md
+++ b/projects/oit_demo/README.md
@@ -48,6 +48,7 @@ The following algorithms are currently supported.
 |1     |Weighted sum                        |Approximate       |[MK2007], [BM2008]
 |2     |Weighted average                    |Approximate       |[BM2008]
 |3     |Depth peeling                       |Exact             |[EC2001], [BM2008]
+|4     |Buffer                              |Exact             |[CK2014]
 
 ## Meshes
 
@@ -64,22 +65,25 @@ The following meshes are available as transparent objects.
 
 The following command line options are available.
 
-|Option                |Description                                   |Algorithm           |Value
-|:---                  |:---                                          |:---                |:---
-|algorithm <ID>        |Select the OIT algorithm                      |All                 |Algorithm ID (see [Algorithms](algorithms))
-|bg_display            |Turns the background on/off                   |All                 |True or false
-|bg_red                |Set the red channel of the background color   |All                 |0.0 to 1.0
-|bg_green              |Set the green channel of the background color |All                 |0.0 to 1.0
-|bg_blue               |Set the blue channel of the background color  |All                 |0.0 to 1.0
-|mo_mesh <ID>          |Select the mesh of the transparent model      |All                 |Mesh ID (see [Meshes](meshes))
-|mo_opacity <float>    |Set the opacity of the model                  |All                 |0.0 to 1.0
-|mo_scale <float>      |Set the scale of the model                    |All                 |1.0 to 5.0
-|uo_face_mode <int>    |Set the face mode                             |Unsorted over       |0 = all faces, 1 = back + front, 2 = back, 3 = front
-|wa_type <int>         |Select the average type                       |Weighted average    |0 = fragment count, 1 = exact coverage
-|dp_start_layer <int>  |Set the starting layer to draw                |Depth peeling       |0 to 7
-|dp_layers_count <int> |Set the number of layers to draw              |Depth peeling       |1 to 8
+|Option                  |Description                                   |Algorithm           |Value
+|:---                    |:---                                          |:---                |:---
+|algorithm <ID>          |Select the OIT algorithm                      |All                 |Algorithm ID (see [Algorithms](algorithms))
+|bg_display              |Turns the background on/off                   |All                 |True or false
+|bg_red                  |Set the red channel of the background color   |All                 |0.0 to 1.0
+|bg_green                |Set the green channel of the background color |All                 |0.0 to 1.0
+|bg_blue                 |Set the blue channel of the background color  |All                 |0.0 to 1.0
+|mo_mesh <ID>            |Select the mesh of the transparent model      |All                 |Mesh ID (see [Meshes](meshes))
+|mo_opacity <float>      |Set the opacity of the model                  |All                 |0.0 to 1.0
+|mo_scale <float>        |Set the scale of the model                    |All                 |1.0 to 5.0
+|uo_face_mode <int>      |Set the face mode                             |Unsorted over       |0 = all faces, 1 = back + front, 2 = back, 3 = front
+|wa_type <int>           |Select the average type                       |Weighted average    |0 = fragment count, 1 = exact coverage
+|dp_start_layer <int>    |Set the starting layer to draw                |Depth peeling       |0 to 7
+|dp_layers_count <int>   |Set the number of layers to draw              |Depth peeling       |1 to 8
+|bu_fragments_max_count  |Set the maximum number of fragment per pixel  |Buffer              |1 to 8
 
 ## References
+
+[CK2014] Christoph Kubisch. Order Independent Transparency In OpenGL 4.x. 2014.
 
 [MB2013] Morgan McGuire and Louis Bavoil. Weighted Blended Order-Independent Transparency. 2013.
 

--- a/projects/oit_demo/WeightedAverage.cpp
+++ b/projects/oit_demo/WeightedAverage.cpp
@@ -24,8 +24,8 @@ void OITDemoApp::SetupWeightedAverage()
     {
         grfx::TextureCreateInfo createInfo         = {};
         createInfo.imageType                       = grfx::IMAGE_TYPE_2D;
-        createInfo.width                           = GetSwapchain()->GetWidth();
-        createInfo.height                          = GetSwapchain()->GetHeight();
+        createInfo.width                           = mTransparencyTexture->GetWidth();
+        createInfo.height                          = mTransparencyTexture->GetHeight();
         createInfo.depth                           = 1;
         createInfo.sampleCount                     = grfx::SAMPLE_COUNT_1;
         createInfo.mipLevelCount                   = 1;
@@ -182,7 +182,7 @@ void OITDemoApp::SetupWeightedAverage()
         writes[2].type       = grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE;
         writes[2].pImageView = mWeightedAverage.extraTexture->GetSampledImageView();
 
-        PPX_CHECKED_CALL(mWeightedAverage.combineDescriptorSet->UpdateDescriptors(3, writes));
+        PPX_CHECKED_CALL(mWeightedAverage.combineDescriptorSet->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
     }
 
     // Pipeline
@@ -262,8 +262,8 @@ void OITDemoApp::RecordWeightedAverage()
             grfx::RESOURCE_STATE_DEPTH_STENCIL_WRITE);
         mCommandBuffer->BeginRenderPass(gatherPass, grfx::DRAW_PASS_CLEAR_FLAG_CLEAR_RENDER_TARGETS);
 
-        mCommandBuffer->SetScissors(mTransparencyPass->GetScissor());
-        mCommandBuffer->SetViewports(mTransparencyPass->GetViewport());
+        mCommandBuffer->SetScissors(gatherPass->GetScissor());
+        mCommandBuffer->SetViewports(gatherPass->GetViewport());
 
         mCommandBuffer->BindGraphicsDescriptorSets(mWeightedAverage.gatherPipelineInterface, 1, &mWeightedAverage.gatherDescriptorSet);
         mCommandBuffer->BindGraphicsPipeline(gatherPipeline);

--- a/projects/oit_demo/WeightedAverage.cpp
+++ b/projects/oit_demo/WeightedAverage.cpp
@@ -166,7 +166,7 @@ void OITDemoApp::SetupWeightedAverage()
 
         PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mWeightedAverage.combineDescriptorSetLayout, &mWeightedAverage.combineDescriptorSet));
 
-        grfx::WriteDescriptor writes[3] = {};
+        std::array<grfx::WriteDescriptor, 3> writes = {};
 
         writes[0].binding  = CUSTOM_SAMPLER_0_REGISTER;
         writes[0].type     = grfx::DESCRIPTOR_TYPE_SAMPLER;
@@ -182,7 +182,7 @@ void OITDemoApp::SetupWeightedAverage()
         writes[2].type       = grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE;
         writes[2].pImageView = mWeightedAverage.extraTexture->GetSampledImageView();
 
-        PPX_CHECKED_CALL(mWeightedAverage.combineDescriptorSet->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
+        PPX_CHECKED_CALL(mWeightedAverage.combineDescriptorSet->UpdateDescriptors(static_cast<uint32_t>(writes.size()), writes.data()));
     }
 
     // Pipeline

--- a/src/ppx/grfx/dx12/dx12_device.cpp
+++ b/src/ppx/grfx/dx12/dx12_device.cpp
@@ -693,6 +693,11 @@ bool Device::IndependentBlendingSupported() const
     return true;
 }
 
+bool Device::FragmentStoresAndAtomicsSupported() const
+{
+    return true;
+}
+
 } // namespace dx12
 } // namespace grfx
 } // namespace ppx

--- a/src/ppx/grfx/grfx_draw_pass.cpp
+++ b/src/ppx/grfx/grfx_draw_pass.cpp
@@ -270,14 +270,16 @@ Result DrawPass::CreateApiObjects(const grfx::internal::DrawPassCreateInfo* pCre
         if ((clearMask & DRAW_PASS_CLEAR_FLAG_CLEAR_RENDER_TARGETS) != 0) {
             renderTargetLoadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR;
         }
-        if ((clearMask & DRAW_PASS_CLEAR_FLAG_CLEAR_DEPTH) != 0) {
-            if (GetFormatDescription(mDepthStencilTexture->GetImageFormat())->aspect & FORMAT_ASPECT_DEPTH) {
-                depthLoadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR;
+        if (mDepthStencilTexture) {
+            if ((clearMask & DRAW_PASS_CLEAR_FLAG_CLEAR_DEPTH) != 0) {
+                if (GetFormatDescription(mDepthStencilTexture->GetImageFormat())->aspect & FORMAT_ASPECT_DEPTH) {
+                    depthLoadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR;
+                }
             }
-        }
-        if ((clearMask & DRAW_PASS_CLEAR_FLAG_CLEAR_STENCIL) != 0) {
-            if (GetFormatDescription(mDepthStencilTexture->GetImageFormat())->aspect & FORMAT_ASPECT_STENCIL) {
-                stencilLoadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR;
+            if ((clearMask & DRAW_PASS_CLEAR_FLAG_CLEAR_STENCIL) != 0) {
+                if (GetFormatDescription(mDepthStencilTexture->GetImageFormat())->aspect & FORMAT_ASPECT_STENCIL) {
+                    stencilLoadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR;
+                }
             }
         }
 

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -201,6 +201,7 @@ Result Device::ConfigureFeatures(const grfx::DeviceCreateInfo* pCreateInfo, VkPh
     features.pipelineStatisticsQuery              = foundFeatures.pipelineStatisticsQuery;
     features.geometryShader                       = foundFeatures.geometryShader;
     features.tessellationShader                   = foundFeatures.tessellationShader;
+    features.fragmentStoresAndAtomics             = foundFeatures.fragmentStoresAndAtomics;
     features.shaderStorageImageReadWithoutFormat  = foundFeatures.shaderStorageImageReadWithoutFormat;
     features.shaderStorageImageWriteWithoutFormat = foundFeatures.shaderStorageImageWriteWithoutFormat;
     features.samplerAnisotropy                    = foundFeatures.samplerAnisotropy;
@@ -680,6 +681,11 @@ bool Device::DynamicRenderingSupported() const
 bool Device::IndependentBlendingSupported() const
 {
     return mDeviceFeatures.independentBlend == VK_TRUE;
+}
+
+bool Device::FragmentStoresAndAtomicsSupported() const
+{
+    return mDeviceFeatures.fragmentStoresAndAtomics == VK_TRUE;
 }
 
 void Device::ResetQueryPoolEXT(


### PR DESCRIPTION
* Added the first buffer-based algorithm (buckets)
* Added a way to find out if the hardware supports fragment shader stores and atomics
* Fixed an issue that was preventing the creation of a draw pass without depth/stencil
* Performed some code clean up based on the previous PR comments