### PR TITLE
Enable ImGui on Android.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,6 +127,13 @@ if (PPX_VULKAN)
     )
 endif()
 
+if (PPX_ANDROID)
+    list(APPEND IMGUI_SOURCE_FILES
+        ${IMGUI_DIR}/backends/imgui_impl_android.h
+        ${IMGUI_DIR}/backends/imgui_impl_android.cpp
+    )
+endif()
+
 if (PPX_D3D12)
     list(APPEND IMGUI_SOURCE_FILES
         ${IMGUI_DIR}/backends/imgui_impl_dx12.h

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -899,10 +899,7 @@ Result Application::InitializeImGui()
 #if defined(PPX_VULKAN)
         case grfx::API_VK_1_1:
         case grfx::API_VK_1_2: {
-#if !defined(PPX_ANDROID)
-            // ImGui does not support ANDROID
             mImGui = std::unique_ptr<ImGuiImpl>(new ImGuiImplVk());
-#endif
         } break;
 #endif // defined(PPX_VULKAN)
     }

--- a/src/ppx/imgui_impl.cpp
+++ b/src/ppx/imgui_impl.cpp
@@ -37,6 +37,10 @@
 #include "ppx/grfx/vk/vk_render_pass.h"
 #endif // defined(PPX_VULKAN)
 
+#if defined(PPX_ANDROID)
+#include "backends/imgui_impl_android.h"
+#endif
+
 #if defined(PPX_MSW)
 #include <ShellScalingApi.h>
 #endif
@@ -226,13 +230,17 @@ void ImGuiImplDx12::Render(grfx::CommandBuffer* pCommandBuffer)
 // -------------------------------------------------------------------------------------------------
 // ImGuiImplVk
 // -------------------------------------------------------------------------------------------------
-#if defined(PPX_VULKAN) && !defined(PPX_ANDROID)
+#if defined(PPX_VULKAN)
 
 Result ImGuiImplVk::InitApiObjects(ppx::Application* pApp)
 {
+#if defined(PPX_ANDROID)
+    ImGui_ImplAndroid_Init(pApp->GetAndroidContext()->window);
+#else
     // Setup GLFW binding
     GLFWwindow* pWindow = static_cast<GLFWwindow*>(pApp->GetWindow());
     ImGui_ImplGlfw_InitForVulkan(pWindow, false);
+#endif
 
     // Setup style
     SetColorStyle();
@@ -330,7 +338,11 @@ Result ImGuiImplVk::InitApiObjects(ppx::Application* pApp)
 void ImGuiImplVk::Shutdown(ppx::Application* pApp)
 {
     ImGui_ImplVulkan_Shutdown();
+#if defined(PPX_ANDROID)
+    ImGui_ImplAndroid_Shutdown();
+#else
     ImGui_ImplGlfw_Shutdown();
+#endif
     ImGui::DestroyContext();
 
     if (mPool) {
@@ -342,7 +354,11 @@ void ImGuiImplVk::Shutdown(ppx::Application* pApp)
 void ImGuiImplVk::NewFrameApi()
 {
     ImGui_ImplVulkan_NewFrame();
+#if defined(PPX_ANDROID)
+    ImGui_ImplAndroid_NewFrame();
+#else
     ImGui_ImplGlfw_NewFrame();
+#endif
     ImGui::NewFrame();
 }
 
@@ -351,25 +367,6 @@ void ImGuiImplVk::Render(grfx::CommandBuffer* pCommandBuffer)
     ImGui::Render();
     ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), grfx::vk::ToApi(pCommandBuffer)->GetVkCommandBuffer());
 }
-
-#elif defined(PPX_ANDROID)
-Result ImGuiImplVk::InitApiObjects(ppx::Application* pApp)
-{
-    return ppx::SUCCESS;
-}
-
-void ImGuiImplVk::Shutdown(ppx::Application* pApp)
-{
-}
-
-void ImGuiImplVk::NewFrameApi()
-{
-}
-
-void ImGuiImplVk::Render(grfx::CommandBuffer* pCommandBuffer)
-{
-}
-
 #endif // defined(PPX_VULKAN)
 
 } // namespace ppx


### PR DESCRIPTION
ImGui renders, but the aspect ratio is wrong.
We should get the Android Window size instead of hard code 720p.