### PR TITLE
android: change how we replace manifest values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,11 @@ android {
         dimension 'project'
         // Package names cannot start with a number, adding prefixing.
         applicationIdSuffix ".project_" + sample_name
+        manifestPlaceholders = [
+            sampleLibraryName : "vk_" + sample_name,
+            appLabel : "vk_" + sample_name
+        ]
         it.buildConfigField "String", "sample_library_name", '"vk_' + sample_name + '"'
-        it.resValue         "string", "sample_library_name",  'vk_' + sample_name
-        it.resValue         "string", "app_label", sample_name
         externalNativeBuild {
             cmake {
                 targets "vk_" + sample_name

--- a/src/android/AndroidManifest.Quest.xml
+++ b/src/android/AndroidManifest.Quest.xml
@@ -2,7 +2,6 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="31" />
 
   <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="true"/>
   <uses-feature android:name="android.hardware.sensor.gyroscope" android:required="true"/>
@@ -16,7 +15,7 @@
   <application
       android:allowBackup="true"
       android:icon="@android:drawable/ic_info"
-      android:label="@string/app_label"
+      android:label="${appLabel}"
       android:theme="@style/Theme.AppCompat.NoActionBar"
       tools:targetApi="31">
     <activity
@@ -28,7 +27,7 @@
         <category android:name="com.oculus.intent.category.VR" />
         <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
       </intent-filter>
-      <meta-data android:name="android.app.lib_name" android:value="@string/sample_library_name"/>
+      <meta-data android:name="android.app.lib_name" android:value="${sampleLibraryName}"/>
     </activity>
   </application>
 </manifest>

--- a/src/android/AndroidManifest.XR.xml
+++ b/src/android/AndroidManifest.XR.xml
@@ -2,7 +2,6 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="31"/>
 
   <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="true"/>
   <uses-feature android:name="android.hardware.sensor.gyroscope" android:required="true"/>
@@ -13,7 +12,7 @@
   <application
       android:allowBackup="true"
       android:icon="@android:drawable/ic_info"
-      android:label="@string/app_label"
+      android:label="${appLabel}"
       android:theme="@style/Theme.AppCompat.NoActionBar"
       tools:targetApi="31">
     <activity
@@ -24,7 +23,7 @@
         <category android:name="android.intent.category.LAUNCHER" />
         <category android:name="org.khronos.openxr.intent.category.IMMERSIVE_HMD" />
       </intent-filter>
-      <meta-data android:name="android.app.lib_name" android:value="@string/sample_library_name"/>
+      <meta-data android:name="android.app.lib_name" android:value="${sampleLibraryName}"/>
     </activity>
   </application>
 </manifest>

--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -2,10 +2,11 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+
   <application
       android:allowBackup="true"
       android:icon="@android:drawable/ic_info"
-      android:label="@string/app_label"
+      android:label="${appLabel}"
       android:theme="@style/Theme.AppCompat.NoActionBar"
       tools:targetApi="31">
     <activity
@@ -15,7 +16,7 @@
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
-      <meta-data android:name="android.app.lib_name" android:value="@string/sample_library_name"/>
+      <meta-data android:name="android.app.lib_name" android:value="${sampleLibraryName}"/>
     </activity>
   </application>
 </manifest>


### PR DESCRIPTION
The initial method I found was using resource strings. But we can actually replace them at compile-time using those placeholder variables. This would simplify integration with other build-systems.