### PR TITLE
Resizable window, offscreen framebuffer, and resizable viewport

### DIFF
--- a/include/ppx/config.h
+++ b/include/ppx/config.h
@@ -21,7 +21,7 @@
 #       define VC_EXTRALEAN
 #   endif
 #   if !defined(WIN32_LEAN_AND_MEAN)
-#       define WIN32_LEAN_AND_MEAN 
+#       define WIN32_LEAN_AND_MEAN
 #   endif
 #   if !defined(NOMINMAX)
 #       define NOMINMAX
@@ -112,6 +112,8 @@ enum Result
     ERROR_NO_GPUS_FOUND                = -16,
     ERROR_REQUIRED_FEATURE_UNAVAILABLE = -17,
     ERROR_BAD_DATA_SOURCE              = -18,
+    ERROR_OUT_OF_DATE                  = -19,
+    ERROR_SUBOPTIMAL                   = -20,
 
     ERROR_GLFW_INIT_FAILED          = -200,
     ERROR_GLFW_CREATE_WINDOW_FAILED = -201,
@@ -191,6 +193,8 @@ inline const char* ToString(ppx::Result value)
         case Result::ERROR_NO_GPUS_FOUND                              : return "ERROR_NO_GPUS_FOUND";
         case Result::ERROR_REQUIRED_FEATURE_UNAVAILABLE               : return "ERROR_REQUIRED_FEATURE_UNAVAILABLE";
         case Result::ERROR_BAD_DATA_SOURCE                            : return "ERROR_BAD_DATA_SOURCE";
+        case Result::ERROR_OUT_OF_DATE                                : return "ERROR_OUT_OF_DATE";
+        case Result::ERROR_SUBOPTIMAL                                 : return "ERROR_SUBOPTIMAL";
 
         case Result::ERROR_GLFW_INIT_FAILED                           : return "ERROR_GLFW_INIT_FAILED";
         case Result::ERROR_GLFW_CREATE_WINDOW_FAILED                  : return "ERROR_GLFW_CREATE_WINDOW_FAILED";

--- a/include/ppx/grfx/dx12/dx12_swapchain.h
+++ b/include/ppx/grfx/dx12/dx12_swapchain.h
@@ -70,10 +70,13 @@ protected:
         grfx::Fence*     pFence,
         uint32_t*        pImageIndex) override;
 
+    virtual Result ResizeInternal(uint32_t width, uint32_t height) override;
+
 private:
     DXGISwapChainPtr     mSwapchain;
     HANDLE               mFrameLatencyWaitableObject = nullptr;
     D3D12CommandQueuePtr mQueue;
+    UINT                 mSwapchainFlags;
 
     //
     // Store sync internval so we can control its behavior based
@@ -84,6 +87,8 @@ private:
     //
     UINT mSyncInterval   = 1;
     BOOL mTearingEnabled = FALSE;
+
+    Result CreateImages(std::vector<ID3D12Resource*> colorImages, std::vector<ID3D12Resource*> depthImages);
 };
 
 } // namespace dx12

--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -101,6 +101,7 @@ struct SwapchainCreateInfo
 #if defined(PPX_BUILD_XR)
     XrComponent* pXrComponent = nullptr;
 #endif
+    bool createRenderPass = true;
 };
 
 //! @class Swapchain
@@ -119,6 +120,8 @@ public:
     uint32_t     GetImageCount() const { return mCreateInfo.imageCount; }
     grfx::Format GetColorFormat() const { return mCreateInfo.colorFormat; }
     grfx::Format GetDepthFormat() const { return mCreateInfo.depthFormat; }
+
+    Result Resize(uint32_t width, uint32_t height);
 
     Result GetColorImage(uint32_t imageIndex, grfx::Image** ppImage) const;
     Result GetDepthImage(uint32_t imageIndex, grfx::Image** ppImage) const;
@@ -172,6 +175,8 @@ protected:
         uint32_t                      imageIndex,
         uint32_t                      waitSemaphoreCount,
         const grfx::Semaphore* const* ppWaitSemaphores) = 0;
+
+    virtual Result ResizeInternal(uint32_t width, uint32_t height);
 
 private:
     Result AcquireNextImageHeadless(

--- a/include/ppx/render_target.h
+++ b/include/ppx/render_target.h
@@ -1,0 +1,281 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ppx_render_target_h
+#define ppx_render_target_h
+
+#include "ppx/grfx/grfx_config.h"
+
+#include <functional>
+#include <memory>
+
+namespace ppx {
+
+//! @class RenderTarget
+//!
+//! The RenderTarget interface should match Swapchain.
+//! It could be backed by a actual swapchain or an off-screen buffer.
+//!
+
+class RenderTarget
+{
+public:
+    RenderTarget() = default;
+    virtual ~RenderTarget() {}
+
+    RenderTarget(const RenderTarget&)            = delete;
+    RenderTarget& operator=(const RenderTarget&) = delete;
+
+public:
+    virtual uint32_t     GetImageCount() const  = 0;
+    virtual grfx::Format GetColorFormat() const = 0;
+    virtual grfx::Format GetDepthFormat() const = 0;
+
+    virtual Result GetColorImage(uint32_t imageIndex, grfx::Image** ppImage) const = 0;
+    virtual Result GetDepthImage(uint32_t imageIndex, grfx::Image** ppImage) const = 0;
+
+    // Full image width/height, might be larger than the render area
+    // In Swapchain, it's Get{Width,Height} but in that case the viewport and image size are the same.
+    virtual uint32_t GetImageWidth() const  = 0;
+    virtual uint32_t GetImageHeight() const = 0;
+
+    virtual Result GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::RenderPass** ppRenderPass) const = 0;
+
+    virtual Result AcquireNextImage(
+        uint64_t         timeout,    // Nanoseconds
+        grfx::Semaphore* pSemaphore, // Wait sempahore
+        grfx::Fence*     pFence,     // Wait fence
+        uint32_t*        pImageIndex) = 0;
+
+    virtual Result Present(
+        uint32_t                      imageIndex,
+        uint32_t                      waitSemaphoreCount,
+        const grfx::Semaphore* const* ppWaitSemaphores) = 0;
+
+    virtual grfx::Rect GetRenderArea() const; // Returns ScissorRect.
+    grfx::Viewport     GetViewport(float minDepth = 0.0, float maxDepth = 1.0) const;
+    float              GetAspect() const;
+
+    grfx::ImagePtr GetColorImage(uint32_t imageIndex) const;
+    grfx::ImagePtr GetDepthImage(uint32_t imageIndex) const;
+
+    grfx::RenderPassPtr GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR) const;
+
+    virtual grfx::Device* GetDevice() const = 0;
+
+protected:
+    virtual Result OnUpdate() { return ppx::SUCCESS; }
+};
+
+class SwapchainRenderTarget : public RenderTarget
+{
+public:
+    static std::unique_ptr<SwapchainRenderTarget> Create(grfx::Swapchain* swapchain);
+
+    Result ResizeSwapchain(uint32_t w, uint32_t h);
+    Result ReplaceSwapchain(grfx::Swapchain*);
+    bool   NeedUpdate();
+    void   SetNeedUpdate();
+
+public:
+    uint32_t     GetImageCount() const final;
+    grfx::Format GetColorFormat() const final;
+    grfx::Format GetDepthFormat() const final;
+
+    uint32_t GetImageWidth() const final;
+    uint32_t GetImageHeight() const final;
+
+    Result GetColorImage(uint32_t imageIndex, grfx::Image** ppImage) const final;
+
+    Result GetDepthImage(uint32_t imageIndex, grfx::Image** ppImage) const final;
+
+    Result AcquireNextImage(
+        uint64_t         timeout,
+        grfx::Semaphore* pSemaphore,
+        grfx::Fence*     pFence,
+        uint32_t*        pImageIndex) final;
+
+    Result Present(
+        uint32_t                      imageIndex,
+        uint32_t                      waitSemaphoreCount,
+        const grfx::Semaphore* const* ppWaitSemaphores) final;
+
+    grfx::Device* GetDevice() const final;
+
+private:
+    grfx::Swapchain* mSwapchain  = nullptr;
+    bool             mNeedUpdate = false;
+
+    SwapchainRenderTarget(grfx::Swapchain* swapchain);
+};
+
+class RenderTargetPresentCommon
+{
+public:
+    Result Init(grfx::Queue* queue, uint32_t imageCount);
+
+    Result Present(
+        RenderTarget*                             realTarget,
+        uint32_t                                  imageIndex,
+        uint32_t                                  waitSemaphoreCount,
+        const grfx::Semaphore* const*             ppWaitSemaphores,
+        std::function<void(grfx::CommandBuffer*)> recordCommands);
+
+private:
+    grfx::Queue* mQueue = nullptr;
+    grfx::Queue* GetQueue() const { return mQueue; }
+
+    std::vector<grfx::CommandBufferPtr> mCommandBuffers;
+    std::vector<grfx::SemaphorePtr>     mSemaphores;
+};
+
+class IndirectRenderTarget : public RenderTarget
+{
+public:
+    struct CreateInfo
+    {
+        RenderTarget* next        = nullptr;
+        grfx::Queue*  pQueue      = nullptr;
+        uint32_t      width       = 0;
+        uint32_t      height      = 0;
+        grfx::Format  colorFormat = grfx::FORMAT_UNDEFINED;
+        grfx::Format  depthFormat = grfx::FORMAT_UNDEFINED;
+        uint32_t      imageCount  = 0;
+    };
+    static std::unique_ptr<IndirectRenderTarget> Create(const CreateInfo& createInfo);
+
+    void UpdateRenderArea(grfx::Rect renderArea);
+    void UpdateViewport(uint32_t width, uint32_t height)
+    {
+        UpdateRenderArea({0, 0, width, height});
+    }
+
+public:
+    uint32_t     GetImageCount() const final { return mCreateInfo.imageCount; }
+    grfx::Format GetColorFormat() const final { return mCreateInfo.colorFormat; }
+    grfx::Format GetDepthFormat() const final { return mCreateInfo.depthFormat; }
+
+    uint32_t GetImageWidth() const final { return mCreateInfo.width; }
+    uint32_t GetImageHeight() const final { return mCreateInfo.height; }
+
+    Result GetColorImage(uint32_t imageIndex, grfx::Image** ppImage) const final;
+    Result GetDepthImage(uint32_t imageIndex, grfx::Image** ppImage) const final;
+
+    grfx::Rect GetRenderArea() const final { return mRenderArea; }
+
+    grfx::Device* GetDevice() const final;
+
+    Result AcquireNextImage(
+        uint64_t         timeout,    // Nanoseconds
+        grfx::Semaphore* pSemaphore, // Wait sempahore
+        grfx::Fence*     pFence,     // Wait fence
+        uint32_t*        pImageIndex) final;
+
+    Result Present(
+        uint32_t                      imageIndex,
+        uint32_t                      waitSemaphoreCount,
+        const grfx::Semaphore* const* ppWaitSemaphores) final;
+
+private:
+    IndirectRenderTarget(const CreateInfo& createInfo);
+
+    Result Init();
+
+    CreateInfo mCreateInfo = {};
+    grfx::Rect mRenderArea = {};
+
+    std::vector<grfx::ImagePtr> mDepthImages;
+    std::vector<grfx::ImagePtr> mColorImages;
+
+    RenderTargetPresentCommon mPresent;
+
+    RenderTarget* Next() { return mCreateInfo.next; }
+    grfx::Queue*  GetQueue() const { return mCreateInfo.pQueue; }
+
+    void RecordCommands(grfx::CommandBuffer* commandBuffer, uint32_t imageIndex);
+};
+
+// Wrap a existing RenderTarget, and modify some of its behaivour.
+class RenderTargetWrap : public RenderTarget
+{
+public:
+    RenderTargetWrap(RenderTarget* impl)
+        : mImpl(impl) {}
+
+    uint32_t     GetImageCount() const override { return mImpl->GetImageCount(); }
+    grfx::Format GetColorFormat() const override { return mImpl->GetColorFormat(); }
+    grfx::Format GetDepthFormat() const override { return mImpl->GetDepthFormat(); }
+
+    Result GetColorImage(uint32_t imageIndex, grfx::Image** ppImage) const override { return mImpl->GetColorImage(imageIndex, ppImage); }
+    Result GetDepthImage(uint32_t imageIndex, grfx::Image** ppImage) const override { return mImpl->GetDepthImage(imageIndex, ppImage); }
+
+    // Full image width/height, might be larger than the render area
+    uint32_t GetImageWidth() const override { return mImpl->GetImageWidth(); }
+    uint32_t GetImageHeight() const override { return mImpl->GetImageHeight(); }
+
+    using RenderTarget::GetRenderPass;
+    Result GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::RenderPass** ppRenderPass) const override
+    {
+        return mImpl->GetRenderPass(imageIndex, loadOp, ppRenderPass);
+    }
+
+    Result AcquireNextImage(
+        uint64_t         timeout,    // Nanoseconds
+        grfx::Semaphore* pSemaphore, // Wait sempahore
+        grfx::Fence*     pFence,     // Wait fence
+        uint32_t*        pImageIndex) override
+    {
+        return mImpl->AcquireNextImage(timeout, pSemaphore, pFence, pImageIndex);
+    }
+
+    Result Present(
+        uint32_t                      imageIndex,
+        uint32_t                      waitSemaphoreCount,
+        const grfx::Semaphore* const* ppWaitSemaphores) override
+    {
+        return mImpl->Present(imageIndex, waitSemaphoreCount, ppWaitSemaphores);
+    }
+
+    grfx::Rect GetRenderArea() const override { return mImpl->GetRenderArea(); }
+
+    grfx::Device* GetDevice() const final { return mImpl->GetDevice(); }
+
+protected:
+    RenderTarget* mImpl;
+};
+
+// Draw ImGui after actual presentation.
+class RenderTargetPresentHook : public RenderTargetWrap
+{
+public:
+    static std::unique_ptr<RenderTargetPresentHook> Create(grfx::Queue* queue, RenderTarget* backing, std::function<void(grfx::CommandBuffer*)> f);
+
+    Result Present(
+        uint32_t                      imageIndex,
+        uint32_t                      waitSemaphoreCount,
+        const grfx::Semaphore* const* ppWaitSemaphores) final;
+
+private:
+    RenderTargetPresentHook(RenderTarget* backing, std::function<void(grfx::CommandBuffer*)> f);
+    Result Init(grfx::Queue* queue);
+
+    std::function<void(grfx::CommandBuffer*)> mOnPresent;
+    RenderTargetPresentCommon                 mPresent;
+
+    void RecordCommands(grfx::CommandBuffer* commandBuffer, uint32_t imageIndex);
+};
+
+} // namespace ppx
+
+#endif // ppx_render_target_h

--- a/projects/fishtornado/FishTornado.h
+++ b/projects/fishtornado/FishTornado.h
@@ -72,6 +72,7 @@ public:
     virtual void Shutdown() override;
     virtual void Scroll(float dx, float dy) override;
     virtual void Render() override;
+    virtual void DrawDebugUI() override;
 
     bool WasLastFrameAsync() { return mLastFrameWasAsyncCompute; }
 
@@ -143,19 +144,19 @@ private:
     void UpdateTime();
     void UpdateScene(uint32_t frameIndex);
     void RenderSceneUsingSingleCommandBuffer(
-        uint32_t            frameIndex,
-        PerFrame&           frame,
-        uint32_t            prevFrameIndex,
-        PerFrame&           prevFrame,
-        grfx::SwapchainPtr& swapchain,
-        uint32_t            imageIndex);
+        uint32_t      frameIndex,
+        PerFrame&     frame,
+        uint32_t      prevFrameIndex,
+        PerFrame&     prevFrame,
+        RenderTarget* swapchain,
+        uint32_t      imageIndex);
     void RenderSceneUsingMultipleCommandBuffers(
-        uint32_t            frameIndex,
-        PerFrame&           frame,
-        uint32_t            prevFrameIndex,
-        PerFrame&           prevFrame,
-        grfx::SwapchainPtr& swapchain,
-        uint32_t            imageIndex);
+        uint32_t      frameIndex,
+        PerFrame&     frame,
+        uint32_t      prevFrameIndex,
+        PerFrame&     prevFrame,
+        RenderTarget* swapchain,
+        uint32_t      imageIndex);
     void DrawGui();
 };
 

--- a/projects/fishtornado/Ocean.cpp
+++ b/projects/fishtornado/Ocean.cpp
@@ -130,8 +130,8 @@ void Ocean::Setup(uint32_t numFramesInFlight)
             gpCreateInfo.depthWriteEnable                   = false;
             gpCreateInfo.blendModes[0]                      = {grfx::BLEND_MODE_ADDITIVE};
             gpCreateInfo.outputState.renderTargetCount      = 1;
-            gpCreateInfo.outputState.renderTargetFormats[0] = pApp->GetSwapchain()->GetColorFormat();
-            gpCreateInfo.outputState.depthStencilFormat     = pApp->GetSwapchain()->GetDepthFormat();
+            gpCreateInfo.outputState.renderTargetFormats[0] = pApp->GetRenderTarget()->GetColorFormat();
+            gpCreateInfo.outputState.depthStencilFormat     = pApp->GetRenderTarget()->GetDepthFormat();
             gpCreateInfo.pPipelineInterface                 = pApp->GetForwardPipelineInterface();
             // Vertex description
             gpCreateInfo.vertexInputState.bindingCount = vertexDescription.GetBindingCount();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,6 +161,7 @@ list(
     ${INC_DIR}/ppx/ppm_export.h
     ${INC_DIR}/ppx/profiler.h
     ${INC_DIR}/ppx/random.h
+    ${INC_DIR}/ppx/render_target.h
     ${INC_DIR}/ppx/string_util.h
     ${INC_DIR}/ppx/timer.h
     ${INC_DIR}/ppx/transform.h
@@ -190,6 +191,7 @@ list(
     ${SRC_DIR}/ppx/platform.cpp
     ${SRC_DIR}/ppx/ppm_export.cpp
     ${SRC_DIR}/ppx/profiler.cpp
+    ${SRC_DIR}/ppx/render_target.cpp
     ${SRC_DIR}/ppx/string_util.cpp
     ${SRC_DIR}/ppx/timer.cpp
     ${SRC_DIR}/ppx/transform.cpp

--- a/src/ppx/grfx/vk/vk_swapchain.cpp
+++ b/src/ppx/grfx/vk/vk_swapchain.cpp
@@ -533,6 +533,13 @@ Result Swapchain::AcquireNextImageInternal(
         fence,
         pImageIndex);
 
+    if (vkres == VK_SUBOPTIMAL_KHR) {
+        return ppx::ERROR_SUBOPTIMAL;
+    }
+    if (vkres == VK_ERROR_OUT_OF_DATE_KHR) {
+        return ppx::ERROR_OUT_OF_DATE;
+    }
+
     // Handle failure cases
     if (vkres < VK_SUCCESS) {
         PPX_ASSERT_MSG(false, "vkAcquireNextImageKHR failed: " << ToString(vkres));
@@ -569,6 +576,12 @@ Result Swapchain::PresentInternal(
     VkResult vkres = vk::QueuePresent(
         mQueue,
         &vkpi);
+    if (vkres == VK_SUBOPTIMAL_KHR) {
+        return ppx::ERROR_SUBOPTIMAL;
+    }
+    if (vkres == VK_ERROR_OUT_OF_DATE_KHR) {
+        return ppx::ERROR_OUT_OF_DATE;
+    }
     if (vkres != VK_SUCCESS) {
         return ppx::ERROR_API_FAILURE;
     }

--- a/src/ppx/imgui_impl.cpp
+++ b/src/ppx/imgui_impl.cpp
@@ -263,7 +263,16 @@ Result ImGuiImplVk::InitApiObjects(ppx::Application* pApp)
         init_info.Allocator                 = VK_NULL_HANDLE;
         init_info.CheckVkResultFn           = nullptr;
 
-        grfx::RenderPassPtr renderPass = pApp->GetSwapchain()->GetRenderPass(0, grfx::ATTACHMENT_LOAD_OP_LOAD);
+        grfx::RenderPassPtr renderPass;
+
+        RenderTarget* renderTarget = pApp->GetSwapchainRenderTarget();
+        if (renderTarget != nullptr) {
+            renderPass = renderTarget->GetRenderPass(0, grfx::ATTACHMENT_LOAD_OP_LOAD);
+        }
+        else {
+            renderPass = pApp->GetSwapchain()->GetRenderPass(0, grfx::ATTACHMENT_LOAD_OP_LOAD);
+        }
+
         PPX_ASSERT_MSG(!renderPass.IsNull(), "[imgui:vk] failed to get swapchain renderpass");
 
         bool result = ImGui_ImplVulkan_Init(&init_info, grfx::vk::ToApi(renderPass)->GetVkRenderPass());

--- a/src/ppx/render_target.cpp
+++ b/src/ppx/render_target.cpp
@@ -1,0 +1,604 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ppx/render_target.h"
+
+#include "ppx/config.h"
+#include "ppx/grfx/grfx_device.h"
+#include "ppx/grfx/grfx_enums.h"
+#include "ppx/grfx/grfx_render_pass.h"
+#include "ppx/grfx/grfx_instance.h"
+#include "ppx/grfx/grfx_swapchain.h"
+#include "ppx/grfx/grfx_queue.h"
+
+namespace ppx {
+
+// -------------------------------------------------------------------------------------------------
+// Implement RenderPass for RenderTarget
+
+namespace {
+
+class RenderTargetRenderPassImpl
+{
+public:
+    Result GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::RenderPass** ppRenderPass) const;
+    Result UpdateRenderPass(RenderTarget* renderTarget);
+
+private:
+    std::vector<grfx::RenderPassPtr> mClearRenderPasses;
+    std::vector<grfx::RenderPassPtr> mLoadRenderPasses;
+};
+
+
+template <typename T>
+class WithRenderPass : public T
+{
+public:
+    using T::GetRenderPass;
+    using T::T;
+    Result GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::RenderPass** ppRenderPass) const final
+    {
+        return mRenderPass.GetRenderPass(imageIndex, loadOp, ppRenderPass);
+    }
+
+protected:
+    Result OnUpdate() override
+    {
+        Result ppxres = mRenderPass.UpdateRenderPass(this);
+        if (Failed(ppxres)) {
+            return ppxres;
+        }
+        return T::OnUpdate();
+    }
+
+private:
+    RenderTargetRenderPassImpl mRenderPass;
+};
+
+Result RenderTargetRenderPassImpl::GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::RenderPass** ppRenderPass) const
+{
+    if (!IsIndexInRange(imageIndex, mClearRenderPasses)) {
+        return ppx::ERROR_OUT_OF_RANGE;
+    }
+    if (loadOp == grfx::ATTACHMENT_LOAD_OP_CLEAR) {
+        *ppRenderPass = mClearRenderPasses[imageIndex];
+    }
+    else {
+        *ppRenderPass = mLoadRenderPasses[imageIndex];
+    }
+    return ppx::SUCCESS;
+}
+
+Result RenderTargetRenderPassImpl::UpdateRenderPass(RenderTarget* renderTarget)
+{
+    for (auto rp : mClearRenderPasses) {
+        renderTarget->GetDevice()->DestroyRenderPass(rp);
+    }
+    mClearRenderPasses.clear();
+    for (auto rp : mLoadRenderPasses) {
+        renderTarget->GetDevice()->DestroyRenderPass(rp);
+    }
+    mLoadRenderPasses.clear();
+
+    bool hasDepthImage = renderTarget->GetDepthFormat() != grfx::FORMAT_UNDEFINED;
+
+    // Create render passes with grfx::ATTACHMENT_LOAD_OP_CLEAR for render target.
+    for (uint32_t i = 0; i < renderTarget->GetImageCount(); i++) {
+        grfx::RenderPassCreateInfo3 rpCreateInfo = {};
+        rpCreateInfo.width                       = renderTarget->GetImageWidth();
+        rpCreateInfo.height                      = renderTarget->GetImageHeight();
+        rpCreateInfo.renderTargetCount           = 1;
+        rpCreateInfo.pRenderTargetImages[0]      = renderTarget->GetColorImage(i);
+        rpCreateInfo.pDepthStencilImage          = hasDepthImage ? renderTarget->GetDepthImage(i) : nullptr;
+        rpCreateInfo.renderTargetClearValues[0]  = {{0.0f, 0.0f, 0.0f, 0.0f}};
+        rpCreateInfo.depthStencilClearValue      = {1.0f, 0xFF};
+        rpCreateInfo.renderTargetLoadOps[0]      = grfx::ATTACHMENT_LOAD_OP_CLEAR;
+        rpCreateInfo.depthLoadOp                 = grfx::ATTACHMENT_LOAD_OP_CLEAR;
+        rpCreateInfo.ownership                   = grfx::OWNERSHIP_RESTRICTED;
+
+        grfx::RenderPassPtr renderPass;
+
+        Result ppxres = renderTarget->GetDevice()->CreateRenderPass(&rpCreateInfo, &renderPass);
+        if (Failed(ppxres)) {
+            PPX_ASSERT_MSG(false, "RenderTargetRenderPassImpl::UpdateRenderPass(CLEAR) failed");
+            return ppxres;
+        }
+
+        mClearRenderPasses.push_back(renderPass);
+    }
+
+    // Create render passes with grfx::ATTACHMENT_LOAD_OP_LOAD for render target.
+    for (uint32_t i = 0; i < renderTarget->GetImageCount(); i++) {
+        grfx::RenderPassCreateInfo3 rpCreateInfo = {};
+        rpCreateInfo.width                       = renderTarget->GetImageWidth();
+        rpCreateInfo.height                      = renderTarget->GetImageHeight();
+        rpCreateInfo.renderTargetCount           = 1;
+        rpCreateInfo.pRenderTargetImages[0]      = renderTarget->GetColorImage(i);
+        rpCreateInfo.pDepthStencilImage          = hasDepthImage ? renderTarget->GetDepthImage(i) : nullptr;
+        rpCreateInfo.renderTargetClearValues[0]  = {{0.0f, 0.0f, 0.0f, 0.0f}};
+        rpCreateInfo.depthStencilClearValue      = {1.0f, 0xFF};
+        rpCreateInfo.renderTargetLoadOps[0]      = grfx::ATTACHMENT_LOAD_OP_LOAD;
+        rpCreateInfo.depthLoadOp                 = grfx::ATTACHMENT_LOAD_OP_CLEAR;
+        rpCreateInfo.ownership                   = grfx::OWNERSHIP_RESTRICTED;
+
+        grfx::RenderPassPtr renderPass;
+
+        Result ppxres = renderTarget->GetDevice()->CreateRenderPass(&rpCreateInfo, &renderPass);
+        if (Failed(ppxres)) {
+            PPX_ASSERT_MSG(false, "RenderTargetRenderPassImpl::UpdateRenderPass(LOAD) failed");
+            return ppxres;
+        }
+
+        mLoadRenderPasses.push_back(renderPass);
+    }
+
+    return ppx::SUCCESS;
+}
+
+} // namespace
+
+// -------------------------------------------------------------------------------------------------
+// RenderTarget
+
+grfx::Rect RenderTarget::GetRenderArea() const
+{
+    return grfx::Rect{0, 0, GetImageWidth(), GetImageHeight()};
+}
+
+grfx::ImagePtr RenderTarget::GetColorImage(uint32_t imageIndex) const
+{
+    grfx::ImagePtr object;
+    GetColorImage(imageIndex, &object);
+    return object;
+}
+
+grfx::ImagePtr RenderTarget::GetDepthImage(uint32_t imageIndex) const
+{
+    grfx::ImagePtr object;
+    GetDepthImage(imageIndex, &object);
+    return object;
+}
+
+float RenderTarget::GetAspect() const
+{
+    grfx::Rect rect = GetRenderArea();
+    return static_cast<float>(rect.width) / rect.height;
+}
+
+grfx::Viewport RenderTarget::GetViewport(float minDepth, float maxDepth) const
+{
+    grfx::Rect rect = GetRenderArea();
+    return grfx::Viewport{
+        static_cast<float>(rect.x),
+        static_cast<float>(rect.y),
+        static_cast<float>(rect.width),
+        static_cast<float>(rect.height),
+        minDepth,
+        maxDepth,
+    };
+}
+
+grfx::RenderPassPtr RenderTarget::GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp) const
+{
+    grfx::RenderPassPtr object;
+    GetRenderPass(imageIndex, loadOp, &object);
+    return object;
+}
+
+// -------------------------------------------------------------------------------------------------
+// SwapchainRenderTarget
+
+std::unique_ptr<SwapchainRenderTarget> SwapchainRenderTarget::Create(grfx::Swapchain* swapchain)
+{
+    std::unique_ptr<SwapchainRenderTarget> renderTarget(new WithRenderPass<SwapchainRenderTarget>(swapchain));
+    PPX_CHECKED_CALL(renderTarget->OnUpdate());
+    return renderTarget;
+}
+
+SwapchainRenderTarget::SwapchainRenderTarget(grfx::Swapchain* swapchain)
+    : mSwapchain(swapchain)
+{
+}
+
+Result SwapchainRenderTarget::ResizeSwapchain(uint32_t w, uint32_t h)
+{
+    Result ppxres = mSwapchain->Resize(w, h);
+    if (ppxres == ppx::SUCCESS) {
+        mNeedUpdate = false;
+        return OnUpdate();
+    }
+    return ppxres;
+}
+
+Result SwapchainRenderTarget::ReplaceSwapchain(grfx::Swapchain* swapchain)
+{
+    mSwapchain  = swapchain;
+    mNeedUpdate = false;
+    return OnUpdate();
+}
+
+bool SwapchainRenderTarget::NeedUpdate()
+{
+    return mNeedUpdate;
+}
+
+void SwapchainRenderTarget::SetNeedUpdate()
+{
+    mNeedUpdate = true;
+}
+
+uint32_t SwapchainRenderTarget::GetImageCount() const
+{
+    return mSwapchain->GetImageCount();
+}
+
+grfx::Format SwapchainRenderTarget::GetColorFormat() const
+{
+    return mSwapchain->GetColorFormat();
+}
+
+grfx::Format SwapchainRenderTarget::GetDepthFormat() const
+{
+    return mSwapchain->GetDepthFormat();
+}
+
+uint32_t SwapchainRenderTarget::GetImageWidth() const
+{
+    return mSwapchain->GetWidth();
+}
+
+uint32_t SwapchainRenderTarget::GetImageHeight() const
+{
+    return mSwapchain->GetHeight();
+}
+
+Result SwapchainRenderTarget::GetColorImage(uint32_t imageIndex, grfx::Image** ppImage) const
+{
+    return mSwapchain->GetColorImage(imageIndex, ppImage);
+}
+
+Result SwapchainRenderTarget::GetDepthImage(uint32_t imageIndex, grfx::Image** ppImage) const
+{
+    return mSwapchain->GetDepthImage(imageIndex, ppImage);
+}
+
+Result SwapchainRenderTarget::AcquireNextImage(
+    uint64_t         timeout,
+    grfx::Semaphore* pSemaphore,
+    grfx::Fence*     pFence,
+    uint32_t*        pImageIndex)
+{
+    Result ppxres = mSwapchain->AcquireNextImage(timeout, pSemaphore, pFence, pImageIndex);
+    if (ppxres == ppx::ERROR_OUT_OF_DATE) {
+        mNeedUpdate = true;
+        return ppxres;
+    }
+    if (ppxres == ppx::ERROR_SUBOPTIMAL) {
+        mNeedUpdate = true;
+        return ppx::SUCCESS;
+    }
+    return ppxres;
+}
+
+Result SwapchainRenderTarget::Present(
+    uint32_t                      imageIndex,
+    uint32_t                      waitSemaphoreCount,
+    const grfx::Semaphore* const* ppWaitSemaphores)
+{
+    Result ppxres = mSwapchain->Present(imageIndex, waitSemaphoreCount, ppWaitSemaphores);
+    if (ppxres == ppx::ERROR_OUT_OF_DATE) {
+        mNeedUpdate = true;
+        return ppxres;
+    }
+    if (ppxres == ppx::ERROR_SUBOPTIMAL) {
+        mNeedUpdate = true;
+        return ppx::SUCCESS;
+    }
+    return ppxres;
+}
+
+grfx::Device* SwapchainRenderTarget::GetDevice() const
+{
+    return mSwapchain->GetDevice();
+}
+
+// -------------------------------------------------------------------------------------------------
+// RenderTargetPresentCommon
+Result RenderTargetPresentCommon::Init(grfx::Queue* queue, uint32_t imageCount)
+{
+    mQueue = queue;
+
+    for (uint32_t i = 0; i < imageCount; ++i) {
+        grfx::CommandBufferPtr commandBuffer = nullptr;
+        mQueue->CreateCommandBuffer(&commandBuffer, 0, 0);
+        mCommandBuffers.push_back(commandBuffer);
+    }
+    grfx::Device* device = mQueue->GetDevice();
+    for (uint32_t i = 0; i < imageCount; i++) {
+        grfx::SemaphoreCreateInfo info = {};
+        grfx::SemaphorePtr        pSemaphore;
+        PPX_CHECKED_CALL(device->CreateSemaphore(&info, &pSemaphore));
+        mSemaphores.push_back(pSemaphore);
+    }
+    return ppx::SUCCESS;
+}
+
+Result RenderTargetPresentCommon::Present(
+    RenderTarget*                             realTarget,
+    uint32_t                                  imageIndex,
+    uint32_t                                  waitSemaphoreCount,
+    const grfx::Semaphore* const*             ppWaitSemaphores,
+    std::function<void(grfx::CommandBuffer*)> recordCommandss)
+{
+    grfx::CommandBufferPtr commandBuffer = mCommandBuffers[imageIndex];
+
+    commandBuffer->Begin();
+    recordCommandss(commandBuffer);
+    commandBuffer->End();
+
+    grfx::Semaphore* pSignalSemaphore = mSemaphores[imageIndex].Get();
+
+    grfx::SubmitInfo sInfo     = {};
+    sInfo.ppCommandBuffers     = &commandBuffer;
+    sInfo.commandBufferCount   = 1;
+    sInfo.ppWaitSemaphores     = ppWaitSemaphores;
+    sInfo.waitSemaphoreCount   = waitSemaphoreCount;
+    sInfo.ppSignalSemaphores   = &pSignalSemaphore;
+    sInfo.signalSemaphoreCount = 1;
+    mQueue->Submit(&sInfo);
+
+    return realTarget->Present(imageIndex, 1, &pSignalSemaphore);
+}
+
+// -------------------------------------------------------------------------------------------------
+// IndirectRenderTarget
+
+std::unique_ptr<IndirectRenderTarget> IndirectRenderTarget::Create(const CreateInfo& createInfo)
+{
+    std::unique_ptr<IndirectRenderTarget> renderTarget(new WithRenderPass<IndirectRenderTarget>(createInfo));
+    PPX_CHECKED_CALL(renderTarget->Init());
+    return renderTarget;
+}
+
+IndirectRenderTarget::IndirectRenderTarget(const CreateInfo& createInfo)
+    : mCreateInfo(createInfo), mRenderArea(0, 0, createInfo.width, createInfo.height)
+{
+}
+
+grfx::Device* IndirectRenderTarget::GetDevice() const
+{
+    return mCreateInfo.pQueue->GetDevice();
+}
+
+Result IndirectRenderTarget::Init()
+{
+    {
+        Result ppxres = mPresent.Init(mCreateInfo.pQueue, mCreateInfo.imageCount);
+        if (Failed(ppxres)) {
+            return ppxres;
+        }
+    }
+    // Create color images if needed. This is only needed if we're creating
+    // a headless swapchain.
+    if (mColorImages.empty()) {
+        for (uint32_t i = 0; i < mCreateInfo.imageCount; ++i) {
+            grfx::ImageCreateInfo rtCreateInfo = grfx::ImageCreateInfo::RenderTarget2D(mCreateInfo.width, mCreateInfo.height, mCreateInfo.colorFormat);
+            rtCreateInfo.ownership             = grfx::OWNERSHIP_RESTRICTED;
+            rtCreateInfo.RTVClearValue         = {0.0f, 0.0f, 0.0f, 0.0f};
+            rtCreateInfo.initialState          = grfx::RESOURCE_STATE_PRESENT;
+            rtCreateInfo.usageFlags =
+                grfx::IMAGE_USAGE_COLOR_ATTACHMENT |
+                grfx::IMAGE_USAGE_TRANSFER_SRC |
+                grfx::IMAGE_USAGE_TRANSFER_DST |
+                grfx::IMAGE_USAGE_SAMPLED;
+
+            grfx::ImagePtr renderTargetOLD;
+
+            Result ppxres = GetQueue()->GetDevice()->CreateImage(&rtCreateInfo, &renderTargetOLD);
+            if (Failed(ppxres)) {
+                return ppxres;
+            }
+
+            mColorImages.push_back(renderTargetOLD);
+        }
+    }
+
+    // Create depth images if needed. This is usually needed for both normal swapchains
+    // and headless swapchains, but not needed for XR swapchains which create their own
+    // depth images.
+    if (mCreateInfo.depthFormat != grfx::FORMAT_UNDEFINED && mDepthImages.empty()) {
+        for (uint32_t i = 0; i < mCreateInfo.imageCount; ++i) {
+            grfx::ImageCreateInfo dpCreateInfo = grfx::ImageCreateInfo::DepthStencilTarget(mCreateInfo.width, mCreateInfo.height, mCreateInfo.depthFormat);
+            dpCreateInfo.ownership             = grfx::OWNERSHIP_RESTRICTED;
+            dpCreateInfo.DSVClearValue         = {1.0f, 0xFF};
+
+            grfx::ImagePtr depthStencilTarget;
+
+            Result ppxres = GetQueue()->GetDevice()->CreateImage(&dpCreateInfo, &depthStencilTarget);
+            if (Failed(ppxres)) {
+                return ppxres;
+            }
+
+            mDepthImages.push_back(depthStencilTarget);
+        }
+    }
+
+    return OnUpdate();
+}
+
+Result IndirectRenderTarget::GetColorImage(uint32_t imageIndex, grfx::Image** ppImage) const
+{
+    if (!IsIndexInRange(imageIndex, mColorImages)) {
+        return ppx::ERROR_OUT_OF_RANGE;
+    }
+    *ppImage = mColorImages[imageIndex];
+    return ppx::SUCCESS;
+}
+
+Result IndirectRenderTarget::GetDepthImage(uint32_t imageIndex, grfx::Image** ppImage) const
+{
+    if (!IsIndexInRange(imageIndex, mDepthImages)) {
+        return ppx::ERROR_OUT_OF_RANGE;
+    }
+    *ppImage = mDepthImages[imageIndex];
+    return ppx::SUCCESS;
+}
+
+void IndirectRenderTarget::UpdateRenderArea(grfx::Rect renderArea)
+{
+    if (renderArea.x < 0 || renderArea.y < 0 ||
+        renderArea.width == 0 || renderArea.height == 0 ||
+        renderArea.x + renderArea.width > mCreateInfo.width ||
+        renderArea.y + renderArea.height > mCreateInfo.height) {
+        return;
+    }
+    mRenderArea = renderArea;
+}
+
+Result IndirectRenderTarget::AcquireNextImage(
+    uint64_t         timeout,    // Nanoseconds
+    grfx::Semaphore* pSemaphore, // Wait sempahore
+    grfx::Fence*     pFence,     // Wait fence
+    uint32_t*        pImageIndex)
+{
+    return Next()->AcquireNextImage(timeout, pSemaphore, pFence, pImageIndex);
+}
+
+Result IndirectRenderTarget::Present(
+    uint32_t                      imageIndex,
+    uint32_t                      waitSemaphoreCount,
+    const grfx::Semaphore* const* ppWaitSemaphores)
+{
+    return mPresent.Present(
+        mCreateInfo.next,
+        imageIndex,
+        waitSemaphoreCount,
+        ppWaitSemaphores,
+        [this, imageIndex](grfx::CommandBuffer* commandBuffer) {
+            RecordCommands(commandBuffer, imageIndex);
+        });
+}
+
+void IndirectRenderTarget::RecordCommands(grfx::CommandBuffer* commandBuffer, uint32_t imageIndex)
+{
+    grfx::ImageToImageCopyInfo imcopy = {};
+    {
+        grfx::Rect src           = GetRenderArea();
+        grfx::Rect dst           = Next()->GetRenderArea();
+        imcopy.srcImage.offset.x = src.x;
+        imcopy.srcImage.offset.y = src.y;
+        imcopy.dstImage.offset.x = dst.x;
+        imcopy.dstImage.offset.y = dst.y;
+        if (src.width > dst.width) {
+            imcopy.srcImage.offset.x += (src.width - dst.width) / 2;
+        }
+        else {
+            imcopy.dstImage.offset.x += (dst.width - src.width) / 2;
+        }
+        if (src.height > dst.height) {
+            imcopy.srcImage.offset.y += (src.height - dst.height) / 2;
+        }
+        else {
+            imcopy.dstImage.offset.y += (dst.height - src.height) / 2;
+        }
+        imcopy.extent.x = std::min(src.width, dst.width);
+        imcopy.extent.y = std::min(src.height, dst.height);
+    }
+
+    commandBuffer->TransitionImageLayout(Next()->GetColorImage(imageIndex), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
+    {
+        // Clear screen.
+        grfx::RenderPassPtr renderPass = Next()->GetRenderPass(imageIndex, grfx::ATTACHMENT_LOAD_OP_CLEAR);
+
+        grfx::RenderPassBeginInfo beginInfo = {};
+        beginInfo.pRenderPass               = renderPass;
+        beginInfo.renderArea                = renderPass->GetRenderArea();
+        beginInfo.RTVClearCount             = 1;
+        beginInfo.RTVClearValues[0]         = {{0.5, 0.5, 0.5, 0}};
+        beginInfo.DSVClearValue             = {1.0f, 0xFF};
+
+        commandBuffer->BeginRenderPass(&beginInfo);
+        commandBuffer->EndRenderPass();
+    }
+    commandBuffer->TransitionImageLayout(Next()->GetColorImage(imageIndex), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_RENDER_TARGET, grfx::RESOURCE_STATE_COPY_DST);
+    {
+        // Copy rendered image.
+        grfx::Image* srcImage = RenderTarget::GetColorImage(imageIndex);
+        grfx::Image* dstImage = Next()->GetColorImage(imageIndex);
+        // Note(tianc): this should be a image blit instead of copy.
+        commandBuffer->CopyImageToImage(&imcopy, srcImage, dstImage);
+    }
+    commandBuffer->TransitionImageLayout(Next()->GetColorImage(imageIndex), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_COPY_DST, grfx::RESOURCE_STATE_PRESENT);
+}
+
+// -------------------------------------------------------------------------------------------------
+// RenderTargetPresentHook
+
+std::unique_ptr<RenderTargetPresentHook> RenderTargetPresentHook::Create(grfx::Queue* queue, RenderTarget* backing, std::function<void(grfx::CommandBuffer*)> f)
+{
+    std::unique_ptr<RenderTargetPresentHook> renderTarget(new RenderTargetPresentHook(backing, f));
+    PPX_CHECKED_CALL(renderTarget->Init(queue));
+    return renderTarget;
+}
+
+RenderTargetPresentHook::RenderTargetPresentHook(RenderTarget* backing, std::function<void(grfx::CommandBuffer*)> f)
+    : RenderTargetWrap(backing), mOnPresent(f)
+{
+}
+
+Result RenderTargetPresentHook::Init(grfx::Queue* queue)
+{
+    return mPresent.Init(queue, GetImageCount());
+}
+
+Result RenderTargetPresentHook::Present(
+    uint32_t                      imageIndex,
+    uint32_t                      waitSemaphoreCount,
+    const grfx::Semaphore* const* ppWaitSemaphores)
+{
+    return mPresent.Present(
+        mImpl,
+        imageIndex,
+        waitSemaphoreCount,
+        ppWaitSemaphores,
+        [this, imageIndex](grfx::CommandBuffer* commandBuffer) {
+            return RecordCommands(commandBuffer, imageIndex);
+        });
+}
+
+void RenderTargetPresentHook::RecordCommands(grfx::CommandBuffer* commandBuffer, uint32_t imageIndex)
+{
+    commandBuffer->TransitionImageLayout(mImpl->GetColorImage(imageIndex), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
+    {
+        grfx::RenderPassPtr renderPass = mImpl->GetRenderPass(imageIndex, grfx::ATTACHMENT_LOAD_OP_LOAD);
+
+        grfx::RenderPassBeginInfo beginInfo = {};
+        beginInfo.pRenderPass               = renderPass;
+        beginInfo.renderArea                = renderPass->GetRenderArea();
+        beginInfo.RTVClearCount             = 1;
+        beginInfo.RTVClearValues[0]         = {{0.5, 0.5, 0.5, 0}};
+        beginInfo.DSVClearValue             = {1.0f, 0xFF};
+
+        commandBuffer->BeginRenderPass(&beginInfo);
+        if (mOnPresent) {
+            commandBuffer->SetViewports(mImpl->GetViewport());
+            commandBuffer->SetScissors(mImpl->GetRenderArea());
+            mOnPresent(commandBuffer);
+        }
+        commandBuffer->EndRenderPass();
+    }
+    commandBuffer->TransitionImageLayout(mImpl->GetColorImage(imageIndex), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_RENDER_TARGET, grfx::RESOURCE_STATE_PRESENT);
+}
+
+} // namespace ppx


### PR DESCRIPTION
* Enable window resizing, resize/recreate depend on platform
* Enable offscreen framebuffer, and copy resulting image to swapchain
* Enable resize of viewport (the actual resize knob will be in a separate CL)

Note, this is still WIP, I'd like to have a review before I modify all of the samples/benchmark