### PR TITLE
Add a new workflow to check if Android builds

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,35 @@
+name: Android build
+
+on:
+  pull_request:
+
+# Cancel previous runs if a more recent commit is pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  android-build:
+    name: Check Android build with gradle
+    runs-on: "ubuntu-20.04"
+    strategy:
+      fail-fast: true
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Setup Vulkan SDK
+        run: |
+          wget -q https://sdk.lunarg.com/sdk/download/1.3.216.0/linux/vulkansdk-linux-x86_64-1.3.216.0.tar.gz
+          mkdir "${HOME}/vulkan-sdk"
+          tar -xf vulkansdk-linux-x86_64-1.3.216.0.tar.gz -C "${HOME}/vulkan-sdk"
+          echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.3.216.0/x86_64" >> $GITHUB_ENV
+      - name: Build Cube sample for Android
+        run: |
+          ./gradlew assembleMobileGbufferDebug
+

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -31,5 +31,4 @@ jobs:
           echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.3.216.0/x86_64" >> $GITHUB_ENV
       - name: Build Cube sample for Android
         run: |
-          ./gradlew assembleMobileGbufferDebug
-
+          ./gradlew assembleMobile

--- a/docs/ci_testing.md
+++ b/docs/ci_testing.md
@@ -11,6 +11,7 @@ The following tests are run as part of every PR submission:
   * Full build of BigWheels, SPIR-V shaders, and Vulkan samples.
   * Unit tests.
   * Some Vulkan samples are run with a virtual framebuffer (using `xvfb`) and using Mesa's Lavapipe as the software renderer.
+* On Linux, build APKs for mobile.
 * Code formatting check that ensures code is formatted using `clang-format`.
 
 The samples run as part of the runtime tests produce screenshots that are then uploaded as GitHub artifacts. You can retrieve them by navigating to a successful CI run's page and then downloading the `screenshots` artifact.


### PR DESCRIPTION
Builds a single sample for mobile - Gbuffer

I think we could also combine all CI checks (windows, linux, android) into a single workflow with multiple jobs. But since the existing linux and windows are 2 different workflows, I created a new one for now 

Fixes https://github.com/google/bigwheels/issues/118