### PR TITLE
Explicitly set the VMA VK version.

### DIFF
--- a/include/ppx/grfx/vk/vk_config_platform.h
+++ b/include/ppx/grfx/vk/vk_config_platform.h
@@ -41,6 +41,7 @@
 #endif
 // clang-format on
 #include <vulkan/vulkan.h>
+#define VMA_VULKAN_VERSION 1002000 // Vulkan 1.2
 #include "vk_mem_alloc.h"
 
 #define PPX_VULKAN_VERSION_1_1 110

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -28,6 +28,7 @@
 #include "ppx/grfx/vk/vk_sync.h"
 
 #define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION 1002000 // Vulkan 1.2
 #include "vk_mem_alloc.h"
 #include <unordered_set>
 


### PR DESCRIPTION
Set `VMA_VULKAN_VERSION` to explicitly compile VMA for Vulkan 1.2 and below.

[VMA Docs](https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/quick_start.html#quick_start_initialization_selecting_vulkan_version).