### PR TITLE
Enabled window resizing for desktop

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -414,7 +414,8 @@ private:
     Result InitializePlatform();
     Result InitializeGrfxDevice();
     Result InitializeGrfxSurface();
-    Result InitializeGrfxSwapchain();
+    Result CreateSwapchains();
+    void   DestroySwapchains();
     Result InitializeImGui();
     void   ShutdownImGui();
     void   StopGrfx();
@@ -466,6 +467,10 @@ private:
     float             mAverageFrameTime  = 0;
     double            mFirstFrameTime    = 0;
     std::deque<float> mFrameTimesMs;
+
+#if defined(PPX_MSW)
+    bool mForceInvalidateClientArea = false;
+#endif
 
 #if defined(PPX_BUILD_XR)
     XrComponent mXrComponent;

--- a/include/ppx/grfx/dx12/dx12_swapchain.h
+++ b/include/ppx/grfx/dx12/dx12_swapchain.h
@@ -55,20 +55,25 @@ public:
     Swapchain() {}
     virtual ~Swapchain() {}
 
-    virtual Result PresentInternal(
-        uint32_t                      imageIndex,
-        uint32_t                      waitSemaphoreCount,
-        const grfx::Semaphore* const* ppWaitSemaphores) override;
+    virtual Result Resize(uint32_t width, uint32_t height) override;
 
 protected:
     virtual Result CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo) override;
     virtual void   DestroyApiObjects() override;
 
+private:
     virtual Result AcquireNextImageInternal(
         uint64_t         timeout,
         grfx::Semaphore* pSemaphore,
         grfx::Fence*     pFence,
         uint32_t*        pImageIndex) override;
+
+    virtual Result PresentInternal(
+        uint32_t                      imageIndex,
+        uint32_t                      waitSemaphoreCount,
+        const grfx::Semaphore* const* ppWaitSemaphores) override;
+
+    Result CreateColorImages(uint32_t width, uint32_t height, grfx::Format format, const std::vector<ID3D12Resource*>& colorImages);
 
 private:
     DXGISwapChainPtr     mSwapchain;
@@ -84,6 +89,10 @@ private:
     //
     UINT mSyncInterval   = 1;
     BOOL mTearingEnabled = FALSE;
+
+    // Cache these for resize event
+    UINT         mFlags       = 0;
+    grfx::Format mColorFormat = grfx::FORMAT_UNDEFINED;
 };
 
 } // namespace dx12

--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -140,7 +140,10 @@ public:
         uint32_t                      waitSemaphoreCount,
         const grfx::Semaphore* const* ppWaitSemaphores);
 
-    uint32_t GetCurrentImageIndex() const { return currentImageIndex; }
+    uint32_t GetCurrentImageIndex() const { return mCurrentImageIndex; }
+
+    // D3D12 only, will return ERROR_FAILED on Vulkan
+    virtual Result Resize(uint32_t width, uint32_t height) = 0;
 
 #if defined(PPX_BUILD_XR)
     bool ShouldSkipExternalSynchronization() const
@@ -162,6 +165,14 @@ protected:
     virtual void   Destroy() override;
     friend class grfx::Device;
 
+    // Make these protected since D3D12's swapchain resize will need to call them
+    void   DestroyColorImages();
+    Result CreateDepthImages();
+    void   DestroyDepthImages();
+    Result CreateRenderPasses();
+    void   DestroyRenderPasses();
+
+private:
     virtual Result AcquireNextImageInternal(
         uint64_t         timeout,    // Nanoseconds
         grfx::Semaphore* pSemaphore, // Wait sempahore
@@ -173,7 +184,6 @@ protected:
         uint32_t                      waitSemaphoreCount,
         const grfx::Semaphore* const* ppWaitSemaphores) = 0;
 
-private:
     Result AcquireNextImageHeadless(
         uint64_t         timeout,
         grfx::Semaphore* pSemaphore,
@@ -199,9 +209,8 @@ protected:
     XrSwapchain mXrDepthSwapchain = XR_NULL_HANDLE;
 #endif
 
-    // Keeps track of the image index returned by the
-    // last AcquireNextImage call.
-    uint32_t currentImageIndex = 0;
+    // Keeps track of the image index returned by the last AcquireNextImage call.
+    uint32_t mCurrentImageIndex = 0;
 };
 
 } // namespace grfx

--- a/include/ppx/grfx/vk/vk_swapchain.h
+++ b/include/ppx/grfx/vk/vk_swapchain.h
@@ -34,7 +34,7 @@ public:
 
     VkSurfacePtr GetVkSurface() const { return mSurface; }
 
-    const VkSurfaceCapabilitiesKHR&       GetCapabilities() const { return mCapabilities; }
+    VkSurfaceCapabilitiesKHR              GetCapabilities() const;
     const std::vector<VkSurfaceFormatKHR> GetSurfaceFormats() const { return mSurfaceFormats; }
 
     virtual uint32_t GetMinImageWidth() const override;
@@ -50,7 +50,6 @@ protected:
 
 private:
     VkSurfacePtr                    mSurface;
-    VkSurfaceCapabilitiesKHR        mCapabilities = {};
     std::vector<VkSurfaceFormatKHR> mSurfaceFormats;
     std::vector<uint32_t>           mPresentableQueueFamilies;
     std::vector<VkPresentModeKHR>   mPresentModes;
@@ -70,20 +69,23 @@ public:
 
     VkSwapchainPtr GetVkSwapchain() const { return mSwapchain; }
 
-    virtual Result PresentInternal(
-        uint32_t                      imageIndex,
-        uint32_t                      waitSemaphoreCount,
-        const grfx::Semaphore* const* ppWaitSemaphores) override;
+    virtual Result Resize(uint32_t width, uint32_t height) override { return ppx::ERROR_FAILED; }
 
 protected:
     virtual Result CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo) override;
     virtual void   DestroyApiObjects() override;
 
+private:
     virtual Result AcquireNextImageInternal(
         uint64_t         timeout,
         grfx::Semaphore* pSemaphore,
         grfx::Fence*     pFence,
         uint32_t*        pImageIndex) override;
+
+    virtual Result PresentInternal(
+        uint32_t                      imageIndex,
+        uint32_t                      waitSemaphoreCount,
+        const grfx::Semaphore* const* ppWaitSemaphores) override;
 
 private:
     VkSwapchainPtr mSwapchain;

--- a/projects/01_triangle/main.cpp
+++ b/projects/01_triangle/main.cpp
@@ -27,6 +27,7 @@ class ProjApp
 public:
     virtual void Config(ppx::ApplicationSettings& settings) override;
     virtual void Setup() override;
+    virtual void Resize(uint32_t, uint32_t) override;
     virtual void Render() override;
 
 private:
@@ -56,6 +57,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui      = true;
     settings.grfx.api         = kApi;
     settings.grfx.enableDebug = false;
+    settings.window.resizable = true;
 }
 
 void ProjApp::Setup()
@@ -142,6 +144,12 @@ void ProjApp::Setup()
         mVertexBuffer->UnmapMemory();
     }
 
+    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
+    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
+}
+
+void ProjApp::Resize(uint32_t, uint32_t)
+{
     mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
     mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -416,7 +416,7 @@ Result Application::InitializeGrfxSurface()
     return ppx::SUCCESS;
 }
 
-Result Application::InitializeGrfxSwapchain()
+Result Application::CreateSwapchains()
 {
 #if defined(PPX_BUILD_XR)
     if (mSettings.xr.enable) {
@@ -518,6 +518,19 @@ Result Application::InitializeGrfxSwapchain()
     return ppx::SUCCESS;
 }
 
+void Application::DestroySwapchains()
+{
+    // Make sure the device is idle so that nothing is accessing the swapchain images
+    mDevice->WaitIdle();
+
+    // Destroy all swapchains
+    for (auto& sc : mSwapchains) {
+        mDevice->DestroySwapchain(sc);
+        sc.Reset();
+    }
+    mSwapchains.clear();
+}
+
 Result Application::InitializeImGui()
 {
     switch (mSettings.grfx.api) {
@@ -569,11 +582,7 @@ void Application::StopGrfx()
 void Application::ShutdownGrfx()
 {
     if (mInstance) {
-        for (auto& sc : mSwapchains) {
-            mDevice->DestroySwapchain(sc);
-            sc.Reset();
-        }
-        mSwapchains.clear();
+        DestroySwapchains();
 
         if (mDevice) {
             mInstance->DestroyDevice(mDevice);
@@ -780,6 +789,47 @@ void Application::ResizeCallback(uint32_t width, uint32_t height)
         mSettings.window.width  = width;
         mSettings.window.height = height;
         mWindowSurfaceInvalid   = ((width == 0) || (height == 0));
+
+        // Vulkan will return an error if either dimension is 0
+        if (!mWindowSurfaceInvalid) {
+            // D3D12 swapchain need needs resizing
+            if ((mDevice->GetApi() == grfx::API_DX_12_0) || (mDevice->GetApi() == grfx::API_DX_12_1)) {
+                // Wait for device to idle
+                mDevice->WaitIdle();
+
+                PPX_ASSERT_MSG((mSwapchains.size() == 1), "Invalid number of swapchains for D3D12");
+
+                auto ppxres = mSwapchains[0]->Resize(mSettings.window.width, mSettings.window.height);
+                if (Failed(ppxres)) {
+                    PPX_ASSERT_MSG(false, "D3D12 swapchain resize failed");
+                    // Signal the app to quit if swapchain recreation fails
+                    mWindow->Quit();
+                }
+
+#if defined(PPX_MSW)
+                mForceInvalidateClientArea = true;
+#endif
+
+                PPX_LOG_INFO("Resized application swapchain");
+                PPX_LOG_INFO("   resolution  : " << mSettings.window.width << "x" << mSettings.window.height);
+                PPX_LOG_INFO("   image count : " << mSettings.grfx.swapchain.imageCount);
+            }
+            // Vulkan swapchain needs recreation
+            else {
+                // This function will wait for device to idle
+                DestroySwapchains();
+
+                auto ppxres = CreateSwapchains();
+                if (Failed(ppxres)) {
+                    PPX_ASSERT_MSG(false, "Vulkan swapchain recreate failed");
+                    // Signal the app to quit if swapchain recreation fails
+                    mWindow->Quit();
+                }
+            }
+        }
+
+        // Dispatch resize event
+        DispatchResize(mSettings.window.width, mSettings.window.height);
     }
 }
 
@@ -994,9 +1044,11 @@ int Application::Run(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    // Create swapchain. This will be a "fake", manually-managed swapchain
-    // if headless mode is enabled.
-    ppxres = InitializeGrfxSwapchain();
+    // Create swapchains
+    //
+    // This will be a "fake", manually-managed swapchain if headless mode is enabled.
+    //
+    ppxres = CreateSwapchains();
     if (Failed(ppxres)) {
         return EXIT_FAILURE;
     }
@@ -1082,6 +1134,36 @@ int Application::Run(int argc, char** argv)
 
             // Call render
             DispatchRender();
+
+#if defined(PPX_MSW)
+            //
+            // This is for D3D12 only.
+            //
+            // Why is it necessary to force invalidate the client area?
+            //
+            // Due to a bug (or feature) in the Windows event loop when interacting
+            // with IDXGISwapchain::ResizeBuffers() - the client area is incorrectly
+            // updated. The paint message seems to get missed or is using the and
+            // outdated rect. The result is that the left and bottom of edges of the
+            // window's client area is filled with garbage.
+            //
+            // Moving the window one pixel to the left and back again causes the client
+            // area to be correctly invalidated.
+            //
+            // https://stackoverflow.com/questions/72956884/idxgiswapchain-resizebuffers-does-not-work-as-expected-with-wm-sizing
+            //
+            if (mForceInvalidateClientArea) {
+                grfx::SurfaceCreateInfo ci = {};
+                GetWindow()->FillSurfaceInfo(&ci);
+
+                RECT wr = {};
+                GetWindowRect(ci.hwnd, &wr);
+                MoveWindow(ci.hwnd, wr.left + 1, wr.top, (wr.right - wr.left), (wr.bottom - wr.top), TRUE);
+                MoveWindow(ci.hwnd, wr.left, wr.top, (wr.right - wr.left), (wr.bottom - wr.top), TRUE);
+
+                mForceInvalidateClientArea = false;
+            }
+#endif
         }
 
         // Take screenshot if this is the requested frame.

--- a/src/ppx/grfx/dx12/dx12_descriptor.cpp
+++ b/src/ppx/grfx/dx12/dx12_descriptor.cpp
@@ -336,7 +336,7 @@ Result DescriptorSet::UpdateDescriptors(uint32_t writeCount, const grfx::WriteDe
                 desc.Format                           = DXGI_FORMAT_R32_TYPELESS;
                 desc.ViewDimension                    = D3D12_UAV_DIMENSION_BUFFER;
                 desc.Buffer.FirstElement              = srcWrite.bufferOffset / 4;
-                desc.Buffer.NumElements               = sizeInBytes / 4;
+                desc.Buffer.NumElements               = static_cast<UINT>(sizeInBytes / 4);
                 desc.Buffer.StructureByteStride       = 0;
                 desc.Buffer.Flags                     = D3D12_BUFFER_UAV_FLAG_RAW;
 

--- a/src/ppx/grfx/dx12/dx12_image.cpp
+++ b/src/ppx/grfx/dx12/dx12_image.cpp
@@ -114,15 +114,18 @@ Result Image::CreateApiObjects(const grfx::ImageCreateInfo* pCreateInfo)
 
 void Image::DestroyApiObjects()
 {
-    // Reset if resource isn't external
-    if (IsNull(mCreateInfo.pApiObject)) {
-        if (mResource) {
-            mResource.Reset();
-        }
-    }
-    else {
-        // Deatch if the resource is external
-        mResource.Detach();
+    // This will release the ref to the resource regardless
+    // if it's an internal or external object. This correctly
+    // handles the refs counts for swapchain buffers so an error
+    // doesn't occur during resize events.
+    //
+    // The previous version handled internal and external objects
+    // different because reset/release caused a crash on swapchain
+    // images. This doesn't seem to be the case with this change,
+    // however please report if crashes do occur.
+    //
+    if (mResource) {
+        mResource.Reset();
     }
 
     if (mAllocation) {

--- a/src/ppx/grfx/dx12/dx12_swapchain.cpp
+++ b/src/ppx/grfx/dx12/dx12_swapchain.cpp
@@ -14,6 +14,7 @@
 
 #include "ppx/grfx/dx12/dx12_swapchain.h"
 #include "ppx/grfx/dx12/dx12_device.h"
+#include "ppx/grfx/dx12/dx12_image.h"
 #include "ppx/grfx/dx12/dx12_instance.h"
 #include "ppx/grfx/dx12/dx12_queue.h"
 #include "ppx/grfx/dx12/dx12_sync.h"
@@ -52,9 +53,10 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
     }
 
     std::vector<ID3D12Resource*> colorImages;
-    std::vector<ID3D12Resource*> depthImages;
 
 #if defined(PPX_BUILD_XR)
+    std::vector<ID3D12Resource*> depthImages;
+
     const bool isXREnabled = (mCreateInfo.pXrComponent != nullptr);
     if (isXREnabled) {
         const XrComponent& xrComponent = *mCreateInfo.pXrComponent;
@@ -131,8 +133,11 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
             return ERROR_GRFX_UNSUPPORTED_SWAPCHAIN_FORMAT;
         }
 
-        // Present mode behavior
-        UINT flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+        // Cache color format
+        mColorFormat = pCreateInfo->colorFormat;
+
+        // Make swapchain waitable
+        mFlags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
 
         // Set swapchain flags. We enable tearing if supported.
         {
@@ -149,11 +154,11 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
                 } break;
                 case grfx::PRESENT_MODE_IMMEDIATE: {
                     mSyncInterval = 0;
-                    flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+                    mFlags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
                 } break;
             }
 
-            if (flags & DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING) {
+            if (mFlags & DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING) {
                 HRESULT hr = factory->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &mTearingEnabled, sizeof(mTearingEnabled));
                 if (!SUCCEEDED(hr)) {
                     return ppx::ERROR_API_FAILURE;
@@ -173,7 +178,7 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
         DXGI_SWAP_CHAIN_DESC1 dxDesc = {};
         dxDesc.Width                 = static_cast<UINT>(pCreateInfo->width);
         dxDesc.Height                = static_cast<UINT>(pCreateInfo->height);
-        dxDesc.Format                = dx::ToDxgiFormat(pCreateInfo->colorFormat);
+        dxDesc.Format                = dx::ToDxgiFormat(mColorFormat);
         dxDesc.Stereo                = FALSE;
         dxDesc.SampleDesc.Count      = 1;
         dxDesc.SampleDesc.Quality    = 0;
@@ -182,7 +187,7 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
         dxDesc.Scaling               = DXGI_SCALING_NONE;
         dxDesc.SwapEffect            = swapEffect;
         dxDesc.AlphaMode             = DXGI_ALPHA_MODE_IGNORE;
-        dxDesc.Flags                 = flags;
+        dxDesc.Flags                 = mFlags;
 
         D3D12CommandQueuePtr::InterfaceType* pCmdQueue = ToApi(pCreateInfo->pQueue)->GetDxQueue();
         CComPtr<IDXGISwapChain1>             dxgiSwapChain;
@@ -217,10 +222,9 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
             return ppx::ERROR_API_FAILURE;
         }
 
-        // Store the texture resources created by the swapchain.
-        // Query the image count again in case the underlying swapchain
-        // modified the number of images created.
+        // Retrieve swapchain buffer pointers
         {
+            // Query the buffers count in case the underlying swapchain modified the number of buffers created.
             DXGI_SWAP_CHAIN_DESC dxDesc = {};
             HRESULT              hr     = mSwapchain->GetDesc(&dxDesc);
             if (FAILED(hr)) {
@@ -228,6 +232,7 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
                 return ppx::ERROR_API_FAILURE;
             }
 
+            // Grab the texture resources created by the swapchain.
             for (UINT i = 0; i < dxDesc.BufferCount; ++i) {
                 D3D12ResourcePtr resource;
                 HRESULT          hr = mSwapchain->GetBuffer(i, IID_PPV_ARGS(&resource));
@@ -239,35 +244,23 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
         }
     }
 
-    // Create images.
+    // Create color images
     {
-        for (size_t i = 0; i < colorImages.size(); ++i) {
-            grfx::ImageCreateInfo imageCreateInfo           = {};
-            imageCreateInfo.type                            = grfx::IMAGE_TYPE_2D;
-            imageCreateInfo.width                           = pCreateInfo->width;
-            imageCreateInfo.height                          = pCreateInfo->height;
-            imageCreateInfo.depth                           = 1;
-            imageCreateInfo.format                          = pCreateInfo->colorFormat;
-            imageCreateInfo.sampleCount                     = grfx::SAMPLE_COUNT_1;
-            imageCreateInfo.mipLevelCount                   = 1;
-            imageCreateInfo.arrayLayerCount                 = 1;
-            imageCreateInfo.usageFlags.bits.transferSrc     = true;
-            imageCreateInfo.usageFlags.bits.transferDst     = true;
-            imageCreateInfo.usageFlags.bits.sampled         = true;
-            imageCreateInfo.usageFlags.bits.storage         = true;
-            imageCreateInfo.usageFlags.bits.colorAttachment = true;
-            imageCreateInfo.pApiObject                      = colorImages[i];
+        colorImages[0]->AddRef();
+        int rc = colorImages[0]->Release();
 
-            grfx::ImagePtr image;
-            Result         ppxres = GetDevice()->CreateImage(&imageCreateInfo, &image);
-            if (Failed(ppxres)) {
-                PPX_ASSERT_MSG(false, "image create failed");
-                return ppxres;
-            }
-
-            mColorImages.push_back(image);
+        auto ppxres = CreateColorImages(pCreateInfo->width, pCreateInfo->height, pCreateInfo->colorFormat, colorImages);
+        if (Failed(ppxres)) {
+            return ppxres;
         }
 
+        colorImages[0]->AddRef();
+        rc         = colorImages[0]->Release();
+        int stopMe = 1;
+    }
+
+#if defined(PPX_BUILD_XR)
+    {
         for (size_t i = 0; i < depthImages.size(); ++i) {
             grfx::ImageCreateInfo imageCreateInfo = grfx::ImageCreateInfo::DepthStencilTarget(pCreateInfo->width, pCreateInfo->height, pCreateInfo->depthFormat, grfx::SAMPLE_COUNT_1);
             imageCreateInfo.pApiObject            = depthImages[i];
@@ -282,6 +275,7 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
             mDepthImages.push_back(image);
         }
     }
+#endif
 
     // Save queue for later use
     mQueue = ToApi(pCreateInfo->pQueue)->GetDxQueue();
@@ -294,13 +288,44 @@ void Swapchain::DestroyApiObjects()
     mFrameLatencyWaitableObject = nullptr;
 
     if (mSwapchain) {
-        //mSwapchain->Release();
         mSwapchain.Reset();
     }
 
     if (mQueue) {
         mQueue.Reset();
     }
+}
+
+Result Swapchain::CreateColorImages(uint32_t width, uint32_t height, grfx::Format format, const std::vector<ID3D12Resource*>& colorImages)
+{
+    for (size_t i = 0; i < colorImages.size(); ++i) {
+        grfx::ImageCreateInfo imageCreateInfo           = {};
+        imageCreateInfo.type                            = grfx::IMAGE_TYPE_2D;
+        imageCreateInfo.width                           = width;
+        imageCreateInfo.height                          = height;
+        imageCreateInfo.depth                           = 1;
+        imageCreateInfo.format                          = format;
+        imageCreateInfo.sampleCount                     = grfx::SAMPLE_COUNT_1;
+        imageCreateInfo.mipLevelCount                   = 1;
+        imageCreateInfo.arrayLayerCount                 = 1;
+        imageCreateInfo.usageFlags.bits.transferSrc     = true;
+        imageCreateInfo.usageFlags.bits.transferDst     = true;
+        imageCreateInfo.usageFlags.bits.sampled         = true;
+        imageCreateInfo.usageFlags.bits.storage         = true;
+        imageCreateInfo.usageFlags.bits.colorAttachment = true;
+        imageCreateInfo.pApiObject                      = colorImages[i];
+
+        grfx::ImagePtr image;
+        Result         ppxres = GetDevice()->CreateImage(&imageCreateInfo, &image);
+        if (Failed(ppxres)) {
+            PPX_ASSERT_MSG(false, "image create failed");
+            return ppxres;
+        }
+
+        mColorImages.push_back(image);
+    }
+
+    return ppx::SUCCESS;
 }
 
 Result Swapchain::AcquireNextImageInternal(
@@ -349,7 +374,8 @@ Result Swapchain::AcquireNextImageInternal(
         }
     }
 
-    currentImageIndex = *pImageIndex;
+    mCurrentImageIndex = *pImageIndex;
+
     return ppx::SUCCESS;
 }
 
@@ -374,6 +400,75 @@ Result Swapchain::PresentInternal(
         PPX_ASSERT_MSG(false, "IDXGISwapChain::Present failed");
         return ppx::ERROR_API_FAILURE;
     }
+
+    return ppx::SUCCESS;
+}
+
+Result Swapchain::Resize(uint32_t width, uint32_t height)
+{
+    mCreateInfo.width  = width;
+    mCreateInfo.height = height;
+
+    std::vector<ID3D12Resource*> colorImages;
+    for (auto& im : mColorImages) {
+        auto pRes = static_cast<dx12::Image*>(im.Get())->GetDxResource();
+        colorImages.push_back(pRes);
+    }
+
+    colorImages[0]->AddRef();
+    int rc = colorImages[0]->Release();
+
+    // Destroy these to make sure there's no reference before resizing
+    DestroyRenderPasses();
+    DestroyDepthImages();
+    DestroyColorImages();
+
+    colorImages[0]->AddRef();
+    rc = colorImages[0]->Release();
+
+    // Resize buffers
+    HRESULT hr = mSwapchain->ResizeBuffers(
+        0,                         // 0 preserves the existing buffer count
+        static_cast<UINT>(width),  // New width
+        static_cast<UINT>(height), // New height
+        DXGI_FORMAT_UNKNOWN,       // DXGI_FORMAT_UNKNOWN preserves the existing format of buffer
+        mFlags);
+    if (FAILED(hr)) {
+        return ppx::ERROR_API_FAILURE;
+    }
+
+    // Create color images
+    {
+        // Get buffer count
+        DXGI_SWAP_CHAIN_DESC desc = {};
+        HRESULT              hr   = mSwapchain->GetDesc(&desc);
+        if (FAILED(hr)) {
+            PPX_ASSERT_MSG(false, "IDXGISwapChain::GetDesc failed");
+            return ppx::ERROR_API_FAILURE;
+        }
+
+        // Grab the texture resources created by the swapchain.
+        std::vector<ID3D12Resource*> colorImages;
+        for (UINT i = 0; i < desc.BufferCount; ++i) {
+            D3D12ResourcePtr resource;
+            HRESULT          hr = mSwapchain->GetBuffer(i, IID_PPV_ARGS(&resource));
+            if (FAILED(hr)) {
+                return ppx::ERROR_API_FAILURE;
+            }
+            colorImages.push_back(resource);
+        }
+
+        auto ppxres = CreateColorImages(width, height, mColorFormat, colorImages);
+        if (Failed(ppxres)) {
+            return ppxres;
+        }
+    }
+
+    // Create depth images
+    CreateDepthImages();
+
+    // Create render passes
+    CreateRenderPasses();
 
     return ppx::SUCCESS;
 }

--- a/src/ppx/grfx/grfx_swapchain.cpp
+++ b/src/ppx/grfx/grfx_swapchain.cpp
@@ -44,13 +44,15 @@ Result Swapchain::Create(const grfx::SwapchainCreateInfo* pCreateInfo)
                      << "   requested : " << pCreateInfo->imageCount);
     }
 
-    // NOTE: mCreateInfo.imageCount will be used from this point on.
+    //
+    // NOTE: mCreateInfo will be used from this point on.
+    //
 
     // Create color images if needed. This is only needed if we're creating
     // a headless swapchain.
     if (mColorImages.empty()) {
         for (uint32_t i = 0; i < mCreateInfo.imageCount; ++i) {
-            grfx::ImageCreateInfo rtCreateInfo = ImageCreateInfo::RenderTarget2D(pCreateInfo->width, pCreateInfo->height, pCreateInfo->colorFormat);
+            grfx::ImageCreateInfo rtCreateInfo = ImageCreateInfo::RenderTarget2D(mCreateInfo.width, mCreateInfo.height, mCreateInfo.colorFormat);
             rtCreateInfo.ownership             = grfx::OWNERSHIP_RESTRICTED;
             rtCreateInfo.RTVClearValue         = {0.0f, 0.0f, 0.0f, 0.0f};
             rtCreateInfo.initialState          = grfx::RESOURCE_STATE_PRESENT;
@@ -73,74 +75,21 @@ Result Swapchain::Create(const grfx::SwapchainCreateInfo* pCreateInfo)
     // Create depth images if needed. This is usually needed for both normal swapchains
     // and headless swapchains, but not needed for XR swapchains which create their own
     // depth images.
-    if (pCreateInfo->depthFormat != grfx::FORMAT_UNDEFINED && mDepthImages.empty()) {
-        for (uint32_t i = 0; i < mCreateInfo.imageCount; ++i) {
-            grfx::ImageCreateInfo dpCreateInfo = ImageCreateInfo::DepthStencilTarget(pCreateInfo->width, pCreateInfo->height, pCreateInfo->depthFormat);
-            dpCreateInfo.ownership             = grfx::OWNERSHIP_RESTRICTED;
-            dpCreateInfo.DSVClearValue         = {1.0f, 0xFF};
-
-            grfx::ImagePtr depthStencilTarget;
-            ppxres = GetDevice()->CreateImage(&dpCreateInfo, &depthStencilTarget);
-            if (Failed(ppxres)) {
-                return ppxres;
-            }
-
-            mDepthImages.push_back(depthStencilTarget);
-        }
+    //
+    ppxres = CreateDepthImages();
+    if (Failed(ppxres)) {
+        return ppxres;
     }
 
-    // Create render passes with grfx::ATTACHMENT_LOAD_OP_CLEAR for render target.
-    for (size_t i = 0; i < mCreateInfo.imageCount; ++i) {
-        grfx::RenderPassCreateInfo3 rpCreateInfo = {};
-        rpCreateInfo.width                       = pCreateInfo->width;
-        rpCreateInfo.height                      = pCreateInfo->height;
-        rpCreateInfo.renderTargetCount           = 1;
-        rpCreateInfo.pRenderTargetImages[0]      = mColorImages[i];
-        rpCreateInfo.pDepthStencilImage          = mDepthImages.empty() ? nullptr : mDepthImages[i];
-        rpCreateInfo.renderTargetClearValues[0]  = {{0.0f, 0.0f, 0.0f, 0.0f}};
-        rpCreateInfo.depthStencilClearValue      = {1.0f, 0xFF};
-        rpCreateInfo.renderTargetLoadOps[0]      = grfx::ATTACHMENT_LOAD_OP_CLEAR;
-        rpCreateInfo.depthLoadOp                 = grfx::ATTACHMENT_LOAD_OP_CLEAR;
-        rpCreateInfo.ownership                   = grfx::OWNERSHIP_RESTRICTED;
-
-        grfx::RenderPassPtr renderPass;
-        ppxres = GetDevice()->CreateRenderPass(&rpCreateInfo, &renderPass);
-        if (Failed(ppxres)) {
-            PPX_ASSERT_MSG(false, "grfx::Swapchain::CreateRenderPass(CLEAR) failed");
-            return ppxres;
-        }
-
-        mClearRenderPasses.push_back(renderPass);
-    }
-
-    // Create render passes with grfx::ATTACHMENT_LOAD_OP_LOAD for render target.
-    for (size_t i = 0; i < mCreateInfo.imageCount; ++i) {
-        grfx::RenderPassCreateInfo3 rpCreateInfo = {};
-        rpCreateInfo.width                       = pCreateInfo->width;
-        rpCreateInfo.height                      = pCreateInfo->height;
-        rpCreateInfo.renderTargetCount           = 1;
-        rpCreateInfo.pRenderTargetImages[0]      = mColorImages[i];
-        rpCreateInfo.pDepthStencilImage          = mDepthImages.empty() ? nullptr : mDepthImages[i];
-        rpCreateInfo.renderTargetClearValues[0]  = {{0.0f, 0.0f, 0.0f, 0.0f}};
-        rpCreateInfo.depthStencilClearValue      = {1.0f, 0xFF};
-        rpCreateInfo.renderTargetLoadOps[0]      = grfx::ATTACHMENT_LOAD_OP_LOAD;
-        rpCreateInfo.depthLoadOp                 = grfx::ATTACHMENT_LOAD_OP_CLEAR;
-        rpCreateInfo.ownership                   = grfx::OWNERSHIP_RESTRICTED;
-
-        grfx::RenderPassPtr renderPass;
-        ppxres = GetDevice()->CreateRenderPass(&rpCreateInfo, &renderPass);
-        if (Failed(ppxres)) {
-            PPX_ASSERT_MSG(false, "grfx::Swapchain::CreateRenderPass(LOAD) failed");
-            return ppxres;
-        }
-
-        mLoadRenderPasses.push_back(renderPass);
+    ppxres = CreateRenderPasses();
+    if (Failed(ppxres)) {
+        return ppxres;
     }
 
     if (IsHeadless()) {
-        // Set currentImageIndex to (imageCount - 1) so that the first
+        // Set mCurrentImageIndex to (imageCount - 1) so that the first
         // AcquireNextImage call acquires the first image at index 0.
-        currentImageIndex = mCreateInfo.imageCount - 1;
+        mCurrentImageIndex = mCreateInfo.imageCount - 1;
 
         // Create command buffers to signal and wait semaphores at
         // AcquireNextImage and Present calls.
@@ -153,7 +102,7 @@ Result Swapchain::Create(const grfx::SwapchainCreateInfo* pCreateInfo)
 
     PPX_LOG_INFO("Swapchain created");
     PPX_LOG_INFO("   "
-                 << "resolution  : " << pCreateInfo->width << "x" << pCreateInfo->height);
+                 << "resolution  : " << mCreateInfo.width << "x" << mCreateInfo.height);
     PPX_LOG_INFO("   "
                  << "image count : " << mCreateInfo.imageCount);
 
@@ -162,33 +111,11 @@ Result Swapchain::Create(const grfx::SwapchainCreateInfo* pCreateInfo)
 
 void Swapchain::Destroy()
 {
-    for (auto& elem : mClearRenderPasses) {
-        if (elem) {
-            GetDevice()->DestroyRenderPass(elem);
-        }
-    }
-    mClearRenderPasses.clear();
+    DestroyRenderPasses();
 
-    for (auto& elem : mLoadRenderPasses) {
-        if (elem) {
-            GetDevice()->DestroyRenderPass(elem);
-        }
-    }
-    mLoadRenderPasses.clear();
+    DestroyDepthImages();
 
-    for (auto& elem : mDepthImages) {
-        if (elem) {
-            GetDevice()->DestroyImage(elem);
-        }
-    }
-    mDepthImages.clear();
-
-    for (auto& elem : mColorImages) {
-        if (elem) {
-            GetDevice()->DestroyImage(elem);
-        }
-    }
-    mColorImages.clear();
+    DestroyColorImages();
 
 #if defined(PPX_BUILD_XR)
     if (mXrColorSwapchain != XR_NULL_HANDLE) {
@@ -207,6 +134,132 @@ void Swapchain::Destroy()
     mHeadlessCommandBuffers.clear();
 
     grfx::DeviceObject<grfx::SwapchainCreateInfo>::Destroy();
+}
+
+void Swapchain::DestroyColorImages()
+{
+    for (auto& elem : mColorImages) {
+        if (elem) {
+            GetDevice()->DestroyImage(elem);
+        }
+    }
+    mColorImages.clear();
+}
+
+Result Swapchain::CreateDepthImages()
+{
+#if defined(PPX_BUILD_XR)
+    PPX_ASSERT_MSG(false, "Swapchain::CreateDepthImages() is meant for non-XR applications, was it called by mistake?");
+#endif
+
+    if ((mCreateInfo.depthFormat != grfx::FORMAT_UNDEFINED) && mDepthImages.empty()) {
+        for (uint32_t i = 0; i < mCreateInfo.imageCount; ++i) {
+            grfx::ImageCreateInfo dpCreateInfo = ImageCreateInfo::DepthStencilTarget(mCreateInfo.width, mCreateInfo.height, mCreateInfo.depthFormat);
+            dpCreateInfo.ownership             = grfx::OWNERSHIP_RESTRICTED;
+            dpCreateInfo.DSVClearValue         = {1.0f, 0xFF};
+
+            grfx::ImagePtr depthStencilTarget;
+            auto ppxres = GetDevice()->CreateImage(&dpCreateInfo, &depthStencilTarget);
+            if (Failed(ppxres)) {
+                return ppxres;
+            }
+
+            mDepthImages.push_back(depthStencilTarget);
+        }
+    }
+
+    return ppx::SUCCESS;
+}
+
+void Swapchain::DestroyDepthImages()
+{
+#if defined(PPX_BUILD_XR)
+    PPX_ASSERT_MSG(false, "Swapchain::DestroyDepthImages() is meant for non-XR applications, was it called by mistake?");
+#endif
+
+    for (auto& elem : mDepthImages) {
+        if (elem) {
+            GetDevice()->DestroyImage(elem);
+        }
+    }
+    mDepthImages.clear();
+}
+
+Result Swapchain::CreateRenderPasses()
+{
+    uint32_t imageCount = CountU32(mColorImages);
+    PPX_ASSERT_MSG((imageCount > 0), "No color images found for swapchain renderpasses");
+
+    // Create render passes with grfx::ATTACHMENT_LOAD_OP_CLEAR for render target.
+    for (size_t i = 0; i < imageCount; ++i) {
+        grfx::RenderPassCreateInfo3 rpCreateInfo = {};
+        rpCreateInfo.width                       = mCreateInfo.width;
+        rpCreateInfo.height                      = mCreateInfo.height;
+        rpCreateInfo.renderTargetCount           = 1;
+        rpCreateInfo.pRenderTargetImages[0]      = mColorImages[i];
+        rpCreateInfo.pDepthStencilImage          = mDepthImages.empty() ? nullptr : mDepthImages[i];
+        rpCreateInfo.renderTargetClearValues[0]  = {{0.0f, 0.0f, 0.0f, 0.0f}};
+        rpCreateInfo.depthStencilClearValue      = {1.0f, 0xFF};
+        rpCreateInfo.renderTargetLoadOps[0]      = grfx::ATTACHMENT_LOAD_OP_CLEAR;
+        rpCreateInfo.depthLoadOp                 = grfx::ATTACHMENT_LOAD_OP_CLEAR;
+        rpCreateInfo.ownership                   = grfx::OWNERSHIP_RESTRICTED;
+
+        grfx::RenderPassPtr renderPass;
+        auto ppxres = GetDevice()->CreateRenderPass(&rpCreateInfo, &renderPass);
+        if (Failed(ppxres)) {
+            PPX_ASSERT_MSG(false, "grfx::Swapchain::CreateRenderPass(CLEAR) failed");
+            return ppxres;
+        }
+
+        mClearRenderPasses.push_back(renderPass);
+    }
+
+    // Create render passes with grfx::ATTACHMENT_LOAD_OP_LOAD for render target.
+    for (size_t i = 0; i < imageCount; ++i) {
+        grfx::RenderPassCreateInfo3 rpCreateInfo = {};
+        rpCreateInfo.width                       = mCreateInfo.width;
+        rpCreateInfo.height                      = mCreateInfo.height;
+        rpCreateInfo.renderTargetCount           = 1;
+        rpCreateInfo.pRenderTargetImages[0]      = mColorImages[i];
+        rpCreateInfo.pDepthStencilImage          = mDepthImages.empty() ? nullptr : mDepthImages[i];
+        rpCreateInfo.renderTargetClearValues[0]  = {{0.0f, 0.0f, 0.0f, 0.0f}};
+        rpCreateInfo.depthStencilClearValue      = {1.0f, 0xFF};
+        rpCreateInfo.renderTargetLoadOps[0]      = grfx::ATTACHMENT_LOAD_OP_LOAD;
+        rpCreateInfo.depthLoadOp                 = grfx::ATTACHMENT_LOAD_OP_CLEAR;
+        rpCreateInfo.ownership                   = grfx::OWNERSHIP_RESTRICTED;
+
+        grfx::RenderPassPtr renderPass;
+        auto ppxres = GetDevice()->CreateRenderPass(&rpCreateInfo, &renderPass);
+        if (Failed(ppxres)) {
+            PPX_ASSERT_MSG(false, "grfx::Swapchain::CreateRenderPass(LOAD) failed");
+            return ppxres;
+        }
+
+        mLoadRenderPasses.push_back(renderPass);
+    }
+
+    return ppx::SUCCESS;
+}
+
+void Swapchain::DestroyRenderPasses()
+{
+#if defined(PPX_BUILD_XR)
+    PPX_ASSERT_MSG(false, "Swapchain::DestroyRenderPasses() is meant for non-XR applications, was it called by mistake?");
+#endif
+
+    for (auto& elem : mClearRenderPasses) {
+        if (elem) {
+            GetDevice()->DestroyRenderPass(elem);
+        }
+    }
+    mClearRenderPasses.clear();
+
+    for (auto& elem : mLoadRenderPasses) {
+        if (elem) {
+            GetDevice()->DestroyRenderPass(elem);
+        }
+    }
+    mLoadRenderPasses.clear();
 }
 
 bool Swapchain::IsHeadless() const
@@ -325,10 +378,10 @@ Result Swapchain::Present(
 
 Result Swapchain::AcquireNextImageHeadless(uint64_t timeout, grfx::Semaphore* pSemaphore, grfx::Fence* pFence, uint32_t* pImageIndex)
 {
-    *pImageIndex      = (currentImageIndex + 1u) % CountU32(mColorImages);
-    currentImageIndex = *pImageIndex;
+    *pImageIndex       = (mCurrentImageIndex + 1u) % CountU32(mColorImages);
+    mCurrentImageIndex = *pImageIndex;
 
-    grfx::CommandBufferPtr commandBuffer = mHeadlessCommandBuffers[currentImageIndex];
+    grfx::CommandBufferPtr commandBuffer = mHeadlessCommandBuffers[mCurrentImageIndex];
 
     commandBuffer->Begin();
     commandBuffer->End();
@@ -346,7 +399,7 @@ Result Swapchain::AcquireNextImageHeadless(uint64_t timeout, grfx::Semaphore* pS
 
 Result Swapchain::PresentHeadless(uint32_t imageIndex, uint32_t waitSemaphoreCount, const grfx::Semaphore* const* ppWaitSemaphores)
 {
-    grfx::CommandBufferPtr commandBuffer = mHeadlessCommandBuffers[currentImageIndex];
+    grfx::CommandBufferPtr commandBuffer = mHeadlessCommandBuffers[mCurrentImageIndex];
 
     commandBuffer->Begin();
     commandBuffer->End();


### PR DESCRIPTION
This change enables window resizing for desktop applications for D3D12 and Vulkan. Each API takes a different path for resizing due how their swapchains are handled.

D3D12: IDXGISwapChain::ResizeBuffers is used. grfx::Swapchain::Resize() was added to handle window resize events. There is a weird workaround for D3D12 to correctly invalidate the client area on resizes.

Vulkan: The swapchain is destroyed and recreated.
grfx::Swapchain::Resize() returns an error on Vulkan.

Changes:
- Removed the surface caps caching for Vulkan. The caching was causing the surface width/height to be locked into when the surface was created.
- Fixed AddRef/Releaase related bug in D3D12's image class that was causing resource references not to be released when the resource was external.
- Enabled window resizing for 01_triangle sample.
- Fixed some casting warnings