### PR TITLE
android: fix app ID on android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ android {
     def defineFlavor = { sample_name ->
       return {
         dimension 'project'
+        // Package names cannot start with a number, adding prefixing.
+        applicationIdSuffix ".project_" + sample_name
         it.buildConfigField "String", "sample_library_name", '"vk_' + sample_name + '"'
         it.resValue         "string", "sample_library_name",  'vk_' + sample_name
         it.resValue         "string", "app_label", sample_name


### PR DESCRIPTION
All the samples shared the same ID, meaning we could only install one sample at the time on a device. This should solve the issue.