### PR TITLE
Explicitly set the gradle build action version

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           submodules: 'true'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
       - name: Setup Vulkan SDK
         run: |
           wget -q https://sdk.lunarg.com/sdk/download/1.3.216.0/linux/vulkansdk-linux-x86_64-1.3.216.0.tar.gz


### PR DESCRIPTION
There seems to be a vulnerability fixed in 2.4.2.