### PR TITLE
Added a new buffer-based OIT algorithm

### DIFF
--- a/assets/oit_demo/shaders/BufferBucketsCombine.hlsl
+++ b/assets/oit_demo/shaders/BufferBucketsCombine.hlsl
@@ -22,15 +22,15 @@ RWTexture2D<uint2> FragmentTexture : register(CUSTOM_UAV_1_REGISTER);
 float4 psmain(VSOutput input) : SV_TARGET
 {
     const uint2 bucketIndex   = (uint2)input.position.xy;
-    const int fragmentCount   = min(min((int)CountTexture[bucketIndex], g_Globals.bufferBucketFragmentsMaxCount), BUFFER_BUCKET_SIZE_PER_PIXEL);
+    const int fragmentCount   = min(min((int)CountTexture[bucketIndex], g_Globals.bufferBucketsFragmentsMaxCount), BUFFER_BUCKETS_SIZE_PER_PIXEL);
     CountTexture[bucketIndex] = 0U; // Reset fragment count for the next frame
 
-    uint2 sortedFragments[BUFFER_BUCKET_SIZE_PER_PIXEL];
+    uint2 sortedFragments[BUFFER_BUCKETS_SIZE_PER_PIXEL];
 
     // Copy the fragments into local memory for sorting
     {
         uint2 fragmentIndex = bucketIndex;
-        fragmentIndex.y *= BUFFER_BUCKET_SIZE_PER_PIXEL;
+        fragmentIndex.y *= BUFFER_BUCKETS_SIZE_PER_PIXEL;
         for(int i = 0; i < fragmentCount; ++i)
         {
             sortedFragments[i] = FragmentTexture[fragmentIndex];

--- a/assets/oit_demo/shaders/BufferBucketsGather.hlsl
+++ b/assets/oit_demo/shaders/BufferBucketsGather.hlsl
@@ -34,14 +34,14 @@ void psmain(VSOutput input)
     InterlockedAdd(CountTexture[bucketIndex], 1U, nextBucketFragmentIndex);
 
     // Ignore the fragment if the bucket is already full
-    if(nextBucketFragmentIndex >= BUFFER_BUCKET_SIZE_PER_PIXEL)
+    if(nextBucketFragmentIndex >= BUFFER_BUCKETS_SIZE_PER_PIXEL)
     {
         clip(-1.0f);
     }
 
     // Add the fragment to the bucket
     uint2 textureFragmentIndex = bucketIndex;
-    textureFragmentIndex.y *= BUFFER_BUCKET_SIZE_PER_PIXEL;
+    textureFragmentIndex.y *= BUFFER_BUCKETS_SIZE_PER_PIXEL;
     textureFragmentIndex.y += nextBucketFragmentIndex;
     FragmentTexture[textureFragmentIndex] = uint2(PackColor(float4(input.color, g_Globals.meshOpacity)), asuint(input.position.z));
 }

--- a/assets/oit_demo/shaders/BufferBucketsGather.hlsl
+++ b/assets/oit_demo/shaders/BufferBucketsGather.hlsl
@@ -20,12 +20,6 @@ Texture2D          OpaqueDepthTexture : register(CUSTOM_TEXTURE_0_REGISTER);
 RWTexture2D<uint>  CountTexture       : register(CUSTOM_UAV_0_REGISTER);
 RWTexture2D<uint2> FragmentTexture    : register(CUSTOM_UAV_1_REGISTER);
 
-uint PackColor(float4 color)
-{
-    const uint4 ci = (uint4)(clamp(color, 0.0f, 1.0f) * 255.0f);
-    return (ci.r << 24) | (ci.g << 16) | (ci.b << 8) | ci.a;
-}
-
 void psmain(VSOutput input)
 {
     // Test fragment against opaque depth

--- a/assets/oit_demo/shaders/BufferLinkedListsCombine.hlsl
+++ b/assets/oit_demo/shaders/BufferLinkedListsCombine.hlsl
@@ -27,12 +27,12 @@ float4 psmain(VSOutput input) : SV_TARGET
 
     // Get the first fragment index in the linked list
     uint fragmentIndex = LinkedListHeadTexture[input.position.xy];
-    LinkedListHeadTexture[input.position.xy] = BUFFER_LINKED_LIST_INVALID_INDEX; // Reset the list head for the next frame
+    LinkedListHeadTexture[input.position.xy] = BUFFER_LISTS_INVALID_INDEX; // Reset the list head for the next frame
 
     // Copy the fragments into local memory for sorting
-    uint2 sortedFragments[BUFFER_LINKED_LIST_MAX_SIZE];
+    uint2 sortedFragments[BUFFER_LISTS_MAX_SIZE];
     uint fragmentCount = 0U;
-    while(fragmentIndex != BUFFER_LINKED_LIST_INVALID_INDEX && fragmentCount < BUFFER_LINKED_LIST_MAX_SIZE)
+    while(fragmentIndex != BUFFER_LISTS_INVALID_INDEX && fragmentCount < BUFFER_LISTS_MAX_SIZE)
     {
         const uint4 fragment = FragmentBuffer[fragmentIndex];
         fragmentIndex = fragment.z;

--- a/assets/oit_demo/shaders/BufferLinkedListsCombine.hlsl
+++ b/assets/oit_demo/shaders/BufferLinkedListsCombine.hlsl
@@ -30,9 +30,10 @@ float4 psmain(VSOutput input) : SV_TARGET
     LinkedListHeadTexture[input.position.xy] = BUFFER_LISTS_INVALID_INDEX; // Reset the list head for the next frame
 
     // Copy the fragments into local memory for sorting
-    uint2 sortedFragments[BUFFER_LISTS_MAX_SIZE];
+    uint2 sortedFragments[BUFFER_LISTS_SORTED_FRAGMENT_MAX_COUNT];
     uint fragmentCount = 0U;
-    while(fragmentIndex != BUFFER_LISTS_INVALID_INDEX && fragmentCount < BUFFER_LISTS_MAX_SIZE)
+    const uint sortedFragmentMaxCount = min(g_Globals.bufferListsSortedFragmentMaxCount, BUFFER_LISTS_SORTED_FRAGMENT_MAX_COUNT);
+    while(fragmentIndex != BUFFER_LISTS_INVALID_INDEX && fragmentCount < sortedFragmentMaxCount)
     {
         const uint4 fragment = FragmentBuffer[fragmentIndex];
         fragmentIndex = fragment.z;

--- a/assets/oit_demo/shaders/BufferLinkedListsGather.hlsl
+++ b/assets/oit_demo/shaders/BufferLinkedListsGather.hlsl
@@ -1,0 +1,51 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define IS_SHADER
+#include "Common.hlsli"
+#include "TransparencyVS.hlsli"
+
+Texture2D                 OpaqueDepthTexture    : register(CUSTOM_TEXTURE_0_REGISTER);
+RWTexture2D<uint>         LinkedListHeadTexture : register(CUSTOM_UAV_0_REGISTER);
+RWStructuredBuffer<uint4> FragmentBuffer        : register(CUSTOM_UAV_1_REGISTER);
+RWStructuredBuffer<uint>  AtomicCounter         : register(CUSTOM_UAV_2_REGISTER);
+
+void psmain(VSOutput input)
+{
+    // Test fragment against opaque depth
+    {
+        const float opaqueDepth = OpaqueDepthTexture.Load(int3(input.position.xy, 0)).r;
+        clip(input.position.z < opaqueDepth ? 1.0f : -1.0f);
+    }
+
+    // Find the next fragment index
+    uint nextFragmentIndex = 0;
+    InterlockedAdd(AtomicCounter[0], 1U, nextFragmentIndex);
+
+    // Ignore the fragment if the fragment buffer is full
+    uint fragmentBufferElementCount   = 0;
+    uint fragmentBufferStride         = 0;
+    FragmentBuffer.GetDimensions(fragmentBufferElementCount, fragmentBufferStride);
+    if(nextFragmentIndex >= fragmentBufferElementCount)
+    {
+        clip(-1.0f);
+    }
+
+    // Update the linked list head
+    uint previousFragmentIndex = 0;
+    InterlockedExchange(LinkedListHeadTexture[input.position.xy], nextFragmentIndex, previousFragmentIndex);
+
+    // Add the fragment to the buffer
+    FragmentBuffer[nextFragmentIndex] = uint4(PackColor(float4(input.color, g_Globals.meshOpacity)), asuint(input.position.z), previousFragmentIndex, 0U);
+}

--- a/assets/oit_demo/shaders/BufferLinkedListsGather.hlsl
+++ b/assets/oit_demo/shaders/BufferLinkedListsGather.hlsl
@@ -34,9 +34,10 @@ void psmain(VSOutput input)
     InterlockedAdd(AtomicCounter[0], 1U, nextFragmentIndex);
 
     // Ignore the fragment if the fragment buffer is full
-    uint fragmentBufferElementCount   = 0;
-    uint fragmentBufferStride         = 0;
-    FragmentBuffer.GetDimensions(fragmentBufferElementCount, fragmentBufferStride);
+    uint fragmentBufferMaxElementCount = 0;
+    uint fragmentBufferStride          = 0;
+    FragmentBuffer.GetDimensions(fragmentBufferMaxElementCount, fragmentBufferStride);
+    const uint fragmentBufferElementCount = min((fragmentBufferMaxElementCount / BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE) * g_Globals.bufferListsFragmentBufferScale, fragmentBufferMaxElementCount);
     if(nextFragmentIndex >= fragmentBufferElementCount)
     {
         clip(-1.0f);

--- a/assets/oit_demo/shaders/CMakeLists.txt
+++ b/assets/oit_demo/shaders/CMakeLists.txt
@@ -115,6 +115,18 @@ generate_rules_for_shader(
     INCLUDES ${FULLSCREEN_INCLUDE_FILES}
     STAGES "ps" "vs")
 
+generate_rules_for_shader(
+    "buffer_linked_lists_gather"
+    SOURCE "${PPX_DIR}/assets/oit_demo/shaders/BufferLinkedListsGather.hlsl"
+    INCLUDES ${TRANSPARENCY_INCLUDE_FILES}
+    STAGES "ps" "vs")
+
+generate_rules_for_shader(
+    "buffer_linked_lists_combine"
+    SOURCE "${PPX_DIR}/assets/oit_demo/shaders/BufferLinkedListsCombine.hlsl"
+    INCLUDES ${FULLSCREEN_INCLUDE_FILES}
+    STAGES "ps" "vs")
+
 ################################################################################
 
 generate_group_rule_for_shader(
@@ -132,6 +144,8 @@ generate_group_rule_for_shader(
     "depth_peeling_combine"
     "buffer_buckets_gather"
     "buffer_buckets_combine"
+    "buffer_linked_lists_gather"
+    "buffer_linked_lists_combine"
     "composite"
 )
 

--- a/assets/oit_demo/shaders/Common.hlsli
+++ b/assets/oit_demo/shaders/Common.hlsli
@@ -42,7 +42,7 @@
 #define BUFFER_BUCKETS_SIZE_PER_PIXEL           8
 
 #define BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE  8
-#define BUFFER_LISTS_MAX_SIZE                   64
+#define BUFFER_LISTS_SORTED_FRAGMENT_MAX_COUNT  64
 #define BUFFER_LISTS_INVALID_INDEX              0xFFFFFFFFU
 
 struct ShaderGlobals
@@ -60,7 +60,7 @@ struct ShaderGlobals
     int      depthPeelingBackLayerIndex;
     int      bufferBucketsFragmentsMaxCount;
     int      bufferListsFragmentBufferScale;
-    int      bufferListsMaxSize;
+    int      bufferListsSortedFragmentMaxCount;
     int      _intUnused0;
     int      _intUnused1;
     int      _intUnused2;

--- a/assets/oit_demo/shaders/Common.hlsli
+++ b/assets/oit_demo/shaders/Common.hlsli
@@ -36,14 +36,14 @@
 
 #define EPSILON 0.0001f
 
-#define DEPTH_PEELING_LAYERS_COUNT          8
-#define DEPTH_PEELING_DEPTH_TEXTURES_COUNT  2
+#define DEPTH_PEELING_LAYERS_COUNT              8
+#define DEPTH_PEELING_DEPTH_TEXTURES_COUNT      2
 
-#define BUFFER_BUCKET_SIZE_PER_PIXEL        8
+#define BUFFER_BUCKETS_SIZE_PER_PIXEL           8
 
-#define BUFFER_BUFFER_MAX_SCALE             8
-#define BUFFER_LINKED_LIST_MAX_SIZE         64
-#define BUFFER_LINKED_LIST_INVALID_INDEX    0xFFFFFFFFU
+#define BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE  8
+#define BUFFER_LISTS_MAX_SIZE                   64
+#define BUFFER_LISTS_INVALID_INDEX              0xFFFFFFFFU
 
 struct ShaderGlobals
 {
@@ -58,10 +58,9 @@ struct ShaderGlobals
 
     int      depthPeelingFrontLayerIndex;
     int      depthPeelingBackLayerIndex;
-    int      bufferBucketFragmentsMaxCount;
-    int      bufferFragmentBufferScale;
-
-    int      bufferLinkedListMaxSize;
+    int      bufferBucketsFragmentsMaxCount;
+    int      bufferListsFragmentBufferScale;
+    int      bufferListsMaxSize;
     int      _intUnused0;
     int      _intUnused1;
     int      _intUnused2;

--- a/assets/oit_demo/shaders/DepthPeelingCombine.hlsl
+++ b/assets/oit_demo/shaders/DepthPeelingCombine.hlsl
@@ -19,12 +19,6 @@
 SamplerState NearestSampler                            : register(CUSTOM_SAMPLER_0_REGISTER);
 Texture2D    LayerTextures[DEPTH_PEELING_LAYERS_COUNT] : register(CUSTOM_TEXTURE_0_REGISTER);
 
-void MergeColor(inout float4 outColor, float4 layerColor)
-{
-    outColor.rgb = lerp(outColor.rgb, layerColor.rgb, layerColor.a);
-    outColor.a *= 1.0f - layerColor.a;
-}
-
 float4 psmain(VSOutput input) : SV_TARGET
 {
     float4 color = float4(0.0f, 0.0f, 0.0f, 1.0f);

--- a/projects/oit_demo/Buffer.cpp
+++ b/projects/oit_demo/Buffer.cpp
@@ -222,6 +222,8 @@ void OITDemoApp::SetupBufferBuckets()
 
 void OITDemoApp::SetupBufferLinkedLists()
 {
+    mBuffer.lists.linkedListHeadTextureNeedClear = true;
+
     // Linked list head texture
     {
         grfx::TextureCreateInfo createInfo         = {};
@@ -536,8 +538,7 @@ void OITDemoApp::RecordBufferBuckets()
 
 void OITDemoApp::RecordBufferLinkedLists()
 {
-    static bool sListsTextureNeedClear = true;
-    if (sListsTextureNeedClear) {
+    if (mBuffer.lists.linkedListHeadTextureNeedClear) {
         mCommandBuffer->TransitionImageLayout(
             mBuffer.lists.clearPass,
             grfx::RESOURCE_STATE_SHADER_RESOURCE,
@@ -557,7 +558,7 @@ void OITDemoApp::RecordBufferLinkedLists()
             grfx::RESOURCE_STATE_SHADER_RESOURCE,
             grfx::RESOURCE_STATE_SHADER_RESOURCE);
 
-        sListsTextureNeedClear = false;
+        mBuffer.lists.linkedListHeadTextureNeedClear = false;
     }
 
     {

--- a/projects/oit_demo/Buffer.cpp
+++ b/projects/oit_demo/Buffer.cpp
@@ -249,23 +249,23 @@ void OITDemoApp::SetupBufferLinkedLists()
 
     // Fragment buffer
     {
-        grfx::BufferCreateInfo bufferCreateInfo           = {};
-        bufferCreateInfo.size                             = fragmentBufferSize;
-        bufferCreateInfo.structuredElementStride          = fragmentBufferElementSize;
-        bufferCreateInfo.usageFlags.bits.structuredBuffer = true;
-        bufferCreateInfo.memoryUsage                      = grfx::MEMORY_USAGE_GPU_ONLY;
-        bufferCreateInfo.initialState                     = grfx::RESOURCE_STATE_GENERAL;
+        grfx::BufferCreateInfo bufferCreateInfo             = {};
+        bufferCreateInfo.size                               = fragmentBufferSize;
+        bufferCreateInfo.structuredElementStride            = fragmentBufferElementSize;
+        bufferCreateInfo.usageFlags.bits.rwStructuredBuffer = true;
+        bufferCreateInfo.memoryUsage                        = grfx::MEMORY_USAGE_GPU_ONLY;
+        bufferCreateInfo.initialState                       = grfx::RESOURCE_STATE_GENERAL;
         PPX_CHECKED_CALL(GetDevice()->CreateBuffer(&bufferCreateInfo, &mBuffer.lists.fragmentBuffer));
     }
 
     // Atomic counter
     {
-        grfx::BufferCreateInfo bufferCreateInfo           = {};
-        bufferCreateInfo.size                             = std::max(sizeof(uint), static_cast<size_t>(PPX_MINIMUM_UNIFORM_BUFFER_SIZE));
-        bufferCreateInfo.structuredElementStride          = sizeof(uint);
-        bufferCreateInfo.usageFlags.bits.structuredBuffer = true;
-        bufferCreateInfo.memoryUsage                      = grfx::MEMORY_USAGE_GPU_ONLY;
-        bufferCreateInfo.initialState                     = grfx::RESOURCE_STATE_GENERAL;
+        grfx::BufferCreateInfo bufferCreateInfo             = {};
+        bufferCreateInfo.size                               = std::max(sizeof(uint), static_cast<size_t>(PPX_MINIMUM_UNIFORM_BUFFER_SIZE));
+        bufferCreateInfo.structuredElementStride            = sizeof(uint);
+        bufferCreateInfo.usageFlags.bits.rwStructuredBuffer = true;
+        bufferCreateInfo.memoryUsage                        = grfx::MEMORY_USAGE_GPU_ONLY;
+        bufferCreateInfo.initialState                       = grfx::RESOURCE_STATE_GENERAL;
         PPX_CHECKED_CALL(GetDevice()->CreateBuffer(&bufferCreateInfo, &mBuffer.lists.atomicCounter));
     }
 
@@ -304,8 +304,8 @@ void OITDemoApp::SetupBufferLinkedLists()
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{SHADER_GLOBALS_REGISTER, grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_TEXTURE_0_REGISTER, grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_0_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
-        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_1_REGISTER, grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
-        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_2_REGISTER, grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_1_REGISTER, grfx::DESCRIPTOR_TYPE_RW_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_2_REGISTER, grfx::DESCRIPTOR_TYPE_RW_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
         PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mBuffer.lists.gatherDescriptorSetLayout));
 
         PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mBuffer.lists.gatherDescriptorSetLayout, &mBuffer.lists.gatherDescriptorSet));
@@ -329,14 +329,14 @@ void OITDemoApp::SetupBufferLinkedLists()
         writes[2].pImageView = mBuffer.lists.linkedListHeadTexture->GetStorageImageView();
 
         writes[3].binding                = CUSTOM_UAV_1_REGISTER;
-        writes[3].type                   = grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER;
+        writes[3].type                   = grfx::DESCRIPTOR_TYPE_RW_STRUCTURED_BUFFER;
         writes[3].bufferOffset           = 0;
         writes[3].bufferRange            = PPX_WHOLE_SIZE;
         writes[3].structuredElementCount = fragmentBufferElementCount;
         writes[3].pBuffer                = mBuffer.lists.fragmentBuffer;
 
         writes[4].binding                = CUSTOM_UAV_2_REGISTER;
-        writes[4].type                   = grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER;
+        writes[4].type                   = grfx::DESCRIPTOR_TYPE_RW_STRUCTURED_BUFFER;
         writes[4].bufferOffset           = 0;
         writes[4].bufferRange            = PPX_WHOLE_SIZE;
         writes[4].structuredElementCount = 1;
@@ -386,8 +386,8 @@ void OITDemoApp::SetupBufferLinkedLists()
         grfx::DescriptorSetLayoutCreateInfo layoutCreateInfo = {};
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{SHADER_GLOBALS_REGISTER, grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_0_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
-        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_1_REGISTER, grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
-        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_2_REGISTER, grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_1_REGISTER, grfx::DESCRIPTOR_TYPE_RW_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_2_REGISTER, grfx::DESCRIPTOR_TYPE_RW_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
         PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mBuffer.lists.combineDescriptorSetLayout));
 
         PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mBuffer.lists.combineDescriptorSetLayout, &mBuffer.lists.combineDescriptorSet));
@@ -406,14 +406,14 @@ void OITDemoApp::SetupBufferLinkedLists()
         writes[1].pImageView = mBuffer.lists.linkedListHeadTexture->GetStorageImageView();
 
         writes[2].binding                = CUSTOM_UAV_1_REGISTER;
-        writes[2].type                   = grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER;
+        writes[2].type                   = grfx::DESCRIPTOR_TYPE_RW_STRUCTURED_BUFFER;
         writes[2].bufferOffset           = 0;
         writes[2].bufferRange            = PPX_WHOLE_SIZE;
         writes[2].structuredElementCount = fragmentBufferElementCount;
         writes[2].pBuffer                = mBuffer.lists.fragmentBuffer;
 
         writes[3].binding                = CUSTOM_UAV_2_REGISTER;
-        writes[3].type                   = grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER;
+        writes[3].type                   = grfx::DESCRIPTOR_TYPE_RW_STRUCTURED_BUFFER;
         writes[3].bufferOffset           = 0;
         writes[3].bufferRange            = PPX_WHOLE_SIZE;
         writes[3].structuredElementCount = 1;

--- a/projects/oit_demo/Buffer.cpp
+++ b/projects/oit_demo/Buffer.cpp
@@ -42,7 +42,7 @@ void OITDemoApp::SetupBufferBuckets()
         grfx::TextureCreateInfo createInfo = {};
         createInfo.imageType               = grfx::IMAGE_TYPE_2D;
         createInfo.width                   = mBuffer.buckets.countTexture->GetWidth();
-        createInfo.height                  = mBuffer.buckets.countTexture->GetHeight() * BUFFER_BUCKET_SIZE_PER_PIXEL;
+        createInfo.height                  = mBuffer.buckets.countTexture->GetHeight() * BUFFER_BUCKETS_SIZE_PER_PIXEL;
         createInfo.depth                   = 1;
         createInfo.imageFormat             = grfx::FORMAT_R32G32_UINT;
         createInfo.sampleCount             = grfx::SAMPLE_COUNT_1;
@@ -243,7 +243,7 @@ void OITDemoApp::SetupBufferLinkedLists()
         PPX_CHECKED_CALL(GetDevice()->CreateTexture(&createInfo, &mBuffer.lists.linkedListHeadTexture));
     }
 
-    const uint32_t fragmentBufferElementCount = mTransparencyTexture->GetWidth() * mTransparencyTexture->GetHeight() * BUFFER_BUFFER_MAX_SCALE;
+    const uint32_t fragmentBufferElementCount = mTransparencyTexture->GetWidth() * mTransparencyTexture->GetHeight() * BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE;
     const uint32_t fragmentBufferElementSize  = static_cast<uint32_t>(sizeof(uint4));
     const uint32_t fragmentBufferSize         = fragmentBufferElementCount * fragmentBufferElementSize;
 
@@ -271,7 +271,7 @@ void OITDemoApp::SetupBufferLinkedLists()
 
     // Clear pass
     {
-        constexpr uint            clearValueUint  = BUFFER_LINKED_LIST_INVALID_INDEX;
+        constexpr uint            clearValueUint  = BUFFER_LISTS_INVALID_INDEX;
         const float               clearValueFloat = *reinterpret_cast<const float*>(&clearValueUint);
         grfx::DrawPassCreateInfo2 createInfo      = {};
         createInfo.width                          = mBuffer.lists.linkedListHeadTexture->GetWidth();

--- a/projects/oit_demo/Buffer.cpp
+++ b/projects/oit_demo/Buffer.cpp
@@ -14,9 +14,9 @@
 
 #include "OITDemoApplication.h"
 
-void OITDemoApp::SetupBuffer()
+void OITDemoApp::SetupBufferBuckets()
 {
-    mBuffer.countTextureNeedClear = true;
+    mBuffer.buckets.countTextureNeedClear = true;
 
     // Count texture
     {
@@ -34,15 +34,15 @@ void OITDemoApp::SetupBuffer()
         createInfo.memoryUsage                     = grfx::MEMORY_USAGE_GPU_ONLY;
         createInfo.initialState                    = grfx::RESOURCE_STATE_SHADER_RESOURCE;
 
-        PPX_CHECKED_CALL(GetDevice()->CreateTexture(&createInfo, &mBuffer.countTexture));
+        PPX_CHECKED_CALL(GetDevice()->CreateTexture(&createInfo, &mBuffer.buckets.countTexture));
     }
 
     // Fragment texture
     {
         grfx::TextureCreateInfo createInfo = {};
         createInfo.imageType               = grfx::IMAGE_TYPE_2D;
-        createInfo.width                   = mBuffer.countTexture->GetWidth();
-        createInfo.height                  = mBuffer.countTexture->GetHeight() * BUFFER_BUCKET_SIZE_PER_PIXEL;
+        createInfo.width                   = mBuffer.buckets.countTexture->GetWidth();
+        createInfo.height                  = mBuffer.buckets.countTexture->GetHeight() * BUFFER_BUCKET_SIZE_PER_PIXEL;
         createInfo.depth                   = 1;
         createInfo.imageFormat             = grfx::FORMAT_R32G32_UINT;
         createInfo.sampleCount             = grfx::SAMPLE_COUNT_1;
@@ -52,29 +52,30 @@ void OITDemoApp::SetupBuffer()
         createInfo.memoryUsage             = grfx::MEMORY_USAGE_GPU_ONLY;
         createInfo.initialState            = grfx::RESOURCE_STATE_SHADER_RESOURCE;
 
-        PPX_CHECKED_CALL(GetDevice()->CreateTexture(&createInfo, &mBuffer.fragmentTexture));
+        PPX_CHECKED_CALL(GetDevice()->CreateTexture(&createInfo, &mBuffer.buckets.fragmentTexture));
     }
 
     // Clear pass
     {
         grfx::DrawPassCreateInfo2 createInfo  = {};
-        createInfo.width                      = mBuffer.countTexture->GetWidth();
-        createInfo.height                     = mBuffer.countTexture->GetHeight();
+        createInfo.width                      = mBuffer.buckets.countTexture->GetWidth();
+        createInfo.height                     = mBuffer.buckets.countTexture->GetHeight();
         createInfo.renderTargetCount          = 1;
-        createInfo.pRenderTargetImages[0]     = mBuffer.countTexture->GetImage();
+        createInfo.pRenderTargetImages[0]     = mBuffer.buckets.countTexture->GetImage();
         createInfo.pDepthStencilImage         = nullptr;
         createInfo.renderTargetClearValues[0] = {0, 0, 0, 0};
-        PPX_CHECKED_CALL(GetDevice()->CreateDrawPass(&createInfo, &mBuffer.clearPass));
+        PPX_CHECKED_CALL(GetDevice()->CreateDrawPass(&createInfo, &mBuffer.buckets.clearPass));
     }
 
     // Gather pass
     {
-        grfx::DrawPassCreateInfo2 createInfo = {};
-        createInfo.width                     = mBuffer.countTexture->GetWidth();
-        createInfo.height                    = mBuffer.countTexture->GetHeight();
-        createInfo.renderTargetCount         = 0;
-        createInfo.pDepthStencilImage        = nullptr;
-        PPX_CHECKED_CALL(GetDevice()->CreateDrawPass(&createInfo, &mBuffer.gatherPass));
+        grfx::DrawPassCreateInfo2 createInfo  = {};
+        createInfo.width                      = mBuffer.buckets.countTexture->GetWidth();
+        createInfo.height                     = mBuffer.buckets.countTexture->GetHeight();
+        createInfo.renderTargetCount          = 0;
+        createInfo.pDepthStencilImage         = nullptr;
+        createInfo.renderTargetClearValues[0] = {0, 0, 0, 0};
+        PPX_CHECKED_CALL(GetDevice()->CreateDrawPass(&createInfo, &mBuffer.buckets.gatherPass));
     }
 
     ////////////////////////////////////////
@@ -88,9 +89,9 @@ void OITDemoApp::SetupBuffer()
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_TEXTURE_0_REGISTER, grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_0_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_1_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
-        PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mBuffer.gatherDescriptorSetLayout));
+        PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mBuffer.buckets.gatherDescriptorSetLayout));
 
-        PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mBuffer.gatherDescriptorSetLayout, &mBuffer.gatherDescriptorSet));
+        PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mBuffer.buckets.gatherDescriptorSetLayout, &mBuffer.buckets.gatherDescriptorSet));
 
         std::array<grfx::WriteDescriptor, 4> writes = {};
 
@@ -108,14 +109,14 @@ void OITDemoApp::SetupBuffer()
         writes[2].binding    = CUSTOM_UAV_0_REGISTER;
         writes[2].arrayIndex = 0;
         writes[2].type       = grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        writes[2].pImageView = mBuffer.countTexture->GetStorageImageView();
+        writes[2].pImageView = mBuffer.buckets.countTexture->GetStorageImageView();
 
         writes[3].binding    = CUSTOM_UAV_1_REGISTER;
         writes[3].arrayIndex = 0;
         writes[3].type       = grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        writes[3].pImageView = mBuffer.fragmentTexture->GetStorageImageView();
+        writes[3].pImageView = mBuffer.buckets.fragmentTexture->GetStorageImageView();
 
-        PPX_CHECKED_CALL(mBuffer.gatherDescriptorSet->UpdateDescriptors(static_cast<uint32_t>(writes.size()), writes.data()));
+        PPX_CHECKED_CALL(mBuffer.buckets.gatherDescriptorSet->UpdateDescriptors(static_cast<uint32_t>(writes.size()), writes.data()));
     }
 
     // Pipeline
@@ -123,8 +124,8 @@ void OITDemoApp::SetupBuffer()
         grfx::PipelineInterfaceCreateInfo piCreateInfo = {};
         piCreateInfo.setCount                          = 1;
         piCreateInfo.sets[0].set                       = 0;
-        piCreateInfo.sets[0].pLayout                   = mBuffer.gatherDescriptorSetLayout;
-        PPX_CHECKED_CALL(GetDevice()->CreatePipelineInterface(&piCreateInfo, &mBuffer.gatherPipelineInterface));
+        piCreateInfo.sets[0].pLayout                   = mBuffer.buckets.gatherDescriptorSetLayout;
+        PPX_CHECKED_CALL(GetDevice()->CreatePipelineInterface(&piCreateInfo, &mBuffer.buckets.gatherPipelineInterface));
 
         grfx::ShaderModulePtr VS, PS;
         PPX_CHECKED_CALL(CreateShader("oit_demo/shaders", "BufferBucketsGather.vs", &VS));
@@ -143,8 +144,8 @@ void OITDemoApp::SetupBuffer()
         gpCreateInfo.depthWriteEnable                  = false;
         gpCreateInfo.blendModes[0]                     = grfx::BLEND_MODE_NONE;
         gpCreateInfo.outputState.renderTargetCount     = 0;
-        gpCreateInfo.pPipelineInterface                = mBuffer.gatherPipelineInterface;
-        PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mBuffer.gatherPipeline));
+        gpCreateInfo.pPipelineInterface                = mBuffer.buckets.gatherPipelineInterface;
+        PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mBuffer.buckets.gatherPipeline));
 
         GetDevice()->DestroyShaderModule(VS);
         GetDevice()->DestroyShaderModule(PS);
@@ -160,9 +161,9 @@ void OITDemoApp::SetupBuffer()
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{SHADER_GLOBALS_REGISTER, grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_0_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_1_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
-        PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mBuffer.combineDescriptorSetLayout));
+        PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mBuffer.buckets.combineDescriptorSetLayout));
 
-        PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mBuffer.combineDescriptorSetLayout, &mBuffer.combineDescriptorSet));
+        PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mBuffer.buckets.combineDescriptorSetLayout, &mBuffer.buckets.combineDescriptorSet));
 
         std::array<grfx::WriteDescriptor, 3> writes = {};
 
@@ -175,14 +176,14 @@ void OITDemoApp::SetupBuffer()
         writes[1].binding    = CUSTOM_UAV_0_REGISTER;
         writes[1].arrayIndex = 0;
         writes[1].type       = grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        writes[1].pImageView = mBuffer.countTexture->GetStorageImageView();
+        writes[1].pImageView = mBuffer.buckets.countTexture->GetStorageImageView();
 
         writes[2].binding    = CUSTOM_UAV_1_REGISTER;
         writes[2].arrayIndex = 0;
         writes[2].type       = grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        writes[2].pImageView = mBuffer.fragmentTexture->GetStorageImageView();
+        writes[2].pImageView = mBuffer.buckets.fragmentTexture->GetStorageImageView();
 
-        PPX_CHECKED_CALL(mBuffer.combineDescriptorSet->UpdateDescriptors(static_cast<uint32_t>(writes.size()), writes.data()));
+        PPX_CHECKED_CALL(mBuffer.buckets.combineDescriptorSet->UpdateDescriptors(static_cast<uint32_t>(writes.size()), writes.data()));
     }
 
     // Pipeline
@@ -190,8 +191,8 @@ void OITDemoApp::SetupBuffer()
         grfx::PipelineInterfaceCreateInfo piCreateInfo = {};
         piCreateInfo.setCount                          = 1;
         piCreateInfo.sets[0].set                       = 0;
-        piCreateInfo.sets[0].pLayout                   = mBuffer.combineDescriptorSetLayout;
-        PPX_CHECKED_CALL(GetDevice()->CreatePipelineInterface(&piCreateInfo, &mBuffer.combinePipelineInterface));
+        piCreateInfo.sets[0].pLayout                   = mBuffer.buckets.combineDescriptorSetLayout;
+        PPX_CHECKED_CALL(GetDevice()->CreatePipelineInterface(&piCreateInfo, &mBuffer.buckets.combinePipelineInterface));
 
         grfx::ShaderModulePtr VS, PS;
         PPX_CHECKED_CALL(CreateShader("oit_demo/shaders", "BufferBucketsCombine.vs", &VS));
@@ -211,61 +212,301 @@ void OITDemoApp::SetupBuffer()
         gpCreateInfo.outputState.renderTargetCount      = 1;
         gpCreateInfo.outputState.renderTargetFormats[0] = mTransparencyPass->GetRenderTargetTexture(0)->GetImageFormat();
         gpCreateInfo.outputState.depthStencilFormat     = mTransparencyPass->GetDepthStencilTexture()->GetImageFormat();
-        gpCreateInfo.pPipelineInterface                 = mBuffer.combinePipelineInterface;
-        PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mBuffer.combinePipeline));
+        gpCreateInfo.pPipelineInterface                 = mBuffer.buckets.combinePipelineInterface;
+        PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mBuffer.buckets.combinePipeline));
 
         GetDevice()->DestroyShaderModule(VS);
         GetDevice()->DestroyShaderModule(PS);
     }
 }
 
-void OITDemoApp::RecordBuffer()
+void OITDemoApp::SetupBufferLinkedLists()
 {
-    if (mBuffer.countTextureNeedClear) {
+    // Linked list head texture
+    {
+        grfx::TextureCreateInfo createInfo         = {};
+        createInfo.imageType                       = grfx::IMAGE_TYPE_2D;
+        createInfo.width                           = mTransparencyTexture->GetWidth();
+        createInfo.height                          = mTransparencyTexture->GetHeight();
+        createInfo.depth                           = 1;
+        createInfo.imageFormat                     = grfx::FORMAT_R32_UINT;
+        createInfo.sampleCount                     = grfx::SAMPLE_COUNT_1;
+        createInfo.mipLevelCount                   = 1;
+        createInfo.arrayLayerCount                 = 1;
+        createInfo.usageFlags.bits.colorAttachment = true;
+        createInfo.usageFlags.bits.storage         = true;
+        createInfo.memoryUsage                     = grfx::MEMORY_USAGE_GPU_ONLY;
+        createInfo.initialState                    = grfx::RESOURCE_STATE_SHADER_RESOURCE;
+
+        PPX_CHECKED_CALL(GetDevice()->CreateTexture(&createInfo, &mBuffer.lists.linkedListHeadTexture));
+    }
+
+    const uint32_t fragmentBufferElementCount = mTransparencyTexture->GetWidth() * mTransparencyTexture->GetHeight() * BUFFER_BUFFER_MAX_SCALE;
+    const uint32_t fragmentBufferElementSize  = static_cast<uint32_t>(sizeof(uint4));
+    const uint32_t fragmentBufferSize         = fragmentBufferElementCount * fragmentBufferElementSize;
+
+    // Fragment buffer
+    {
+        grfx::BufferCreateInfo bufferCreateInfo           = {};
+        bufferCreateInfo.size                             = fragmentBufferSize;
+        bufferCreateInfo.structuredElementStride          = fragmentBufferElementSize;
+        bufferCreateInfo.usageFlags.bits.structuredBuffer = true;
+        bufferCreateInfo.memoryUsage                      = grfx::MEMORY_USAGE_GPU_ONLY;
+        bufferCreateInfo.initialState                     = grfx::RESOURCE_STATE_GENERAL;
+        PPX_CHECKED_CALL(GetDevice()->CreateBuffer(&bufferCreateInfo, &mBuffer.lists.fragmentBuffer));
+    }
+
+    // Atomic counter
+    {
+        grfx::BufferCreateInfo bufferCreateInfo           = {};
+        bufferCreateInfo.size                             = std::max(sizeof(uint), static_cast<size_t>(PPX_MINIMUM_UNIFORM_BUFFER_SIZE));
+        bufferCreateInfo.structuredElementStride          = sizeof(uint);
+        bufferCreateInfo.usageFlags.bits.structuredBuffer = true;
+        bufferCreateInfo.memoryUsage                      = grfx::MEMORY_USAGE_GPU_ONLY;
+        bufferCreateInfo.initialState                     = grfx::RESOURCE_STATE_GENERAL;
+        PPX_CHECKED_CALL(GetDevice()->CreateBuffer(&bufferCreateInfo, &mBuffer.lists.atomicCounter));
+    }
+
+    // Clear pass
+    {
+        constexpr uint            clearValueUint  = BUFFER_LINKED_LIST_INVALID_INDEX;
+        const float               clearValueFloat = *reinterpret_cast<const float*>(&clearValueUint);
+        grfx::DrawPassCreateInfo2 createInfo      = {};
+        createInfo.width                          = mBuffer.lists.linkedListHeadTexture->GetWidth();
+        createInfo.height                         = mBuffer.lists.linkedListHeadTexture->GetHeight();
+        createInfo.renderTargetCount              = 1;
+        createInfo.pRenderTargetImages[0]         = mBuffer.lists.linkedListHeadTexture->GetImage();
+        createInfo.pDepthStencilImage             = nullptr;
+        createInfo.renderTargetClearValues[0]     = {clearValueFloat, 0, 0, 0};
+        PPX_CHECKED_CALL(GetDevice()->CreateDrawPass(&createInfo, &mBuffer.lists.clearPass));
+    }
+
+    // Gather pass
+    {
+        grfx::DrawPassCreateInfo2 createInfo  = {};
+        createInfo.width                      = mBuffer.lists.linkedListHeadTexture->GetWidth();
+        createInfo.height                     = mBuffer.lists.linkedListHeadTexture->GetHeight();
+        createInfo.renderTargetCount          = 0;
+        createInfo.pDepthStencilImage         = nullptr;
+        createInfo.renderTargetClearValues[0] = {0, 0, 0, 0};
+        PPX_CHECKED_CALL(GetDevice()->CreateDrawPass(&createInfo, &mBuffer.lists.gatherPass));
+    }
+
+    ////////////////////////////////////////
+    // Gather
+    ////////////////////////////////////////
+
+    // Descriptor
+    {
+        grfx::DescriptorSetLayoutCreateInfo layoutCreateInfo = {};
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{SHADER_GLOBALS_REGISTER, grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_TEXTURE_0_REGISTER, grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_0_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_1_REGISTER, grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_2_REGISTER, grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mBuffer.lists.gatherDescriptorSetLayout));
+
+        PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mBuffer.lists.gatherDescriptorSetLayout, &mBuffer.lists.gatherDescriptorSet));
+
+        grfx::WriteDescriptor writes[5] = {};
+
+        writes[0].binding      = SHADER_GLOBALS_REGISTER;
+        writes[0].type         = grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        writes[0].bufferOffset = 0;
+        writes[0].bufferRange  = PPX_WHOLE_SIZE;
+        writes[0].pBuffer      = mShaderGlobalsBuffer;
+
+        writes[1].binding    = CUSTOM_TEXTURE_0_REGISTER;
+        writes[1].arrayIndex = 0;
+        writes[1].type       = grfx::DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+        writes[1].pImageView = mOpaquePass->GetDepthStencilTexture()->GetSampledImageView();
+
+        writes[2].binding    = CUSTOM_UAV_0_REGISTER;
+        writes[2].arrayIndex = 0;
+        writes[2].type       = grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        writes[2].pImageView = mBuffer.lists.linkedListHeadTexture->GetStorageImageView();
+
+        writes[3].binding                = CUSTOM_UAV_1_REGISTER;
+        writes[3].type                   = grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER;
+        writes[3].bufferOffset           = 0;
+        writes[3].bufferRange            = PPX_WHOLE_SIZE;
+        writes[3].structuredElementCount = fragmentBufferElementCount;
+        writes[3].pBuffer                = mBuffer.lists.fragmentBuffer;
+
+        writes[4].binding                = CUSTOM_UAV_2_REGISTER;
+        writes[4].type                   = grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER;
+        writes[4].bufferOffset           = 0;
+        writes[4].bufferRange            = PPX_WHOLE_SIZE;
+        writes[4].structuredElementCount = 1;
+        writes[4].pBuffer                = mBuffer.lists.atomicCounter;
+
+        PPX_CHECKED_CALL(mBuffer.lists.gatherDescriptorSet->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
+    }
+
+    // Pipeline
+    {
+        grfx::PipelineInterfaceCreateInfo piCreateInfo = {};
+        piCreateInfo.setCount                          = 1;
+        piCreateInfo.sets[0].set                       = 0;
+        piCreateInfo.sets[0].pLayout                   = mBuffer.lists.gatherDescriptorSetLayout;
+        PPX_CHECKED_CALL(GetDevice()->CreatePipelineInterface(&piCreateInfo, &mBuffer.lists.gatherPipelineInterface));
+
+        grfx::ShaderModulePtr VS, PS;
+        PPX_CHECKED_CALL(CreateShader("oit_demo/shaders", "BufferLinkedListsGather.vs", &VS));
+        PPX_CHECKED_CALL(CreateShader("oit_demo/shaders", "BufferLinkedListsGather.ps", &PS));
+
+        grfx::GraphicsPipelineCreateInfo2 gpCreateInfo = {};
+        gpCreateInfo.VS                                = {VS, "vsmain"};
+        gpCreateInfo.PS                                = {PS, "psmain"};
+        gpCreateInfo.vertexInputState.bindingCount     = 1;
+        gpCreateInfo.vertexInputState.bindings[0]      = GetTransparentMesh()->GetDerivedVertexBindings()[0];
+        gpCreateInfo.topology                          = grfx::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        gpCreateInfo.polygonMode                       = grfx::POLYGON_MODE_FILL;
+        gpCreateInfo.cullMode                          = grfx::CULL_MODE_NONE;
+        gpCreateInfo.frontFace                         = grfx::FRONT_FACE_CCW;
+        gpCreateInfo.depthReadEnable                   = false;
+        gpCreateInfo.depthWriteEnable                  = false;
+        gpCreateInfo.blendModes[0]                     = grfx::BLEND_MODE_NONE;
+        gpCreateInfo.outputState.renderTargetCount     = 0;
+        gpCreateInfo.pPipelineInterface                = mBuffer.lists.gatherPipelineInterface;
+        PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mBuffer.lists.gatherPipeline));
+
+        GetDevice()->DestroyShaderModule(VS);
+        GetDevice()->DestroyShaderModule(PS);
+    }
+
+    ////////////////////////////////////////
+    // Combine
+    ////////////////////////////////////////
+
+    // Descriptor
+    {
+        grfx::DescriptorSetLayoutCreateInfo layoutCreateInfo = {};
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{SHADER_GLOBALS_REGISTER, grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_0_REGISTER, grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_1_REGISTER, grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{CUSTOM_UAV_2_REGISTER, grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
+        PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mBuffer.lists.combineDescriptorSetLayout));
+
+        PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mBuffer.lists.combineDescriptorSetLayout, &mBuffer.lists.combineDescriptorSet));
+
+        grfx::WriteDescriptor writes[4] = {};
+
+        writes[0].binding      = SHADER_GLOBALS_REGISTER;
+        writes[0].type         = grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        writes[0].bufferOffset = 0;
+        writes[0].bufferRange  = PPX_WHOLE_SIZE;
+        writes[0].pBuffer      = mShaderGlobalsBuffer;
+
+        writes[1].binding    = CUSTOM_UAV_0_REGISTER;
+        writes[1].arrayIndex = 0;
+        writes[1].type       = grfx::DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        writes[1].pImageView = mBuffer.lists.linkedListHeadTexture->GetStorageImageView();
+
+        writes[2].binding                = CUSTOM_UAV_1_REGISTER;
+        writes[2].type                   = grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER;
+        writes[2].bufferOffset           = 0;
+        writes[2].bufferRange            = PPX_WHOLE_SIZE;
+        writes[2].structuredElementCount = fragmentBufferElementCount;
+        writes[2].pBuffer                = mBuffer.lists.fragmentBuffer;
+
+        writes[3].binding                = CUSTOM_UAV_2_REGISTER;
+        writes[3].type                   = grfx::DESCRIPTOR_TYPE_STRUCTURED_BUFFER;
+        writes[3].bufferOffset           = 0;
+        writes[3].bufferRange            = PPX_WHOLE_SIZE;
+        writes[3].structuredElementCount = 1;
+        writes[3].pBuffer                = mBuffer.lists.atomicCounter;
+
+        PPX_CHECKED_CALL(mBuffer.lists.combineDescriptorSet->UpdateDescriptors(sizeof(writes) / sizeof(writes[0]), writes));
+    }
+
+    // Pipeline
+    {
+        grfx::PipelineInterfaceCreateInfo piCreateInfo = {};
+        piCreateInfo.setCount                          = 1;
+        piCreateInfo.sets[0].set                       = 0;
+        piCreateInfo.sets[0].pLayout                   = mBuffer.lists.combineDescriptorSetLayout;
+        PPX_CHECKED_CALL(GetDevice()->CreatePipelineInterface(&piCreateInfo, &mBuffer.lists.combinePipelineInterface));
+
+        grfx::ShaderModulePtr VS, PS;
+        PPX_CHECKED_CALL(CreateShader("oit_demo/shaders", "BufferLinkedListsCombine.vs", &VS));
+        PPX_CHECKED_CALL(CreateShader("oit_demo/shaders", "BufferLinkedListsCombine.ps", &PS));
+
+        grfx::GraphicsPipelineCreateInfo2 gpCreateInfo  = {};
+        gpCreateInfo.VS                                 = {VS, "vsmain"};
+        gpCreateInfo.PS                                 = {PS, "psmain"};
+        gpCreateInfo.vertexInputState.bindingCount      = 0;
+        gpCreateInfo.topology                           = grfx::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        gpCreateInfo.polygonMode                        = grfx::POLYGON_MODE_FILL;
+        gpCreateInfo.cullMode                           = grfx::CULL_MODE_BACK;
+        gpCreateInfo.frontFace                          = grfx::FRONT_FACE_CCW;
+        gpCreateInfo.depthReadEnable                    = false;
+        gpCreateInfo.depthWriteEnable                   = false;
+        gpCreateInfo.blendModes[0]                      = grfx::BLEND_MODE_NONE;
+        gpCreateInfo.outputState.renderTargetCount      = 1;
+        gpCreateInfo.outputState.renderTargetFormats[0] = mTransparencyPass->GetRenderTargetTexture(0)->GetImageFormat();
+        gpCreateInfo.outputState.depthStencilFormat     = mTransparencyPass->GetDepthStencilTexture()->GetImageFormat();
+        gpCreateInfo.pPipelineInterface                 = mBuffer.lists.combinePipelineInterface;
+        PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mBuffer.lists.combinePipeline));
+
+        GetDevice()->DestroyShaderModule(VS);
+        GetDevice()->DestroyShaderModule(PS);
+    }
+}
+
+void OITDemoApp::SetupBuffer()
+{
+    SetupBufferBuckets();
+    SetupBufferLinkedLists();
+}
+
+void OITDemoApp::RecordBufferBuckets()
+{
+    if (mBuffer.buckets.countTextureNeedClear) {
         mCommandBuffer->TransitionImageLayout(
-            mBuffer.clearPass,
+            mBuffer.buckets.clearPass,
             grfx::RESOURCE_STATE_SHADER_RESOURCE,
             grfx::RESOURCE_STATE_RENDER_TARGET,
             grfx::RESOURCE_STATE_SHADER_RESOURCE,
             grfx::RESOURCE_STATE_SHADER_RESOURCE);
-        mCommandBuffer->BeginRenderPass(mBuffer.clearPass, grfx::DRAW_PASS_CLEAR_FLAG_CLEAR_ALL);
+        mCommandBuffer->BeginRenderPass(mBuffer.buckets.clearPass, grfx::DRAW_PASS_CLEAR_FLAG_CLEAR_ALL);
 
-        mCommandBuffer->SetScissors(mBuffer.clearPass->GetScissor());
-        mCommandBuffer->SetViewports(mBuffer.clearPass->GetViewport());
+        mCommandBuffer->SetScissors(mBuffer.buckets.clearPass->GetScissor());
+        mCommandBuffer->SetViewports(mBuffer.buckets.clearPass->GetViewport());
 
         mCommandBuffer->EndRenderPass();
         mCommandBuffer->TransitionImageLayout(
-            mBuffer.clearPass,
+            mBuffer.buckets.clearPass,
             grfx::RESOURCE_STATE_RENDER_TARGET,
             grfx::RESOURCE_STATE_SHADER_RESOURCE,
             grfx::RESOURCE_STATE_SHADER_RESOURCE,
             grfx::RESOURCE_STATE_SHADER_RESOURCE);
 
-        mBuffer.countTextureNeedClear = false;
+        mBuffer.buckets.countTextureNeedClear = false;
     }
 
     {
-        mCommandBuffer->TransitionImageLayout(mBuffer.countTexture, PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
-        mCommandBuffer->TransitionImageLayout(mBuffer.fragmentTexture, PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
-        mCommandBuffer->BeginRenderPass(mBuffer.gatherPass, 0);
+        mCommandBuffer->TransitionImageLayout(mBuffer.buckets.countTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
+        mCommandBuffer->TransitionImageLayout(mBuffer.buckets.fragmentTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
+        mCommandBuffer->BeginRenderPass(mBuffer.buckets.gatherPass, 0);
 
-        mCommandBuffer->SetScissors(mBuffer.gatherPass->GetScissor());
-        mCommandBuffer->SetViewports(mBuffer.gatherPass->GetViewport());
+        mCommandBuffer->SetScissors(mBuffer.buckets.gatherPass->GetScissor());
+        mCommandBuffer->SetViewports(mBuffer.buckets.gatherPass->GetViewport());
 
-        mCommandBuffer->BindGraphicsDescriptorSets(mBuffer.gatherPipelineInterface, 1, &mBuffer.gatherDescriptorSet);
-        mCommandBuffer->BindGraphicsPipeline(mBuffer.gatherPipeline);
+        mCommandBuffer->BindGraphicsDescriptorSets(mBuffer.buckets.gatherPipelineInterface, 1, &mBuffer.buckets.gatherDescriptorSet);
+        mCommandBuffer->BindGraphicsPipeline(mBuffer.buckets.gatherPipeline);
         mCommandBuffer->BindIndexBuffer(GetTransparentMesh());
         mCommandBuffer->BindVertexBuffers(GetTransparentMesh());
         mCommandBuffer->DrawIndexed(GetTransparentMesh()->GetIndexCount());
 
         mCommandBuffer->EndRenderPass();
-        mCommandBuffer->TransitionImageLayout(mBuffer.countTexture, PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
-        mCommandBuffer->TransitionImageLayout(mBuffer.fragmentTexture, PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+        mCommandBuffer->TransitionImageLayout(mBuffer.buckets.countTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+        mCommandBuffer->TransitionImageLayout(mBuffer.buckets.fragmentTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
     }
 
     {
-        mCommandBuffer->TransitionImageLayout(mBuffer.countTexture, PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
-        mCommandBuffer->TransitionImageLayout(mBuffer.fragmentTexture, PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
+        mCommandBuffer->TransitionImageLayout(mBuffer.buckets.countTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
+        mCommandBuffer->TransitionImageLayout(mBuffer.buckets.fragmentTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
         mCommandBuffer->TransitionImageLayout(
             mTransparencyPass,
             grfx::RESOURCE_STATE_SHADER_RESOURCE,
@@ -277,8 +518,8 @@ void OITDemoApp::RecordBuffer()
         mCommandBuffer->SetScissors(mTransparencyPass->GetScissor());
         mCommandBuffer->SetViewports(mTransparencyPass->GetViewport());
 
-        mCommandBuffer->BindGraphicsDescriptorSets(mBuffer.combinePipelineInterface, 1, &mBuffer.combineDescriptorSet);
-        mCommandBuffer->BindGraphicsPipeline(mBuffer.combinePipeline);
+        mCommandBuffer->BindGraphicsDescriptorSets(mBuffer.buckets.combinePipelineInterface, 1, &mBuffer.buckets.combineDescriptorSet);
+        mCommandBuffer->BindGraphicsPipeline(mBuffer.buckets.combinePipeline);
         mCommandBuffer->Draw(3);
 
         mCommandBuffer->EndRenderPass();
@@ -288,7 +529,95 @@ void OITDemoApp::RecordBuffer()
             grfx::RESOURCE_STATE_SHADER_RESOURCE,
             grfx::RESOURCE_STATE_DEPTH_STENCIL_WRITE,
             grfx::RESOURCE_STATE_SHADER_RESOURCE);
-        mCommandBuffer->TransitionImageLayout(mBuffer.countTexture, PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
-        mCommandBuffer->TransitionImageLayout(mBuffer.fragmentTexture, PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+        mCommandBuffer->TransitionImageLayout(mBuffer.buckets.countTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+        mCommandBuffer->TransitionImageLayout(mBuffer.buckets.fragmentTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+    }
+}
+
+void OITDemoApp::RecordBufferLinkedLists()
+{
+    static bool sListsTextureNeedClear = true;
+    if (sListsTextureNeedClear) {
+        mCommandBuffer->TransitionImageLayout(
+            mBuffer.lists.clearPass,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_RENDER_TARGET,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE);
+        mCommandBuffer->BeginRenderPass(mBuffer.lists.clearPass, grfx::DRAW_PASS_CLEAR_FLAG_CLEAR_ALL);
+
+        mCommandBuffer->SetScissors(mBuffer.lists.clearPass->GetScissor());
+        mCommandBuffer->SetViewports(mBuffer.lists.clearPass->GetViewport());
+
+        mCommandBuffer->EndRenderPass();
+        mCommandBuffer->TransitionImageLayout(
+            mBuffer.lists.clearPass,
+            grfx::RESOURCE_STATE_RENDER_TARGET,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE);
+
+        sListsTextureNeedClear = false;
+    }
+
+    {
+        mCommandBuffer->TransitionImageLayout(mBuffer.lists.linkedListHeadTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
+        mCommandBuffer->BeginRenderPass(mBuffer.lists.gatherPass, 0);
+
+        mCommandBuffer->SetScissors(mBuffer.lists.gatherPass->GetScissor());
+        mCommandBuffer->SetViewports(mBuffer.lists.gatherPass->GetViewport());
+
+        mCommandBuffer->BindGraphicsDescriptorSets(mBuffer.lists.gatherPipelineInterface, 1, &mBuffer.lists.gatherDescriptorSet);
+        mCommandBuffer->BindGraphicsPipeline(mBuffer.lists.gatherPipeline);
+        mCommandBuffer->BindIndexBuffer(GetTransparentMesh());
+        mCommandBuffer->BindVertexBuffers(GetTransparentMesh());
+        mCommandBuffer->DrawIndexed(GetTransparentMesh()->GetIndexCount());
+
+        mCommandBuffer->EndRenderPass();
+        mCommandBuffer->TransitionImageLayout(mBuffer.lists.linkedListHeadTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+    }
+
+    {
+        mCommandBuffer->TransitionImageLayout(mBuffer.lists.linkedListHeadTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_GENERAL);
+        mCommandBuffer->TransitionImageLayout(
+            mTransparencyPass,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_RENDER_TARGET,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_DEPTH_STENCIL_WRITE);
+        mCommandBuffer->BeginRenderPass(mTransparencyPass, grfx::DRAW_PASS_CLEAR_FLAG_CLEAR_RENDER_TARGETS);
+
+        mCommandBuffer->SetScissors(mTransparencyPass->GetScissor());
+        mCommandBuffer->SetViewports(mTransparencyPass->GetViewport());
+
+        mCommandBuffer->BindGraphicsDescriptorSets(mBuffer.lists.combinePipelineInterface, 1, &mBuffer.lists.combineDescriptorSet);
+        mCommandBuffer->BindGraphicsPipeline(mBuffer.lists.combinePipeline);
+        mCommandBuffer->Draw(3);
+
+        mCommandBuffer->EndRenderPass();
+        mCommandBuffer->TransitionImageLayout(
+            mTransparencyPass,
+            grfx::RESOURCE_STATE_RENDER_TARGET,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE,
+            grfx::RESOURCE_STATE_DEPTH_STENCIL_WRITE,
+            grfx::RESOURCE_STATE_SHADER_RESOURCE);
+        mCommandBuffer->TransitionImageLayout(mBuffer.lists.linkedListHeadTexture, 0, 1, 0, 1, grfx::RESOURCE_STATE_GENERAL, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+    }
+}
+
+void OITDemoApp::RecordBuffer()
+{
+    switch (mGuiParameters.buffer.type) {
+        case BUFFER_ALGORITHM_BUCKETS: {
+            RecordBufferBuckets();
+            break;
+        }
+        case BUFFER_ALGORITHM_LINKED_LISTS: {
+            RecordBufferLinkedLists();
+            break;
+        }
+        default: {
+            break;
+        }
     }
 }

--- a/projects/oit_demo/OITDemoApplication.cpp
+++ b/projects/oit_demo/OITDemoApplication.cpp
@@ -351,9 +351,9 @@ void OITDemoApp::ParseCommandLineOptions()
     mGuiParameters.depthPeeling.layersCount = std::clamp(cliOptions.GetExtraOptionValueOrDefault("dp_layers_count", DEPTH_PEELING_LAYERS_COUNT), 1, DEPTH_PEELING_LAYERS_COUNT);
 
     mGuiParameters.buffer.type                    = static_cast<BufferAlgorithmType>(std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_type", 0), 0, BUFFER_ALGORITHMS_COUNT - 1));
-    mGuiParameters.buffer.bucketFragmentsMaxCount = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_bucket_fragments_max_count", BUFFER_BUCKET_SIZE_PER_PIXEL), 1, BUFFER_BUCKET_SIZE_PER_PIXEL);
-    mGuiParameters.buffer.fragmentBufferScale     = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_fragment_buffer_scale", BUFFER_BUFFER_MAX_SCALE), 1, BUFFER_BUFFER_MAX_SCALE);
-    mGuiParameters.buffer.linkedListMaxSize       = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_linked_list_max_size", BUFFER_LINKED_LIST_MAX_SIZE), 1, BUFFER_LINKED_LIST_MAX_SIZE);
+    mGuiParameters.buffer.bucketFragmentsMaxCount = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_bucket_fragments_max_count", BUFFER_BUCKETS_SIZE_PER_PIXEL), 1, BUFFER_BUCKETS_SIZE_PER_PIXEL);
+    mGuiParameters.buffer.fragmentBufferScale     = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_fragment_buffer_scale", BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE), 1, BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE);
+    mGuiParameters.buffer.linkedListMaxSize       = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_linked_list_max_size", BUFFER_LISTS_MAX_SIZE), 1, BUFFER_LISTS_MAX_SIZE);
 }
 
 void OITDemoApp::Setup()
@@ -416,9 +416,9 @@ void OITDemoApp::Update()
         shaderGlobals.depthPeelingFrontLayerIndex = std::max(0, mGuiParameters.depthPeeling.startLayer);
         shaderGlobals.depthPeelingBackLayerIndex  = std::min(DEPTH_PEELING_LAYERS_COUNT - 1, mGuiParameters.depthPeeling.startLayer + mGuiParameters.depthPeeling.layersCount - 1);
 
-        shaderGlobals.bufferBucketFragmentsMaxCount = std::min(BUFFER_BUCKET_SIZE_PER_PIXEL, mGuiParameters.buffer.bucketFragmentsMaxCount);
-        shaderGlobals.bufferFragmentBufferScale     = std::min(BUFFER_BUFFER_MAX_SCALE, mGuiParameters.buffer.fragmentBufferScale);
-        shaderGlobals.bufferLinkedListMaxSize       = std::min(BUFFER_LINKED_LIST_MAX_SIZE, mGuiParameters.buffer.linkedListMaxSize);
+        shaderGlobals.bufferBucketsFragmentsMaxCount = std::min(BUFFER_BUCKETS_SIZE_PER_PIXEL, mGuiParameters.buffer.bucketFragmentsMaxCount);
+        shaderGlobals.bufferListsFragmentBufferScale = std::min(BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE, mGuiParameters.buffer.fragmentBufferScale);
+        shaderGlobals.bufferListsMaxSize             = std::min(BUFFER_LISTS_MAX_SIZE, mGuiParameters.buffer.linkedListMaxSize);
 
         mShaderGlobalsBuffer->CopyFromSource(sizeof(shaderGlobals), &shaderGlobals);
     }
@@ -503,12 +503,12 @@ void OITDemoApp::UpdateGUI()
                 ImGui::Combo("BU type", reinterpret_cast<int32_t*>(&mGuiParameters.buffer.type), typeChoices, IM_ARRAYSIZE(typeChoices));
                 switch (mGuiParameters.buffer.type) {
                     case BUFFER_ALGORITHM_BUCKETS: {
-                        ImGui::SliderInt("BU bucket fragments max count", &mGuiParameters.buffer.bucketFragmentsMaxCount, 1, BUFFER_BUCKET_SIZE_PER_PIXEL);
+                        ImGui::SliderInt("BU bucket fragments max count", &mGuiParameters.buffer.bucketFragmentsMaxCount, 1, BUFFER_BUCKETS_SIZE_PER_PIXEL);
                         break;
                     }
                     case BUFFER_ALGORITHM_LINKED_LISTS: {
-                        ImGui::SliderInt("BU fragment buffer scale", &mGuiParameters.buffer.fragmentBufferScale, 1, BUFFER_BUFFER_MAX_SCALE);
-                        ImGui::SliderInt("BU linked list max size", &mGuiParameters.buffer.linkedListMaxSize, 1, BUFFER_LINKED_LIST_MAX_SIZE);
+                        ImGui::SliderInt("BU fragment buffer scale", &mGuiParameters.buffer.fragmentBufferScale, 1, BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE);
+                        ImGui::SliderInt("BU linked list max size", &mGuiParameters.buffer.linkedListMaxSize, 1, BUFFER_LISTS_MAX_SIZE);
                         break;
                     }
                     default: {

--- a/projects/oit_demo/OITDemoApplication.cpp
+++ b/projects/oit_demo/OITDemoApplication.cpp
@@ -350,10 +350,10 @@ void OITDemoApp::ParseCommandLineOptions()
     mGuiParameters.depthPeeling.startLayer  = std::clamp(cliOptions.GetExtraOptionValueOrDefault("dp_start_layer", 0), 0, DEPTH_PEELING_LAYERS_COUNT - 1);
     mGuiParameters.depthPeeling.layersCount = std::clamp(cliOptions.GetExtraOptionValueOrDefault("dp_layers_count", DEPTH_PEELING_LAYERS_COUNT), 1, DEPTH_PEELING_LAYERS_COUNT);
 
-    mGuiParameters.buffer.type                    = static_cast<BufferAlgorithmType>(std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_type", 0), 0, BUFFER_ALGORITHMS_COUNT - 1));
-    mGuiParameters.buffer.bucketFragmentsMaxCount = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_bucket_fragments_max_count", BUFFER_BUCKETS_SIZE_PER_PIXEL), 1, BUFFER_BUCKETS_SIZE_PER_PIXEL);
-    mGuiParameters.buffer.fragmentBufferScale     = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_fragment_buffer_scale", BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE), 1, BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE);
-    mGuiParameters.buffer.linkedListMaxSize       = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_linked_list_max_size", BUFFER_LISTS_MAX_SIZE), 1, BUFFER_LISTS_MAX_SIZE);
+    mGuiParameters.buffer.type                        = static_cast<BufferAlgorithmType>(std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_type", 0), 0, BUFFER_ALGORITHMS_COUNT - 1));
+    mGuiParameters.buffer.bucketsFragmentsMaxCount    = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_buckets_fragments_max_count", BUFFER_BUCKETS_SIZE_PER_PIXEL), 1, BUFFER_BUCKETS_SIZE_PER_PIXEL);
+    mGuiParameters.buffer.listsFragmentBufferScale    = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_lists_fragment_buffer_scale", BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE), 1, BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE);
+    mGuiParameters.buffer.listsSortedFragmentMaxCount = std::clamp(cliOptions.GetExtraOptionValueOrDefault("bu_lists_sorted_fragment_max_count", BUFFER_LISTS_SORTED_FRAGMENT_MAX_COUNT), 1, BUFFER_LISTS_SORTED_FRAGMENT_MAX_COUNT);
 }
 
 void OITDemoApp::Setup()
@@ -416,9 +416,9 @@ void OITDemoApp::Update()
         shaderGlobals.depthPeelingFrontLayerIndex = std::max(0, mGuiParameters.depthPeeling.startLayer);
         shaderGlobals.depthPeelingBackLayerIndex  = std::min(DEPTH_PEELING_LAYERS_COUNT - 1, mGuiParameters.depthPeeling.startLayer + mGuiParameters.depthPeeling.layersCount - 1);
 
-        shaderGlobals.bufferBucketsFragmentsMaxCount = std::min(BUFFER_BUCKETS_SIZE_PER_PIXEL, mGuiParameters.buffer.bucketFragmentsMaxCount);
-        shaderGlobals.bufferListsFragmentBufferScale = std::min(BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE, mGuiParameters.buffer.fragmentBufferScale);
-        shaderGlobals.bufferListsMaxSize             = std::min(BUFFER_LISTS_MAX_SIZE, mGuiParameters.buffer.linkedListMaxSize);
+        shaderGlobals.bufferBucketsFragmentsMaxCount    = std::min(BUFFER_BUCKETS_SIZE_PER_PIXEL, mGuiParameters.buffer.bucketsFragmentsMaxCount);
+        shaderGlobals.bufferListsFragmentBufferScale    = std::min(BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE, mGuiParameters.buffer.listsFragmentBufferScale);
+        shaderGlobals.bufferListsSortedFragmentMaxCount = std::min(BUFFER_LISTS_SORTED_FRAGMENT_MAX_COUNT, mGuiParameters.buffer.listsSortedFragmentMaxCount);
 
         mShaderGlobalsBuffer->CopyFromSource(sizeof(shaderGlobals), &shaderGlobals);
     }
@@ -503,12 +503,12 @@ void OITDemoApp::UpdateGUI()
                 ImGui::Combo("BU type", reinterpret_cast<int32_t*>(&mGuiParameters.buffer.type), typeChoices, IM_ARRAYSIZE(typeChoices));
                 switch (mGuiParameters.buffer.type) {
                     case BUFFER_ALGORITHM_BUCKETS: {
-                        ImGui::SliderInt("BU bucket fragments max count", &mGuiParameters.buffer.bucketFragmentsMaxCount, 1, BUFFER_BUCKETS_SIZE_PER_PIXEL);
+                        ImGui::SliderInt("BU bucket fragments max count", &mGuiParameters.buffer.bucketsFragmentsMaxCount, 1, BUFFER_BUCKETS_SIZE_PER_PIXEL);
                         break;
                     }
                     case BUFFER_ALGORITHM_LINKED_LISTS: {
-                        ImGui::SliderInt("BU fragment buffer scale", &mGuiParameters.buffer.fragmentBufferScale, 1, BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE);
-                        ImGui::SliderInt("BU linked list max size", &mGuiParameters.buffer.linkedListMaxSize, 1, BUFFER_LISTS_MAX_SIZE);
+                        ImGui::SliderInt("BU fragment buffer scale", &mGuiParameters.buffer.listsFragmentBufferScale, 1, BUFFER_LISTS_FRAGMENT_BUFFER_MAX_SCALE);
+                        ImGui::SliderInt("BU linked list max size", &mGuiParameters.buffer.listsSortedFragmentMaxCount, 1, BUFFER_LISTS_SORTED_FRAGMENT_MAX_COUNT);
                         break;
                     }
                     default: {

--- a/projects/oit_demo/OITDemoApplication.cpp
+++ b/projects/oit_demo/OITDemoApplication.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO Fix DX12 structured buffer issue
-// TODO Add support for linked lists options
 // TODO Remove all unecessary depth buffer attachment
 // TODO Recheck if there are any unnecessary clears (especially for combines)
 // TODO Several meshes on top of each other (including opaque ones)

--- a/projects/oit_demo/OITDemoApplication.h
+++ b/projects/oit_demo/OITDemoApplication.h
@@ -106,9 +106,9 @@ private:
         struct
         {
             BufferAlgorithmType type;
-            int32_t             bucketFragmentsMaxCount;
-            int32_t             fragmentBufferScale;
-            int32_t             linkedListMaxSize;
+            int32_t             bucketsFragmentsMaxCount;
+            int32_t             listsFragmentBufferScale;
+            int32_t             listsSortedFragmentMaxCount;
         } buffer;
     };
 

--- a/projects/oit_demo/OITDemoApplication.h
+++ b/projects/oit_demo/OITDemoApplication.h
@@ -62,6 +62,13 @@ private:
         WEIGHTED_AVERAGE_TYPES_COUNT,
     };
 
+    enum BufferAlgorithmType : int32_t
+    {
+        BUFFER_ALGORITHM_BUCKETS,
+        BUFFER_ALGORITHM_LINKED_LISTS,
+        BUFFER_ALGORITHMS_COUNT,
+    };
+
     struct GuiParameters
     {
         int32_t algorithmDataIndex;
@@ -98,7 +105,10 @@ private:
 
         struct
         {
-            int32_t fragmentsMaxCount;
+            BufferAlgorithmType type;
+            int32_t             bucketFragmentsMaxCount;
+            int32_t             fragmentBufferScale;
+            int32_t             linkedListMaxSize;
         } buffer;
     };
 
@@ -112,6 +122,8 @@ private:
     void SetupWeightedAverage();
     void SetupDepthPeeling();
     void SetupBuffer();
+    void SetupBufferBuckets();
+    void SetupBufferLinkedLists();
 
     void FillSupportedAlgorithmData();
     void ParseCommandLineOptions();
@@ -123,13 +135,16 @@ private:
     void UpdateGUI();
 
     void RecordOpaque();
+    void RecordTransparency();
+    void RecordComposite(grfx::RenderPassPtr renderPass);
+
     void RecordUnsortedOver();
     void RecordWeightedSum();
     void RecordWeightedAverage();
     void RecordDepthPeeling();
     void RecordBuffer();
-    void RecordTransparency();
-    void RecordComposite(grfx::RenderPassPtr renderPass);
+    void RecordBufferBuckets();
+    void RecordBufferLinkedLists();
 
 private:
     GuiParameters mGuiParameters = {};
@@ -236,21 +251,43 @@ private:
 
     struct
     {
-        grfx::TexturePtr  countTexture;
-        grfx::TexturePtr  fragmentTexture;
-        grfx::DrawPassPtr clearPass;
-        grfx::DrawPassPtr gatherPass;
+        struct
+        {
+            grfx::TexturePtr  countTexture;
+            grfx::TexturePtr  fragmentTexture;
+            grfx::DrawPassPtr clearPass;
+            grfx::DrawPassPtr gatherPass;
 
-        grfx::DescriptorSetLayoutPtr gatherDescriptorSetLayout;
-        grfx::DescriptorSetPtr       gatherDescriptorSet;
-        grfx::PipelineInterfacePtr   gatherPipelineInterface;
-        grfx::GraphicsPipelinePtr    gatherPipeline;
+            grfx::DescriptorSetLayoutPtr gatherDescriptorSetLayout;
+            grfx::DescriptorSetPtr       gatherDescriptorSet;
+            grfx::PipelineInterfacePtr   gatherPipelineInterface;
+            grfx::GraphicsPipelinePtr    gatherPipeline;
 
-        grfx::DescriptorSetLayoutPtr combineDescriptorSetLayout;
-        grfx::DescriptorSetPtr       combineDescriptorSet;
-        grfx::PipelineInterfacePtr   combinePipelineInterface;
-        grfx::GraphicsPipelinePtr    combinePipeline;
+            grfx::DescriptorSetLayoutPtr combineDescriptorSetLayout;
+            grfx::DescriptorSetPtr       combineDescriptorSet;
+            grfx::PipelineInterfacePtr   combinePipelineInterface;
+            grfx::GraphicsPipelinePtr    combinePipeline;
+			
+			bool countTextureNeedClear;
+        } buckets;
 
-        bool countTextureNeedClear;
+        struct
+        {
+            grfx::TexturePtr  linkedListHeadTexture;
+            grfx::BufferPtr   fragmentBuffer;
+            grfx::BufferPtr   atomicCounter;
+            grfx::DrawPassPtr clearPass;
+            grfx::DrawPassPtr gatherPass;
+
+            grfx::DescriptorSetLayoutPtr gatherDescriptorSetLayout;
+            grfx::DescriptorSetPtr       gatherDescriptorSet;
+            grfx::PipelineInterfacePtr   gatherPipelineInterface;
+            grfx::GraphicsPipelinePtr    gatherPipeline;
+
+            grfx::DescriptorSetLayoutPtr combineDescriptorSetLayout;
+            grfx::DescriptorSetPtr       combineDescriptorSet;
+            grfx::PipelineInterfacePtr   combinePipelineInterface;
+            grfx::GraphicsPipelinePtr    combinePipeline;
+        } lists;
     } mBuffer;
 };

--- a/projects/oit_demo/OITDemoApplication.h
+++ b/projects/oit_demo/OITDemoApplication.h
@@ -267,8 +267,8 @@ private:
             grfx::DescriptorSetPtr       combineDescriptorSet;
             grfx::PipelineInterfacePtr   combinePipelineInterface;
             grfx::GraphicsPipelinePtr    combinePipeline;
-			
-			bool countTextureNeedClear;
+
+            bool countTextureNeedClear;
         } buckets;
 
         struct
@@ -288,6 +288,8 @@ private:
             grfx::DescriptorSetPtr       combineDescriptorSet;
             grfx::PipelineInterfacePtr   combinePipelineInterface;
             grfx::GraphicsPipelinePtr    combinePipeline;
+
+            bool linkedListHeadTextureNeedClear;
         } lists;
     } mBuffer;
 };

--- a/projects/oit_demo/README.md
+++ b/projects/oit_demo/README.md
@@ -65,21 +65,23 @@ The following meshes are available as transparent objects.
 
 The following command line options are available.
 
-|Option                  |Description                                   |Algorithm           |Value
-|:---                    |:---                                          |:---                |:---
-|algorithm <ID>          |Select the OIT algorithm                      |All                 |Algorithm ID (see [Algorithms](algorithms))
-|bg_display              |Turns the background on/off                   |All                 |True or false
-|bg_red                  |Set the red channel of the background color   |All                 |0.0 to 1.0
-|bg_green                |Set the green channel of the background color |All                 |0.0 to 1.0
-|bg_blue                 |Set the blue channel of the background color  |All                 |0.0 to 1.0
-|mo_mesh <ID>            |Select the mesh of the transparent model      |All                 |Mesh ID (see [Meshes](meshes))
-|mo_opacity <float>      |Set the opacity of the model                  |All                 |0.0 to 1.0
-|mo_scale <float>        |Set the scale of the model                    |All                 |1.0 to 5.0
-|uo_face_mode <int>      |Set the face mode                             |Unsorted over       |0 = all faces, 1 = back + front, 2 = back, 3 = front
-|wa_type <int>           |Select the average type                       |Weighted average    |0 = fragment count, 1 = exact coverage
-|dp_start_layer <int>    |Set the starting layer to draw                |Depth peeling       |0 to 7
-|dp_layers_count <int>   |Set the number of layers to draw              |Depth peeling       |1 to 8
-|bu_fragments_max_count  |Set the maximum number of fragment per pixel  |Buffer              |1 to 8
+|Option                             |Description                                                    |Algorithm             |Value
+|:---                               |:---                                                           |:---                  |:---
+|algorithm <ID>                     |Select the OIT algorithm                                       |All                   |Algorithm ID (see [Algorithms](algorithms))
+|bg_display                         |Turns the background on/off                                    |All                   |True or false
+|bg_red                             |Set the red channel of the background color                    |All                   |0.0 to 1.0
+|bg_green                           |Set the green channel of the background color                  |All                   |0.0 to 1.0
+|bg_blue                            |Set the blue channel of the background color                   |All                   |0.0 to 1.0
+|mo_mesh <ID>                       |Select the mesh of the transparent model                       |All                   |Mesh ID (see [Meshes](meshes))
+|mo_opacity <float>                 |Set the opacity of the model                                   |All                   |0.0 to 1.0
+|mo_scale <float>                   |Set the scale of the model                                     |All                   |1.0 to 5.0
+|uo_face_mode <int>                 |Set the face mode                                              |Unsorted over         |0 = all faces, 1 = back + front, 2 = back, 3 = front
+|wa_type <int>                      |Select the average type                                        |Weighted average      |0 = fragment count, 1 = exact coverage
+|dp_start_layer <int>               |Set the starting layer to draw                                 |Depth peeling         |0 to 7
+|dp_layers_count <int>              |Set the number of layers to draw                               |Depth peeling         |1 to 8
+|bu_buckets_fragments_max_count     |Set the maximum number of fragments per pixel                  |Buffer (buckets)      |1 to 8
+|bu_lists_fragment_buffer_scale     |Set the ratio of fragments to pixel for the transparency pass  |Buffer (linked lists) |1 to 8
+|bu_lists_sorted_fragment_max_count |Set the maximum number of fragments per pixel                  |Buffer (linked lists) |1 to 64
 
 ## References
 


### PR DESCRIPTION
Added a buffer-based OIT algorithm that builds per-pixel linked list of fragments
* It is available under the "Buffer" dropdown
* It has two options

Code refactoring
* Renamed the previous buffer-based algorithm to "buckets" as it uses per-pixel fixed-size buckets to store fragments
* Moved functions and renamed variables in the shader code
