### PR TITLE
Include <cinttypes> to get standard definitions for PRIu64 and PRId64.

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -25,6 +25,7 @@
 
 #include <deque>
 #include <filesystem>
+#include <cinttypes>
 
 // clang-format off
 #if ! defined(GLFW_INCLUDE_NONE)


### PR DESCRIPTION
This prevents build failures in our internal build system.