### PR TITLE
Do not special case std::endl in log handling

### DIFF
--- a/include/ppx/log.h
+++ b/include/ppx/log.h
@@ -86,9 +86,7 @@ public:
 
     Log& operator<<(std::ostream& (*manip)(std::ostream&))
     {
-        if (manip == (std::basic_ostream<char> & (*)(std::basic_ostream<char>&)) & std::endl) {
-            mBuffer << std::endl;
-        }
+        mBuffer << *manip;
         return *this;
     }
 


### PR DESCRIPTION
This solves an issue in our internal builds too.