### PR TITLE
android: switch back to NativeActivity.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ if (NOT PPX_ANDROID)
 endif()
 
 # ------------------------------------------------------------------------------
-# Add game-activity for ANDROID
+# Add native activity for ANDROID
 # ------------------------------------------------------------------------------
 if (PPX_ANDROID)
     include_directories("${ANDROID_NDK}/sources/android/native_app_glue/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,11 @@ endif()
 # Add game-activity for ANDROID
 # ------------------------------------------------------------------------------
 if (PPX_ANDROID)
-    find_package(game-activity REQUIRED CONFIG)
+    include_directories("${ANDROID_NDK}/sources/android/native_app_glue/")
+    add_library(android_native_app_glue
+        OBJECT
+        "${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c")
+    target_compile_options(android_native_app_glue PRIVATE -fPIC)
 endif()
 
 # ------------------------------------------------------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,6 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.7.0'
-    implementation 'androidx.games:games-activity:1.0.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'

--- a/cmake/GraphicsSample.cmake
+++ b/cmake/GraphicsSample.cmake
@@ -54,6 +54,7 @@ function(_add_sample_internal)
         find_library(log-lib log)
         target_link_libraries("${TARGET_NAME}" PUBLIC
           android
+          android_native_app_glue
           ${log-lib}
         )
     else ()

--- a/include/ppx/base_application.h
+++ b/include/ppx/base_application.h
@@ -24,7 +24,7 @@
 #include <filesystem>
 
 #if defined(PPX_ANDROID)
-#include <game-activity/native_app_glue/android_native_app_glue.h>
+#include <android_native_app_glue.h>
 #endif
 
 namespace ppx {

--- a/include/ppx/fs.h
+++ b/include/ppx/fs.h
@@ -37,7 +37,7 @@
 #include <fstream>
 
 #if defined(PPX_ANDROID)
-#include <game-activity/native_app_glue/android_native_app_glue.h>
+#include <android_native_app_glue.h>
 #endif
 
 namespace ppx::fs {

--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -30,7 +30,7 @@
 #elif defined(PPX_MSW)
 #   include <Windows.h>
 #elif defined(PPX_ANDROID)
-#   include <game-activity/native_app_glue/android_native_app_glue.h>
+#   include <android_native_app_glue.h>
 #endif
 // clang-format on
 

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -28,7 +28,7 @@
 #endif // defined(PPX_VULKAN)
 
 #if defined(PPX_ANDROID)
-#include <game-activity/native_app_glue/android_native_app_glue.h>
+#include <android_native_app_glue.h>
 #endif // defined(PPX_ANDROID)
 
 #include <openxr/openxr.h>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -509,15 +509,6 @@ if (PPX_MSW)
     )
 endif()
 
-if (PPX_ANDROID)
-    target_link_libraries(
-        ${PROJECT_NAME}
-        PUBLIC
-        android
-        game-activity::game-activity
-    )
-endif()
-
 # ------------------------------------------------------------------------------
 # Graphics API compile definitions
 # ------------------------------------------------------------------------------

--- a/src/android/MainActivity.java
+++ b/src/android/MainActivity.java
@@ -1,11 +1,11 @@
 package com.google.bigwheels;
 
+import android.app.NativeActivity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
-import com.google.androidgamesdk.GameActivity;
 
-public class MainActivity extends GameActivity {
+public class MainActivity extends NativeActivity {
   static { System.loadLibrary(BuildConfig.sample_library_name); }
 
   private String[] getArgsFromIntent(Intent intent) {

--- a/src/android/main.cpp
+++ b/src/android/main.cpp
@@ -2,9 +2,7 @@
 
 #include <string>
 #include <vector>
-#include <game-activity/GameActivity.cpp>
-#include <game-text-input/gametextinput.cpp>
-#include <game-activity/native_app_glue/android_native_app_glue.h>
+#include <android_native_app_glue.h>
 
 extern bool InitVulkan(android_app* app);
 extern void DeleteVulkan(void);
@@ -21,7 +19,7 @@ static std::vector<std::string> get_java_args(android_app* pApp)
     JNIEnv* jEnv = pApp->activity->env;
     jVm->AttachCurrentThread(&jEnv, nullptr);
 
-    jobject      jMainActivity         = pApp->activity->javaGameActivity;
+    jobject      jMainActivity         = pApp->activity->clazz;
     jclass       jMainActivityClass    = jEnv->GetObjectClass(jMainActivity);
     jmethodID    jConstructCmdLineArgs = jEnv->GetMethodID(jMainActivityClass, "constructCmdLineArgs", "()[Ljava/lang/String;");
     jobjectArray jArgs                 = static_cast<jobjectArray>(jEnv->CallObjectMethod(jMainActivity, jConstructCmdLineArgs));
@@ -43,8 +41,6 @@ static std::vector<std::string> get_java_args(android_app* pApp)
 
 extern "C"
 {
-#include <game-activity/native_app_glue/android_native_app_glue.c>
-
     /*!
      * Handles commands sent to this Android application
      * @param pApp the app the commands are coming from

--- a/src/ppx/fs.cpp
+++ b/src/ppx/fs.cpp
@@ -19,7 +19,7 @@
 #include <optional>
 
 #if defined(PPX_ANDROID)
-#include <game-activity/native_app_glue/android_native_app_glue.h>
+#include <android_native_app_glue.h>
 android_app* gAndroidContext;
 #endif
 

--- a/src/ppx/xr_component.cpp
+++ b/src/ppx/xr_component.cpp
@@ -76,7 +76,7 @@ void XrComponent::InitializeBeforeGrfxDeviceInit(const XrComponentCreateInfo& cr
 #if defined(PPX_ANDROID)
     XrLoaderInitInfoAndroidKHR loaderInitInfoAndroid = {XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR};
     loaderInitInfoAndroid.applicationVM              = createInfo.androidContext->activity->vm;
-    loaderInitInfoAndroid.applicationContext         = createInfo.androidContext->activity->javaGameActivity;
+    loaderInitInfoAndroid.applicationContext         = createInfo.androidContext->activity->clazz;
     PFN_xrInitializeLoaderKHR pfnInitializeLoaderKHR = nullptr;
     CHECK_XR_CALL(xrGetInstanceProcAddr(XR_NULL_HANDLE, "xrInitializeLoaderKHR", (PFN_xrVoidFunction*)(&pfnInitializeLoaderKHR)));
     PPX_ASSERT_MSG(pfnInitializeLoaderKHR != nullptr, "Cannot get xrInitializeLoaderKHR function pointer!");
@@ -143,7 +143,7 @@ void XrComponent::InitializeBeforeGrfxDeviceInit(const XrComponentCreateInfo& cr
     XrInstanceCreateInfoAndroidKHR instanceCreateInfoAndroid = {XR_TYPE_INSTANCE_CREATE_INFO_ANDROID_KHR};
     instanceCreateInfoAndroid.next                           = nullptr;
     instanceCreateInfoAndroid.applicationVM                  = createInfo.androidContext->activity->vm;
-    instanceCreateInfoAndroid.applicationActivity            = createInfo.androidContext->activity->javaGameActivity;
+    instanceCreateInfoAndroid.applicationActivity            = createInfo.androidContext->activity->clazz;
 
     instanceCreateInfo.next = &instanceCreateInfoAndroid;
 #endif // defined(PPX_ANDROID)


### PR DESCRIPTION
NativeActivity is supported since a long time. GameActivity is the new recommended method.
THe issue is GameActivity is not supported by Android, and being brand new means lack of support in other domains.

Moving back to NativeActivity is a risk, if it suddenly gets deprecated. But the cost of the switch being lower than the cost of fixing dependencies to use GameActivity means it's an acceptable risk.