### PR TITLE
Use spaces instead of tabs in cmake files

### DIFF
--- a/assets/materials/shaders/CMakeLists.txt
+++ b/assets/materials/shaders/CMakeLists.txt
@@ -14,9 +14,9 @@
 set(INCLUDE_FILES "${PPX_DIR}/assets/materials/shaders/Config.hlsli")
 
 list(APPEND BRDF_INCLUDE_FILES
-	"${PPX_DIR}/assets/common/shaders/ppx/BRDF.hlsli"
-	"${PPX_DIR}/assets/common/shaders/ppx/Math.hlsli")
-	
+    "${PPX_DIR}/assets/common/shaders/ppx/BRDF.hlsli"
+    "${PPX_DIR}/assets/common/shaders/ppx/Math.hlsli")
+
 generate_rules_for_shader("shader_mtl_vertex_shader"
     SOURCE "${PPX_DIR}/assets/materials/shaders/VertexShader.hlsl"
     INCLUDES ${INCLUDE_FILES}
@@ -24,32 +24,32 @@ generate_rules_for_shader("shader_mtl_vertex_shader"
 
 generate_rules_for_shader("shader_mtl_gouraud"
     SOURCE "${PPX_DIR}/assets/materials/shaders/Gouraud.hlsl"
-	INCLUDE_DIRS "${PPX_DIR}/assets/common/shaders"
+    INCLUDE_DIRS "${PPX_DIR}/assets/common/shaders"
     INCLUDES ${INCLUDE_FILES}
-	         ${BRDF_INCLUDE_FILES}
+             ${BRDF_INCLUDE_FILES}
     STAGES "ps")
 
 generate_rules_for_shader("shader_mtl_phong"
     SOURCE "${PPX_DIR}/assets/materials/shaders/Phong.hlsl"
-	INCLUDE_DIRS "${PPX_DIR}/assets/common/shaders"
+    INCLUDE_DIRS "${PPX_DIR}/assets/common/shaders"
     INCLUDES ${INCLUDE_FILES}
-	         ${BRDF_INCLUDE_FILES}
+             ${BRDF_INCLUDE_FILES}
     STAGES "ps")
 
 generate_rules_for_shader("shader_mtl_blinn_phong"
     SOURCE "${PPX_DIR}/assets/materials/shaders/BlinnPhong.hlsl"
     INCLUDES ${INCLUDE_FILES}
-	INCLUDE_DIRS "${PPX_DIR}/assets/common/shaders"
+    INCLUDE_DIRS "${PPX_DIR}/assets/common/shaders"
     INCLUDES ${INCLUDE_FILES}
-	         ${BRDF_INCLUDE_FILES}
+             ${BRDF_INCLUDE_FILES}
     STAGES "ps")
 
 generate_rules_for_shader("shader_mtl_pbr"
     SOURCE "${PPX_DIR}/assets/materials/shaders/PBR.hlsl"
-	INCLUDE_DIRS "${PPX_DIR}/assets/common/shaders"
+    INCLUDE_DIRS "${PPX_DIR}/assets/common/shaders"
     INCLUDES ${INCLUDE_FILES}
-	         ${BRDF_INCLUDE_FILES}
-	         "${PPX_DIR}/assets/common/shaders/ppx/PBR.hlsli"
+             ${BRDF_INCLUDE_FILES}
+             "${PPX_DIR}/assets/common/shaders/ppx/PBR.hlsli"
     STAGES "ps")
 
 generate_rules_for_shader("shader_mtl_env_draw_shader"

--- a/assets/oit_demo/shaders/CMakeLists.txt
+++ b/assets/oit_demo/shaders/CMakeLists.txt
@@ -39,7 +39,7 @@ generate_rules_for_shader(
 
 generate_rules_for_shader(
     "weighted_sum"
-	SOURCE "${PPX_DIR}/assets/oit_demo/shaders/WeightedSum.hlsl"
+    SOURCE "${PPX_DIR}/assets/oit_demo/shaders/WeightedSum.hlsl"
     INCLUDES ${TRANSPARENCY_INCLUDE_FILES}
     STAGES "ps" "vs")
 

--- a/cmake/ShaderCompile.cmake
+++ b/cmake/ShaderCompile.cmake
@@ -44,11 +44,11 @@ function(internal_add_compile_shader_target TARGET_NAME)
     set(multiValueArgs COMPILER_FLAGS INCLUDE_DIRS INCLUDES)
     cmake_parse_arguments(PARSE_ARGV 1 "ARG" "" "${oneValueArgs}" "${multiValueArgs}")
 
-	set(INCLUDE_DIRS "")
-	foreach(DIR ${ARG_INCLUDE_DIRS})
-		set(INCLUDE_DIRS "${INCLUDE_DIRS} -I \"${DIR}\"")
-	endforeach()
-	string(STRIP "${INCLUDE_DIRS}" INCLUDE_DIRS)
+    set(INCLUDE_DIRS "")
+    foreach(DIR ${ARG_INCLUDE_DIRS})
+        set(INCLUDE_DIRS "${INCLUDE_DIRS} -I \"${DIR}\"")
+    endforeach()
+    string(STRIP "${INCLUDE_DIRS}" INCLUDE_DIRS)
 
     string(TOUPPER "${ARG_SHADER_STAGE}" ARG_SHADER_STAGE)
 
@@ -81,7 +81,7 @@ function(internal_generate_rules_for_shader TARGET_NAME)
             "dx12_${TARGET_NAME}_${ARG_SHADER_STAGE}"
             COMPILER_PATH "${DXC_PATH}"
             SOURCE "${ARG_SOURCE}"
-			INCLUDE_DIRS ${ARG_INCLUDE_DIRS}
+            INCLUDE_DIRS ${ARG_INCLUDE_DIRS}
             INCLUDES ${ARG_INCLUDES}
             OUTPUT_FILE "${CMAKE_BINARY_DIR}/${PATH_PREFIX}/dxil/${BASE_NAME}.${ARG_SHADER_STAGE}.dxil"
             SHADER_STAGE "${ARG_SHADER_STAGE}"
@@ -105,7 +105,7 @@ function(internal_generate_rules_for_shader TARGET_NAME)
             "vk_${TARGET_NAME}_${ARG_SHADER_STAGE}"
             COMPILER_PATH "${DXC_PATH}"
             SOURCE "${ARG_SOURCE}"
-			INCLUDE_DIRS ${ARG_INCLUDE_DIRS}
+            INCLUDE_DIRS ${ARG_INCLUDE_DIRS}
             INCLUDES ${ARG_INCLUDES}
             OUTPUT_FILE "${SHADER_OUTPUT_PATH}"
             SHADER_STAGE "${ARG_SHADER_STAGE}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -499,14 +499,14 @@ elseif (PPX_MSW)
 endif()
 
 if (PPX_BUILD_XR)
-	target_compile_definitions(
+    target_compile_definitions(
         ${PROJECT_NAME}
         PUBLIC PPX_BUILD_XR
     )
 endif()
 
 if (PPX_XR_QUEST)
-	target_compile_definitions(
+    target_compile_definitions(
         ${PROJECT_NAME}
         PUBLIC PPX_XR_QUEST
     )


### PR DESCRIPTION
So that they are displayed consistently everywhere