### PR TITLE
misc: fix format specifier for uint64_t

### DIFF
--- a/projects/15_basic_material/main.cpp
+++ b/projects/15_basic_material/main.cpp
@@ -1131,32 +1131,32 @@ void ProjApp::DrawGui()
 
     ImGui::Text("IAVertices");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.IAVertices);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.IAVertices);
     ImGui::NextColumn();
 
     ImGui::Text("IAPrimitives");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.IAPrimitives);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.IAPrimitives);
     ImGui::NextColumn();
 
     ImGui::Text("VSInvocations");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.VSInvocations);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.VSInvocations);
     ImGui::NextColumn();
 
     ImGui::Text("CInvocations");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.CInvocations);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.CInvocations);
     ImGui::NextColumn();
 
     ImGui::Text("CPrimitives");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.CPrimitives);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.CPrimitives);
     ImGui::NextColumn();
 
     ImGui::Text("PSInvocations");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.PSInvocations);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.PSInvocations);
     ImGui::NextColumn();
 
     ImGui::Columns(1);

--- a/projects/16_gbuffer/main.cpp
+++ b/projects/16_gbuffer/main.cpp
@@ -905,32 +905,32 @@ void ProjApp::DrawGui()
 
     ImGui::Text("IAVertices");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.IAVertices);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.IAVertices);
     ImGui::NextColumn();
 
     ImGui::Text("IAPrimitives");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.IAPrimitives);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.IAPrimitives);
     ImGui::NextColumn();
 
     ImGui::Text("VSInvocations");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.VSInvocations);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.VSInvocations);
     ImGui::NextColumn();
 
     ImGui::Text("CInvocations");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.CInvocations);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.CInvocations);
     ImGui::NextColumn();
 
     ImGui::Text("CPrimitives");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.CPrimitives);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.CPrimitives);
     ImGui::NextColumn();
 
     ImGui::Text("PSInvocations");
     ImGui::NextColumn();
-    ImGui::Text("%lu", mPipelineStatistics.PSInvocations);
+    ImGui::Text("%" PRIu64, mPipelineStatistics.PSInvocations);
     ImGui::NextColumn();
 
     ImGui::Columns(1);

--- a/projects/fishtornado/FishTornado.cpp
+++ b/projects/fishtornado/FishTornado.cpp
@@ -925,32 +925,32 @@ void FishTornadoApp::DrawGui()
 
         ImGui::Text("Fish IAVertices");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.IAVertices);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.IAVertices);
         ImGui::NextColumn();
 
         ImGui::Text("Fish IAPrimitives");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.IAPrimitives);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.IAPrimitives);
         ImGui::NextColumn();
 
         ImGui::Text("Fish VSInvocations");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.VSInvocations);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.VSInvocations);
         ImGui::NextColumn();
 
         ImGui::Text("Fish CInvocations");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.CInvocations);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.CInvocations);
         ImGui::NextColumn();
 
         ImGui::Text("Fish CPrimitives");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.CPrimitives);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.CPrimitives);
         ImGui::NextColumn();
 
         ImGui::Text("Fish PSInvocations");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.PSInvocations);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.PSInvocations);
         ImGui::NextColumn();
 
         ImGui::Columns(1);

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -1080,32 +1080,32 @@ void FishTornadoApp::DrawGui()
 
         ImGui::Text("Fish IAVertices");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.IAVertices);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.IAVertices);
         ImGui::NextColumn();
 
         ImGui::Text("Fish IAPrimitives");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.IAPrimitives);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.IAPrimitives);
         ImGui::NextColumn();
 
         ImGui::Text("Fish VSInvocations");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.VSInvocations);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.VSInvocations);
         ImGui::NextColumn();
 
         ImGui::Text("Fish CInvocations");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.CInvocations);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.CInvocations);
         ImGui::NextColumn();
 
         ImGui::Text("Fish CPrimitives");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.CPrimitives);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.CPrimitives);
         ImGui::NextColumn();
 
         ImGui::Text("Fish PSInvocations");
         ImGui::NextColumn();
-        ImGui::Text("%lu", mPipelineStatistics.PSInvocations);
+        ImGui::Text("%" PRIu64, mPipelineStatistics.PSInvocations);
         ImGui::NextColumn();
 
         ImGui::Columns(1);

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1746,7 +1746,7 @@ void Application::DrawDebugInfo(std::function<void(void)> drawAdditionalFn)
         {
             ImGui::Text("Frame Count");
             ImGui::NextColumn();
-            ImGui::Text("%lu", mFrameCount);
+            ImGui::Text("%" PRIu64, mFrameCount);
             ImGui::NextColumn();
         }
 
@@ -1858,7 +1858,7 @@ void Application::DrawProfilerGrfxApiFunctions()
                 ImGui::TableNextColumn();
                 ImGui::Text("%s", event.GetName().c_str());
                 ImGui::TableNextColumn();
-                ImGui::Text("%lu", count);
+                ImGui::Text("%" PRIu64, count);
                 ImGui::TableNextColumn();
                 ImGui::Text("%f ms", average);
                 ImGui::TableNextColumn();


### PR DESCRIPTION
uint64_t is always 64 bits, but implemented using either `unsigned long` (x64), or `unsigned long long` (x86). This causes issues with the printf format specifier.
This is now an issue as we enforce -Werror by default.