### PR TITLE
Use Application::{GetScissor,GetViewport}().

### DIFF
--- a/benchmarks/compute_operations/main.cpp
+++ b/benchmarks/compute_operations/main.cpp
@@ -57,8 +57,6 @@ private:
     ppx::grfx::PipelineInterfacePtr mPipelineInterface;
     ppx::grfx::GraphicsPipelinePtr  mPipeline;
     ppx::grfx::BufferPtr            mVertexBuffer;
-    grfx::Viewport                  mViewport;
-    grfx::Rect                      mScissorRect;
     grfx::VertexBinding             mVertexBinding;
     uint2                           mRenderTargetSize;
 
@@ -185,9 +183,6 @@ void ProjApp::Setup()
 
         mPerFrame.push_back(frame);
     }
-
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::SetupComputeShaderPass()

--- a/benchmarks/render_target/main.cpp
+++ b/benchmarks/render_target/main.cpp
@@ -60,8 +60,6 @@ private:
     ppx::grfx::GraphicsPipelinePtr  mPipeline;
     ppx::grfx::BufferPtr            mVertexBuffer;
     grfx::DrawPassPtr               mDrawPass;
-    grfx::Viewport                  mViewport;
-    grfx::Rect                      mScissorRect;
     grfx::VertexBinding             mVertexBinding;
 
     // Options
@@ -178,9 +176,6 @@ void ProjApp::Setup()
 
         mPerFrame.push_back(frame);
     }
-
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::SetupDrawToTexturePass()
@@ -281,9 +276,6 @@ void ProjApp::SetupDrawToTexturePass()
         memcpy(pAddr, vertexData.data(), dataSize);
         mVertexBuffer->UnmapMemory();
     }
-
-    mViewport    = {0, 0, float(mRenderTargetSize.x), float(mRenderTargetSize.y), 0, 1};
-    mScissorRect = {0, 0, mRenderTargetSize.x, mRenderTargetSize.y};
 }
 
 void ProjApp::SetupDrawToSwapchain()

--- a/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
+++ b/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
@@ -54,8 +54,6 @@ private:
     ppx::grfx::ShaderModulePtr      mPS;
     ppx::grfx::PipelineInterfacePtr mPipelineInterface;
     ppx::grfx::GraphicsPipelinePtr  mPipeline;
-    grfx::Viewport                  mViewport;
-    grfx::Rect                      mScissorRect;
 
     // For drawing into the swapchain
     grfx::DescriptorSetLayoutPtr mDrawToSwapchainLayout;
@@ -294,9 +292,6 @@ void ProjApp::Setup()
 
         mPerFrame.push_back(frame);
     }
-
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::Render()

--- a/projects/01_triangle/main.cpp
+++ b/projects/01_triangle/main.cpp
@@ -45,8 +45,6 @@ private:
     ppx::grfx::PipelineInterfacePtr mPipelineInterface;
     ppx::grfx::GraphicsPipelinePtr  mPipeline;
     ppx::grfx::BufferPtr            mVertexBuffer;
-    grfx::Viewport                  mViewport;
-    grfx::Rect                      mScissorRect;
     grfx::VertexBinding             mVertexBinding;
 };
 
@@ -141,9 +139,6 @@ void ProjApp::Setup()
         memcpy(pAddr, vertexData.data(), dataSize);
         mVertexBuffer->UnmapMemory();
     }
-
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::Render()
@@ -176,8 +171,8 @@ void ProjApp::Render()
         frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
         frame.cmd->BeginRenderPass(&beginInfo);
         {
-            frame.cmd->SetScissors(1, &mScissorRect);
-            frame.cmd->SetViewports(1, &mViewport);
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
             frame.cmd->BindGraphicsDescriptorSets(mPipelineInterface, 0, nullptr);
             frame.cmd->BindGraphicsPipeline(mPipeline);
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());

--- a/projects/02_triangle_spinning/main.cpp
+++ b/projects/02_triangle_spinning/main.cpp
@@ -49,8 +49,6 @@ private:
     ppx::grfx::DescriptorSetLayoutPtr mDescriptorSetLayout;
     ppx::grfx::DescriptorSetPtr       mDescriptorSet;
     ppx::grfx::BufferPtr              mUniformBuffer;
-    grfx::Viewport                    mViewport;
-    grfx::Rect                        mScissorRect;
     grfx::VertexBinding               mVertexBinding;
 };
 
@@ -178,10 +176,6 @@ void ProjApp::Setup()
         memcpy(pAddr, vertexData.data(), dataSize);
         mVertexBuffer->UnmapMemory();
     }
-
-    // Viewport and scissor rect
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::Render()
@@ -225,8 +219,8 @@ void ProjApp::Render()
         frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
         frame.cmd->BeginRenderPass(&beginInfo);
         {
-            frame.cmd->SetScissors(1, &mScissorRect);
-            frame.cmd->SetViewports(1, &mViewport);
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
             frame.cmd->BindGraphicsDescriptorSets(mPipelineInterface, 1, &mDescriptorSet);
             frame.cmd->BindGraphicsPipeline(mPipeline);
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());

--- a/projects/03_square_textured/main.cpp
+++ b/projects/03_square_textured/main.cpp
@@ -53,8 +53,6 @@ private:
     ppx::grfx::ImagePtr               mImage;
     ppx::grfx::SamplerPtr             mSampler;
     ppx::grfx::SampledImageViewPtr    mSampledImageView;
-    grfx::Viewport                    mViewport;
-    grfx::Rect                        mScissorRect;
     grfx::VertexBinding               mVertexBinding;
 };
 
@@ -214,10 +212,6 @@ void ProjApp::Setup()
         memcpy(pAddr, vertexData.data(), dataSize);
         mVertexBuffer->UnmapMemory();
     }
-
-    // Viewport and scissor rect
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::Render()
@@ -261,8 +255,8 @@ void ProjApp::Render()
         frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
         frame.cmd->BeginRenderPass(&beginInfo);
         {
-            frame.cmd->SetScissors(1, &mScissorRect);
-            frame.cmd->SetViewports(1, &mViewport);
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
             frame.cmd->BindGraphicsDescriptorSets(mPipelineInterface, 1, &mDescriptorSet);
             frame.cmd->BindGraphicsPipeline(mPipeline);
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());

--- a/projects/04_cube/main.cpp
+++ b/projects/04_cube/main.cpp
@@ -49,8 +49,6 @@ private:
     ppx::grfx::DescriptorSetLayoutPtr mDescriptorSetLayout;
     ppx::grfx::DescriptorSetPtr       mDescriptorSet;
     ppx::grfx::BufferPtr              mUniformBuffer;
-    grfx::Viewport                    mViewport;
-    grfx::Rect                        mScissorRect;
     grfx::VertexBinding               mVertexBinding;
 };
 
@@ -218,10 +216,6 @@ void ProjApp::Setup()
         memcpy(pAddr, vertexData.data(), dataSize);
         mVertexBuffer->UnmapMemory();
     }
-
-    // Viewport and scissor rect
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::Render()
@@ -269,8 +263,8 @@ void ProjApp::Render()
         frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
         frame.cmd->BeginRenderPass(&beginInfo);
         {
-            frame.cmd->SetScissors(1, &mScissorRect);
-            frame.cmd->SetViewports(1, &mViewport);
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
             frame.cmd->BindGraphicsDescriptorSets(mPipelineInterface, 1, &mDescriptorSet);
             frame.cmd->BindGraphicsPipeline(mPipeline);
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());

--- a/projects/05_cube_textured/main.cpp
+++ b/projects/05_cube_textured/main.cpp
@@ -53,8 +53,6 @@ private:
     ppx::grfx::ImagePtr               mImage;
     ppx::grfx::SamplerPtr             mSampler;
     ppx::grfx::SampledImageViewPtr    mSampledImageView;
-    grfx::Viewport                    mViewport;
-    grfx::Rect                        mScissorRect;
     grfx::VertexBinding               mVertexBinding;
 };
 
@@ -257,9 +255,6 @@ void ProjApp::Setup()
         mVertexBuffer->UnmapMemory();
     }
 
-    // Viewport and scissor rect
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::Render()
@@ -341,8 +336,8 @@ void ProjApp::Render()
         frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
         frame.cmd->BeginRenderPass(&beginInfo);
         {
-            frame.cmd->SetScissors(1, &mScissorRect);
-            frame.cmd->SetViewports(1, &mViewport);
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
             frame.cmd->BindGraphicsPipeline(mPipeline);
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());
 

--- a/projects/06_compute_fill/main.cpp
+++ b/projects/06_compute_fill/main.cpp
@@ -59,8 +59,6 @@ private:
     grfx::SamplerPtr             mSampler;
     grfx::SampledImageViewPtr    mSampledImageView;
     grfx::StorageImageViewPtr    mStorageImageView;
-    grfx::Viewport               mViewport;
-    grfx::Rect                   mScissorRect;
     grfx::VertexBinding          mVertexBinding;
 };
 
@@ -262,10 +260,6 @@ void ProjApp::Setup()
         memcpy(pAddr, vertexData.data(), dataSize);
         mVertexBuffer->UnmapMemory();
     }
-
-    // Viewport and scissor rect
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::Render()
@@ -317,8 +311,8 @@ void ProjApp::Render()
         frame.cmd->BeginRenderPass(&beginInfo);
         {
             // Draw texture
-            frame.cmd->SetScissors(1, &mScissorRect);
-            frame.cmd->SetViewports(1, &mViewport);
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
             frame.cmd->BindGraphicsDescriptorSets(mGraphicsPipelineInterface, 1, &mGraphicsDescriptorSet);
             frame.cmd->BindGraphicsPipeline(mGraphicsPipeline);
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());

--- a/projects/07_draw_indexed/main.cpp
+++ b/projects/07_draw_indexed/main.cpp
@@ -50,8 +50,6 @@ private:
     grfx::DescriptorSetLayoutPtr mDescriptorSetLayout;
     grfx::DescriptorSetPtr       mDescriptorSet;
     grfx::BufferPtr              mUniformBuffer;
-    grfx::Viewport               mViewport;
-    grfx::Rect                   mScissorRect;
     grfx::VertexBinding          mVertexBinding;
 };
 
@@ -245,10 +243,6 @@ void ProjApp::Setup()
         memcpy(pAddr, indexData.data(), dataSize);
         mIndexBuffer->UnmapMemory();
     }
-
-    // Viewport and scissor rect
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::Render()
@@ -296,8 +290,8 @@ void ProjApp::Render()
         frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
         frame.cmd->BeginRenderPass(&beginInfo);
         {
-            frame.cmd->SetScissors(1, &mScissorRect);
-            frame.cmd->SetViewports(1, &mViewport);
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());
             frame.cmd->BindGraphicsDescriptorSets(mPipelineInterface, 1, &mDescriptorSet);
             frame.cmd->BindGraphicsPipeline(mPipeline);

--- a/projects/11_compressed_texture/main.cpp
+++ b/projects/11_compressed_texture/main.cpp
@@ -76,8 +76,6 @@ private:
     ppx::grfx::BufferPtr              mVertexBuffer;
     ppx::grfx::DescriptorPoolPtr      mDescriptorPool;
     ppx::grfx::DescriptorSetLayoutPtr mDescriptorSetLayout;
-    grfx::Viewport                    mViewport;
-    grfx::Rect                        mScissorRect;
     grfx::VertexBinding               mVertexBinding;
     std::vector<TexturedShape>        mShapes;
 };
@@ -287,10 +285,6 @@ void ProjApp::Setup()
         memcpy(pAddr, vertexData.data(), dataSize);
         mVertexBuffer->UnmapMemory();
     }
-
-    // Viewport and scissor rect
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::Render()
@@ -340,8 +334,8 @@ void ProjApp::Render()
         frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
         frame.cmd->BeginRenderPass(&beginInfo);
         {
-            frame.cmd->SetScissors(1, &mScissorRect);
-            frame.cmd->SetViewports(1, &mViewport);
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
             frame.cmd->BindGraphicsPipeline(mPipeline);
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());
 

--- a/projects/22_image_filter/main.cpp
+++ b/projects/22_image_filter/main.cpp
@@ -55,8 +55,6 @@ private:
     grfx::GraphicsPipelinePtr  mPipeline;
     grfx::BufferPtr            mVertexBuffer;
     grfx::BufferPtr            mUniformBuffer;
-    grfx::Viewport             mViewport;
-    grfx::Rect                 mScissorRect;
     grfx::VertexBinding        mVertexBinding;
 
     // Compute shader
@@ -150,9 +148,6 @@ void ProjApp::Setup()
 
         mPerFrame.push_back(frame);
     }
-
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::SetupComputeShaderPass()
@@ -499,8 +494,8 @@ void ProjApp::Render()
         frame.cmd->BeginRenderPass(&beginInfo);
         {
             // Draw texture
-            frame.cmd->SetScissors(1, &mScissorRect);
-            frame.cmd->SetViewports(1, &mViewport);
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
             frame.cmd->BindGraphicsDescriptorSets(mPipelineInterface, 1, &mDrawToSwapchainSet);
             frame.cmd->BindGraphicsPipeline(mPipeline);
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());

--- a/projects/27_mipmap_demo/main.cpp
+++ b/projects/27_mipmap_demo/main.cpp
@@ -54,8 +54,6 @@ private:
     ppx::grfx::ImagePtr               mImage[2];
     ppx::grfx::SamplerPtr             mSampler;
     ppx::grfx::SampledImageViewPtr    mSampledImageView[2];
-    grfx::Viewport                    mViewport;
-    grfx::Rect                        mScissorRect;
     grfx::VertexBinding               mVertexBinding;
     int                               mLevelRight;
     int                               mLevelLeft;
@@ -247,10 +245,6 @@ void ProjApp::Setup()
         memcpy(pAddr, vertexData.data(), dataSize);
         mVertexBuffer->UnmapMemory();
     }
-
-    // Viewport and scissor rect
-    mViewport    = {0, 0, float(GetWindowWidth()), float(GetWindowHeight()), 0, 1};
-    mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
 void ProjApp::Render()
@@ -317,8 +311,8 @@ void ProjApp::Render()
         frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
         frame.cmd->BeginRenderPass(&beginInfo);
         {
-            frame.cmd->SetScissors(1, &mScissorRect);
-            frame.cmd->SetViewports(1, &mViewport);
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
             frame.cmd->BindGraphicsPipeline(mPipeline);
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());
 


### PR DESCRIPTION
It's used by some samples already.

Some benchmark has more complicated logic regarding viewport size, so they are left alone.