### PR TITLE
Performance Tweaks

### DIFF
--- a/include/ppx/bitmap.h
+++ b/include/ppx/bitmap.h
@@ -18,6 +18,8 @@
 #include "ppx/config.h"
 #include "ppx/grfx/grfx_format.h"
 
+#include "stb_image_resize.h"
+
 #include <filesystem>
 
 namespace ppx {
@@ -93,6 +95,7 @@ public:
 
     Result Resize(uint32_t width, uint32_t height);
     Result ScaleTo(Bitmap* pTargetBitmap) const;
+    Result ScaleTo(Bitmap* pTargetBitmap, stbir_filter filterType) const;
 
     template <typename PixelDataType>
     void Fill(PixelDataType r, PixelDataType g, PixelDataType b, PixelDataType a);

--- a/include/ppx/bitmap.h
+++ b/include/ppx/bitmap.h
@@ -62,7 +62,7 @@ public:
 
     Bitmap();
     Bitmap(const Bitmap& obj);
-    ~Bitmap() {}
+    ~Bitmap();
 
     Bitmap& operator=(const Bitmap& rhs);
 
@@ -192,6 +192,14 @@ private:
     void   InternalCtor();
     Result InternalInitialize(uint32_t width, uint32_t height, Bitmap::Format format, uint32_t rowStride, char* pExternalStorage);
     Result InternalCopy(const Bitmap& obj);
+    void   FreeStbiDataIfNeeded();
+
+    // Stbi-specific functions/wrappers.
+    // These arguments generally mirror those for stbi_load, except format which is used to determine whether
+    // the call should be made to stbi_load or stbi_loadf (that is, whether the file to be read is in integer or floating point format).
+    static char* StbiLoad(const std::filesystem::path& path, Bitmap::Format format, int* pWidth, int* pHeight, int* pChannels, int desiredChannels);
+    // These arugments mirror those for stbi_info.
+    static Result StbiInfo(const std::filesystem::path& path, int* pX, int* pY, int* pComp);
 
 private:
     uint32_t          mWidth           = 0;
@@ -201,6 +209,7 @@ private:
     uint32_t          mPixelStride     = 0;
     uint32_t          mRowStride       = 0;
     char*             mData            = nullptr;
+    bool              mDataIsFromStbi  = false;
     std::vector<char> mInternalStorage = {};
 };
 

--- a/include/ppx/fs.h
+++ b/include/ppx/fs.h
@@ -57,6 +57,9 @@ public:
     size_t Read(void* buf, size_t count);
     size_t GetLength();
     void   Close();
+#if defined(PPX_ANDROID)
+    const void* GetBuffer();
+#endif
 
 private:
 #if defined(PPX_ANDROID)

--- a/include/ppx/mipmap.h
+++ b/include/ppx/mipmap.h
@@ -40,7 +40,13 @@ class Mipmap
 {
 public:
     Mipmap() {}
+    // Using the static, shared-memory pool is currently only safe in single-threaded applications!
+    // This should only be used for temporary mipmaps which will be destroyed prior to the creation of any new mipmap.
+    Mipmap(uint32_t width, uint32_t height, Bitmap::Format format, uint32_t levelCount, bool useStaticPool);
     Mipmap(uint32_t width, uint32_t height, Bitmap::Format format, uint32_t levelCount);
+    // Using the static, shared-memory pool is currently only safe in single-threaded applications!
+    // This should only be used for temporary mipmaps which will be destroyed prior to the creation of any new mipmap.
+    Mipmap(const Bitmap& bitmap, uint32_t levelCount, bool useStaticPool);
     Mipmap(const Bitmap& bitmap, uint32_t levelCount);
     ~Mipmap() {}
 
@@ -62,6 +68,12 @@ public:
 private:
     std::vector<char>   mData;
     std::vector<Bitmap> mMips;
+
+    // Static, shared-memory pool for temporary mipmap generation.
+    // NOTE: This is designed for single-threaded use ONLY as it's an unprotected memory block!
+    // This will need locks if the consuming paths ever become multi-threaded.
+    static std::vector<char> mStaticData;
+    bool                     mUseStaticPool = false;
 };
 
 } // namespace ppx

--- a/include/ppx/tri_mesh.h
+++ b/include/ppx/tri_mesh.h
@@ -162,6 +162,9 @@ public:
     const float3& GetBoundingBoxMin() const { return mBoundingBoxMin; }
     const float3& GetBoundingBoxMax() const { return mBoundingBoxMax; }
 
+    // Preallocates triangle, position, color, normal, texture and tangent data (as desired) based on the provided triangle count.
+    // Using this avoids doing those allocations (potentially multiple times) during the data load.
+    void     PreallocateForTriangleCount(size_t triangleCount, bool enableColors, bool enableNormals, bool enableTexCoords, bool enableTangents);
     uint32_t AppendTriangle(uint32_t v0, uint32_t v1, uint32_t v2);
     uint32_t AppendPosition(const float3& value);
     uint32_t AppendColor(const float3& value);

--- a/src/ppx/bitmap.cpp
+++ b/src/ppx/bitmap.cpp
@@ -41,6 +41,11 @@ Bitmap::Bitmap(const Bitmap& obj)
     }
 }
 
+Bitmap::~Bitmap()
+{
+    FreeStbiDataIfNeeded();
+}
+
 Bitmap& Bitmap::operator=(const Bitmap& rhs)
 {
     if (&rhs != this) {
@@ -51,6 +56,15 @@ Bitmap& Bitmap::operator=(const Bitmap& rhs)
         }
     }
     return *this;
+}
+
+void Bitmap::FreeStbiDataIfNeeded()
+{
+    if (mDataIsFromStbi && !IsNull(mData)) {
+        stbi_image_free(mData);
+        mData           = nullptr;
+        mDataIsFromStbi = false;
+    }
 }
 
 void Bitmap::InternalCtor()
@@ -70,6 +84,9 @@ Result Bitmap::InternalInitialize(uint32_t width, uint32_t height, Bitmap::Forma
     if (format == Bitmap::FORMAT_UNDEFINED) {
         return ppx::ERROR_IMAGE_INVALID_FORMAT;
     }
+
+    // In case of initialization to a preexisting object.
+    FreeStbiDataIfNeeded();
 
     uint32_t minimumRowStride = (width * Bitmap::FormatSize(format));
     if ((rowStride > 0) && (rowStride < minimumRowStride)) {
@@ -104,6 +121,9 @@ Result Bitmap::InternalInitialize(uint32_t width, uint32_t height, Bitmap::Forma
 
 Result Bitmap::InternalCopy(const Bitmap& obj)
 {
+    // In case of copies into a preexisting object.
+    FreeStbiDataIfNeeded();
+
     // Copy properties
     mWidth        = obj.mWidth;
     mHeight       = obj.mHeight;
@@ -502,17 +522,25 @@ static Result IsRadianceFile(const std::filesystem::path& path, bool& isRadiance
     return ppx::SUCCESS;
 }
 
+Result Bitmap::StbiInfo(const std::filesystem::path& path, int* pX, int* pY, int* pComp)
+{
+#if defined(PPX_ANDROID)
+    ppx::fs::File file;
+    if (!file.Open(path)) {
+        return ppx::ERROR_IMAGE_FILE_LOAD_FAILED;
+    }
+    auto stbi_result = stbi_info_from_memory((unsigned char*)file.GetBuffer(), file.GetLength(), pX, pY, pComp);
+    file.Close();
+#else
+    auto stbi_result = stbi_info(path.string().c_str(), pX, pY, pComp);
+#endif
+    return (stbi_result ? ppx::SUCCESS : ppx::ERROR_IMAGE_FILE_LOAD_FAILED);
+}
+
 bool Bitmap::IsBitmapFile(const std::filesystem::path& path)
 {
     int x, y, comp;
-#if defined(PPX_ANDROID)
-    auto bitmapBytes = fs::load_file(path.string().c_str());
-    if (!bitmapBytes.has_value())
-        return stbi__err("can't fopen", "Unable to open file");
-    return stbi_info_from_memory((unsigned char*)bitmapBytes->data(), bitmapBytes->size(), &x, &y, &comp);
-#else
-    return stbi_info(path.string().c_str(), &x, &y, &comp);
-#endif
+    return (StbiInfo(path, &x, &y, &comp) == ppx::SUCCESS);
 }
 
 Result Bitmap::GetFileProperties(const std::filesystem::path& path, uint32_t* pWidth, uint32_t* pHeight, Bitmap::Format* pFormat)
@@ -524,7 +552,7 @@ Result Bitmap::GetFileProperties(const std::filesystem::path& path, uint32_t* pW
     int x    = 0;
     int y    = 0;
     int comp = 0;
-    stbi_info(path.string().c_str(), &x, &y, &comp);
+    StbiInfo(path, &x, &y, &comp);
 
     bool   isRadiance = false;
     Result ppxres     = IsRadianceFile(path, isRadiance);
@@ -540,12 +568,40 @@ Result Bitmap::GetFileProperties(const std::filesystem::path& path, uint32_t* pW
         *pHeight = static_cast<uint32_t>(y);
     }
 
-    // Force to 4 chanenls to make things easier for the graphics APIs
+    // Force to 4 channels to make things easier for the graphics APIs.
     if (!IsNull(pFormat)) {
         *pFormat = isRadiance ? Bitmap::FORMAT_RGBA_FLOAT : Bitmap::FORMAT_RGBA_UINT8;
     }
 
     return ppx::SUCCESS;
+}
+
+char* Bitmap::StbiLoad(const std::filesystem::path& path, Bitmap::Format format, int* pWidth, int* pHeight, int* pChannels, int desiredChannels)
+{
+    char* pResult = nullptr;
+#if defined(PPX_ANDROID)
+    ppx::fs::File file;
+    if (!file.Open(path)) {
+        return pResult;
+    }
+    if (format == Bitmap::FORMAT_RGBA_FLOAT) {
+        pResult = reinterpret_cast<char*>(stbi_loadf_from_memory(
+            reinterpret_cast<const stbi_uc*>(file.GetBuffer()), file.GetLength(), pWidth, pHeight, pChannels, desiredChannels));
+    }
+    else {
+        pResult = reinterpret_cast<char*>(stbi_load_from_memory(
+            reinterpret_cast<const stbi_uc*>(file.GetBuffer()), file.GetLength(), pWidth, pHeight, pChannels, desiredChannels));
+    }
+    file.Close();
+#else
+    if (format == Bitmap::FORMAT_RGBA_FLOAT) {
+        pResult = reinterpret_cast<char*>(stbi_loadf(path.string().c_str(), pWidth, pHeight, pChannels, desiredChannels));
+    }
+    else {
+        pResult = reinterpret_cast<char*>(stbi_load(path.string().c_str(), pWidth, pHeight, pChannels, desiredChannels));
+    }
+#endif
+    return pResult;
 }
 
 Result Bitmap::LoadFile(const std::filesystem::path& path, Bitmap* pBitmap)
@@ -560,75 +616,24 @@ Result Bitmap::LoadFile(const std::filesystem::path& path, Bitmap* pBitmap)
         return ppxres;
     }
 
-    auto bitmapBytes = ppx::fs::load_file(path);
-    if (!bitmapBytes.has_value()) {
+    int            width            = 0;
+    int            height           = 0;
+    int            channels         = 0;
+    int            requiredChannels = 4; // Force to 4 channels to make things easier for the graphics APIs.
+    Bitmap::Format format           = (isRadiance) ? Bitmap::FORMAT_RGBA_FLOAT : Bitmap::FORMAT_RGBA_UINT8;
+    char*          dataPtr          = StbiLoad(path, format, &width, &height, &channels, requiredChannels);
+
+    if (IsNull(dataPtr)) {
         return ppx::ERROR_IMAGE_FILE_LOAD_FAILED;
     }
-
-    // @TODO: Refactor to remove redundancies from both blocks
-    //
-    if (isRadiance) {
-        int width            = 0;
-        int height           = 0;
-        int channels         = 0;
-        int requiredChannels = 4; // Force to 4 chanenls to make things easier for the graphics APIs
-
-        float* pData = stbi_loadf_from_memory(
-            reinterpret_cast<const stbi_uc*>(bitmapBytes.value().data()),
-            static_cast<int>(bitmapBytes.value().size()),
-            &width,
-            &height,
-            &channels,
-            requiredChannels);
-        if (pData == nullptr) {
-            return ppx::ERROR_IMAGE_FILE_LOAD_FAILED;
-        }
-
-        Bitmap::Format format = Bitmap::FORMAT_RGBA_FLOAT;
-
-        ppxres = Bitmap::Create(width, height, format, pBitmap);
-        if (!pBitmap->IsOk()) {
-            // Something has gone really wrong if this happens
-            stbi_image_free(pData);
-            return ppx::ERROR_FAILED;
-        }
-
-        size_t nbytes = Bitmap::StorageFootprint(static_cast<uint32_t>(width), static_cast<uint32_t>(height), format);
-        std::memcpy(pBitmap->GetData(), pData, nbytes);
-
-        stbi_image_free(pData);
+    ppxres = Bitmap::Create(width, height, format, dataPtr, pBitmap);
+    if (!pBitmap->IsOk()) {
+        // Something has gone really wrong if this happens
+        stbi_image_free(dataPtr);
+        return ppx::ERROR_FAILED;
     }
-    else {
-        int width            = 0;
-        int height           = 0;
-        int channels         = 0;
-        int requiredChannels = 4; // Force to 4 channels to make things easier for the graphics APIs
-
-        unsigned char* pData = stbi_load_from_memory(
-            reinterpret_cast<const stbi_uc*>(bitmapBytes.value().data()),
-            static_cast<int>(bitmapBytes.value().size()),
-            &width,
-            &height,
-            &channels,
-            requiredChannels);
-        if (IsNull(pData)) {
-            return ppx::ERROR_IMAGE_FILE_LOAD_FAILED;
-        }
-
-        Bitmap::Format format = Bitmap::FORMAT_RGBA_UINT8;
-
-        ppxres = Bitmap::Create(width, height, format, pBitmap);
-        if (Failed(ppxres)) {
-            // Something has gone really wrong if this happens
-            stbi_image_free(pData);
-            return ppx::ERROR_FAILED;
-        }
-
-        size_t nbytes = Bitmap::StorageFootprint(static_cast<uint32_t>(width), static_cast<uint32_t>(height), format);
-        std::memcpy(pBitmap->GetData(), pData, nbytes);
-
-        stbi_image_free(pData);
-    }
+    // Critical! This marks the memory as needing to be freed later!
+    pBitmap->mDataIsFromStbi = true;
 
     return ppx::SUCCESS;
 }

--- a/src/ppx/bitmap.cpp
+++ b/src/ppx/bitmap.cpp
@@ -253,6 +253,11 @@ Result Bitmap::Resize(uint32_t width, uint32_t height)
 
 Result Bitmap::ScaleTo(Bitmap* pTargetBitmap) const
 {
+    return ScaleTo(pTargetBitmap, STBIR_FILTER_DEFAULT);
+}
+
+Result Bitmap::ScaleTo(Bitmap* pTargetBitmap, stbir_filter filterType) const
+{
     if (IsNull(pTargetBitmap)) {
         return ppx::ERROR_UNEXPECTED_NULL_ARGUMENT;
     }
@@ -288,8 +293,8 @@ Result Bitmap::ScaleTo(Bitmap* pTargetBitmap) const
         0,
         STBIR_EDGE_CLAMP,
         STBIR_EDGE_CLAMP,
-        STBIR_FILTER_DEFAULT,
-        STBIR_FILTER_DEFAULT,
+        filterType,
+        filterType,
         STBIR_COLORSPACE_LINEAR,
         nullptr);
 

--- a/src/ppx/graphics_util.cpp
+++ b/src/ppx/graphics_util.cpp
@@ -237,7 +237,8 @@ Result CreateImageFromBitmap(
         SCOPED_DESTROYER.AddObject(targetImage);
     }
 
-    Mipmap mipmap = Mipmap(*pBitmap, mipLevelCount);
+    // Since this mipmap is temporary, it's safe to use the static pool.
+    Mipmap mipmap = Mipmap(*pBitmap, mipLevelCount, /* useStaticPool= */ true);
     if (!mipmap.IsOk()) {
         return ppx::ERROR_FAILED;
     }
@@ -935,7 +936,8 @@ Result CreateTextureFromBitmap(
         SCOPED_DESTROYER.AddObject(targetTexture);
     }
 
-    Mipmap mipmap = Mipmap(*pBitmap, mipLevelCount);
+    // Since this mipmap is temporary, it's safe to use the static pool.
+    Mipmap mipmap = Mipmap(*pBitmap, mipLevelCount, /* useStaticPool= */ true);
     if (!mipmap.IsOk()) {
         return ppx::ERROR_FAILED;
     }

--- a/src/ppx/mipmap.cpp
+++ b/src/ppx/mipmap.cpp
@@ -16,6 +16,7 @@
 #include "ppx/timer.h"
 
 #include "stb_image.h"
+#include "stb_image_resize.h"
 
 #include <filesystem>
 
@@ -136,7 +137,7 @@ Mipmap::Mipmap(const Bitmap& bitmap, uint32_t levelCount, bool useStaticPool)
                 Bitmap*  pPrevMip  = GetMip(prevLevel);
                 Bitmap*  pMip      = GetMip(level);
 
-                Result ppxres = pPrevMip->ScaleTo(pMip);
+                Result ppxres = pPrevMip->ScaleTo(pMip, STBIR_FILTER_BOX);
                 if (Failed(ppxres)) {
                     mData.clear();
                     mMips.clear();


### PR DESCRIPTION
Adds a number of performance tweaks to the loading process. This brings down the load for fishtornado on a Quest2 headset from ~30-40s to ~5-6s.