### PR TITLE
Add command line args to Android builds.

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -47,9 +47,9 @@
         {                                               \
             return app.GetAndroidContext() != nullptr;  \
         }                                               \
-        bool VulkanDrawFrame(void)                      \
+        bool VulkanDrawFrame(int argc, char** argv)     \
         {                                               \
-            int res = app.Run(0, nullptr);              \
+            int res = app.Run(argc, argv);              \
             return res;                                 \
         }
 #else

--- a/src/android/MainActivity.java
+++ b/src/android/MainActivity.java
@@ -1,8 +1,27 @@
 package com.google.bigwheels;
 
+import android.content.Intent;
+import android.os.Bundle;
 import android.view.View;
 import com.google.androidgamesdk.GameActivity;
 
 public class MainActivity extends GameActivity {
   static { System.loadLibrary(BuildConfig.sample_library_name); }
+
+  private String[] getArgsFromIntent(Intent intent) {
+    String argString = intent.getStringExtra("arguments");
+    if (argString != null) {
+      return argString.split("\\s+");
+    }
+    return new String[0];
+  }
+
+  public String[] constructCmdLineArgs() {
+    String[] intentArgs = getArgsFromIntent(getIntent());
+    String[] args = new String[intentArgs.length + 1];
+    // The first argument is the application name, and is ignored by the parser.
+    args[0] = getTitle().toString();
+    System.arraycopy(intentArgs, 0, args, 1, intentArgs.length);
+    return args;
+  }
 }


### PR DESCRIPTION
This uses [Intent extras](https://developer.android.com/reference/android/content/Intent#getExtras()) to allow the Android application to be started over ADB with additional arguments.

For example:
```sh
adb shell am start -n com.google.bigwheels/.MainActivity -e arguments "--help"
```