### PR TITLE
Fix for 15_basic_material on Android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ android {
         triangle      defineFlavor('01_triangle')
         cube          defineFlavor('04_cube')
         cubexr        defineFlavor('04_cube_xr')
+        basicmaterial defineFlavor('15_basic_material')
         gbuffer       defineFlavor('16_gbuffer')
         fishtornado   defineFlavor('fishtornado')
         fishtornadoxr defineFlavor('fishtornado_xr')
@@ -149,7 +150,7 @@ android {
             manifest.srcFile 'src/android/AndroidManifest.xml'
             java.srcDirs = [ 'src/android' ]
             assets {
-                srcDirs 'assets'
+                srcDirs 'assets', "third_party/assets"
             }
         }
         openxr {

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1079,7 +1079,7 @@ int Application::Run(int argc, char** argv)
         DispatchSetup();
 
         double setupEndTime = timer.SecondsSinceStart();
-        float  fnElapsed = static_cast<float>(setupEndTime - setupStartTime);
+        float  fnElapsed    = static_cast<float>(setupEndTime - setupStartTime);
         PPX_LOG_INFO("Setup() took " << FloatString(fnElapsed) << " seconds to complete");
     }
 

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1071,7 +1071,17 @@ int Application::Run(int argc, char** argv)
     }
 
     // Call setup
-    DispatchSetup();
+    {
+        Timer timer;
+        PPX_ASSERT_MSG(timer.Start() == ppx::TIMER_RESULT_SUCCESS, "timer start failed");
+        double setupStartTime = timer.SecondsSinceStart();
+
+        DispatchSetup();
+
+        double setupEndTime = timer.SecondsSinceStart();
+        float  fnElapsed = static_cast<float>(setupEndTime - setupStartTime);
+        PPX_LOG_INFO("Setup() took " << FloatString(fnElapsed) << " seconds to complete");
+    }
 
     // ---------------------------------------------------------------------------------------------
     // Main loop [BEGIN]


### PR DESCRIPTION
This fixes #140.

- Updated IBL loading work properly on Android, not the most efficient method but that will be addressed in a follow up PR.
- Added logging to show long an application Setup() takes for easier eyeball benchmarking.
- Added 15_basic_material to Android samples.