### PR TITLE
Remove static Oculus loader for the shared loader.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,6 @@ plugins {
     id 'com.android.library' version '7.3.1' apply false
 }
 
-ext {
-  oculusOpenxrSdkLocation = System.getenv('OCULUS_OPENXR_SDK')
-}
-
 android {
     namespace 'com.google.bigwheels'
     compileSdk 32
@@ -105,9 +101,8 @@ android {
                 cmake {
                   arguments '-DPPX_BUILD_XR=TRUE',
                             '-DPPX_XR_QUEST=TRUE',
-                            '-DBUILD_LOADER=FALSE',
-                            '-DBUILD_ALL_EXTENSIONS=FALSE',
-                            "-DOCULUS_OPENXR_SDK=${oculusOpenxrSdkLocation}"
+                            '-DBUILD_LOADER=TRUE',
+                            '-DBUILD_ALL_EXTENSIONS=FALSE'
                   cppFlags '-DXR_USE_PLATFORM_ANDROID'
                 }
             }

--- a/cmake/GraphicsSample.cmake
+++ b/cmake/GraphicsSample.cmake
@@ -31,17 +31,6 @@ function(_add_sample_internal)
         add_executable("${TARGET_NAME}" ${ARG_SOURCES})
     endif()
 
-    if(PPX_BUILD_XR AND PPX_XR_QUEST)
-        # Quest devices do not use the standard OpenXR loader.
-        add_library(openxr_loader SHARED IMPORTED)
-        set_property(
-            TARGET
-            openxr_loader
-            PROPERTY
-            IMPORTED_LOCATION
-            ${OCULUS_OPENXR_SDK}/OpenXR/Libs/Android/${ANDROID_ABI}/Debug/libopenxr_loader.so)
-    endif ()
-
     set_target_properties("${TARGET_NAME}" PROPERTIES FOLDER "ppx/samples/${ARG_API_TAG}")
 
     target_include_directories("${TARGET_NAME}" PUBLIC ${PPX_DIR}/include ${ARG_ADDITIONAL_INCLUDE_DIRECTORIES})

--- a/src/android/AndroidManifest.Quest.xml
+++ b/src/android/AndroidManifest.Quest.xml
@@ -19,6 +19,9 @@
       android:label="${appLabel}"
       android:theme="@style/Theme.AppCompat.NoActionBar"
       tools:targetApi="31">
+    <uses-native-library
+        android:name="libopenxr_forwardloader.oculus.so"
+        android:required="true"/>
     <activity
         android:name="com.google.bigwheels.MainActivity"
         android:exported="true">


### PR DESCRIPTION
This removes the `quest` target's dependency on the Oculus OpenXR SDK.