### PR TITLE
android: fix lifecycle handling

### DIFF
--- a/include/ppx/profiler.h
+++ b/include/ppx/profiler.h
@@ -99,12 +99,17 @@ public:
     Profiler();
     virtual ~Profiler();
 
+    static void      ReinitializeGlobalVariables();
     static Profiler* GetProfilerForThread();
 
     static Result RegisterEvent(ProfilerEventType type, const std::string& name, ProfileEventRecordAction recordAction, ProfilerEventToken* pToken);
     static Result RegisterGrfxApiFnEvent(const std::string& name, ProfilerEventToken* pToken);
 
     void RecordSample(const ProfilerEventToken& token, const ProfilerEventSample& sample);
+
+    // Removed all previously registered events. It is not safe to call this function while
+    // running code recording samples.
+    void RemoveAllEvents();
 
     const std::vector<ProfilerEvent>& GetEvents() const { return mEvents; }
 

--- a/src/android/main.cpp
+++ b/src/android/main.cpp
@@ -1,4 +1,3 @@
-#include "ppx/log.h"
 #include "ppx/profiler.h"
 
 #include <android_native_app_glue.h>
@@ -58,7 +57,9 @@ static ApplicationState gApplicationState = READY;
 // handle those states here, and restart the application once we are back live.
 static void defaultCommandHandler(struct android_app* app, int32_t cmd)
 {
-    PPX_ASSERT_MSG(cmd == APP_CMD_START || cmd == APP_CMD_STOP || cmd == APP_CMD_DESTROY || cmd == APP_CMD_SAVE_STATE || cmd == APP_CMD_LOST_FOCUS || cmd == APP_CMD_GAINED_FOCUS, "Handled in the default-handler a message we shouldn't. This is a bug.");
+    if (cmd == APP_CMD_INIT_WINDOW || cmd == APP_CMD_TERM_WINDOW || cmd == APP_CMD_WINDOW_RESIZED || cmd == APP_CMD_WINDOW_REDRAW_NEEDED || cmd == APP_CMD_CONTENT_RECT_CHANGED) {
+        PPX_ASSERT_MSG(false, "Handled in the default-handler a message we shouldn't. This is a bug.");
+    }
 
     if (cmd == APP_CMD_START) {
         gApplicationState = RUNNING;

--- a/src/android/main.cpp
+++ b/src/android/main.cpp
@@ -1,8 +1,10 @@
-#include <jni.h>
+#include "ppx/log.h"
+#include "ppx/profiler.h"
 
+#include <android_native_app_glue.h>
+#include <jni.h>
 #include <string>
 #include <vector>
-#include <android_native_app_glue.h>
 
 extern bool RunApp(android_app* pAndroidContext, int argc, char** argv);
 
@@ -36,6 +38,70 @@ static std::vector<std::string> get_java_args(android_app* pApp)
     return args;
 }
 
+// The Android activity can go by many more states, like PAUSED.
+// Right now, we just need to be able not to crash if we are stopped and resumed.
+enum ApplicationState
+{
+    // The JNI code is loaded and running, but the activity is not started.
+    READY,
+    // The activity is started, the Applicaiton/Window code should handle events.
+    RUNNING,
+    // The activity is being destroyed. This is a transient state until we return.
+    DESTROYED
+};
+
+// NOTE: JNI libraries can outlive the activity. Meaning we can re-enter the android_main
+// without re-running global constructors or reseting the BSS.
+static ApplicationState gApplicationState = READY;
+
+// When the activity not running, we have no window. To simplify BigWheels code, we
+// handle those states here, and restart the application once we are back live.
+static void defaultCommandHandler(struct android_app* app, int32_t cmd)
+{
+    PPX_ASSERT_MSG(cmd == APP_CMD_START || cmd == APP_CMD_STOP || cmd == APP_CMD_DESTROY || cmd == APP_CMD_SAVE_STATE || cmd == APP_CMD_LOST_FOCUS || cmd == APP_CMD_GAINED_FOCUS, "Handled in the default-handler a message we shouldn't. This is a bug.");
+
+    if (cmd == APP_CMD_START) {
+        gApplicationState = RUNNING;
+        return;
+    }
+
+    if (cmd == APP_CMD_STOP) {
+        gApplicationState = READY;
+        return;
+    }
+
+    if (cmd == APP_CMD_DESTROY) {
+        gApplicationState = DESTROYED;
+        return;
+    }
+}
+
+int32_t defaultInputHandler(struct android_app*, AInputEvent*)
+{
+    PPX_ASSERT_MSG(false, "Handled an input message without a window. This is a bug.");
+    return 0;
+}
+
+void RunAndroidEventLoop(struct android_app* pApp)
+{
+    pApp->onAppCmd     = defaultCommandHandler;
+    pApp->onInputEvent = defaultInputHandler;
+    pApp->userData     = nullptr;
+
+    while (gApplicationState == READY) {
+        int                  events;
+        android_poll_source* pSource;
+        if (ALooper_pollAll(/* timeoutMillis= */ 0,
+                            /* outFd= */ nullptr,
+                            /* outEvents= */ &events,
+                            /* outData= */ (void**)&pSource) >= 0) {
+            if (pSource) {
+                pSource->process(pApp, pSource);
+            }
+        }
+    }
+}
+
 extern "C"
 {
     /*!
@@ -43,6 +109,11 @@ extern "C"
      */
     void android_main(struct android_app* pApp)
     {
+        // On Android, the library is loaded once, and it's lifetime is tied to the classloader lifetime.
+        // This means the activity can be destroyed, but the library still loaded.
+        // When the activity get's restarted, the library is not reloaded, meaning no global reinitialization!
+        gApplicationState = RUNNING;
+
         std::vector<std::string> cmdArgs = get_java_args(pApp);
 
         std::vector<char*> args;
@@ -50,6 +121,18 @@ extern "C"
         for (std::string& arg : cmdArgs) {
             args.push_back(const_cast<char*>(arg.c_str()));
         }
-        RunApp(pApp, cmdArgs.size(), args.data());
+
+        while (gApplicationState != DESTROYED) {
+            if (gApplicationState == RUNNING) {
+                // The profiler assumed the application is run once per process lifetime. This is wrong on
+                // Android, we need to cleanup some state.
+                ppx::Profiler::ReinitializeGlobalVariables();
+                RunApp(pApp, cmdArgs.size(), args.data());
+                gApplicationState = READY;
+            }
+            else {
+                RunAndroidEventLoop(pApp);
+            }
+        }
     }
 }

--- a/src/android/main.cpp
+++ b/src/android/main.cpp
@@ -43,7 +43,7 @@ enum ApplicationState
 {
     // The JNI code is loaded and running, but the activity is not started.
     READY,
-    // The activity is started, the Applicaiton/Window code should handle events.
+    // The activity is started, the Application/Window code should handle events.
     RUNNING,
     // The activity is being destroyed. This is a transient state until we return.
     DESTROYED
@@ -57,23 +57,25 @@ static ApplicationState gApplicationState = READY;
 // handle those states here, and restart the application once we are back live.
 static void defaultCommandHandler(struct android_app* app, int32_t cmd)
 {
-    if (cmd == APP_CMD_INIT_WINDOW || cmd == APP_CMD_TERM_WINDOW || cmd == APP_CMD_WINDOW_RESIZED || cmd == APP_CMD_WINDOW_REDRAW_NEEDED || cmd == APP_CMD_CONTENT_RECT_CHANGED) {
-        PPX_ASSERT_MSG(false, "Handled in the default-handler a message we shouldn't. This is a bug.");
-    }
-
-    if (cmd == APP_CMD_START) {
-        gApplicationState = RUNNING;
-        return;
-    }
-
-    if (cmd == APP_CMD_STOP) {
-        gApplicationState = READY;
-        return;
-    }
-
-    if (cmd == APP_CMD_DESTROY) {
-        gApplicationState = DESTROYED;
-        return;
+    switch (cmd) {
+        case APP_CMD_START:
+            gApplicationState = RUNNING;
+            break;
+        case APP_CMD_STOP:
+            gApplicationState = READY;
+            break;
+        case APP_CMD_DESTROY:
+            gApplicationState = DESTROYED;
+            break;
+        case APP_CMD_INIT_WINDOW:
+        case APP_CMD_TERM_WINDOW:
+        case APP_CMD_WINDOW_RESIZED:
+        case APP_CMD_WINDOW_REDRAW_NEEDED:
+        case APP_CMD_CONTENT_RECT_CHANGED:
+            PPX_ASSERT_MSG(false, "Handled in the default-handler a message we shouldn't. This is a bug.");
+            break;
+        default:
+            break;
     }
 }
 

--- a/src/ppx/profiler.cpp
+++ b/src/ppx/profiler.cpp
@@ -96,6 +96,13 @@ Profiler::~Profiler()
 {
 }
 
+void Profiler::ReinitializeGlobalVariables()
+{
+    for (auto& profiler : sPerThreadProfilers) {
+        profiler.RemoveAllEvents();
+    }
+}
+
 Profiler* Profiler::GetProfilerForThread()
 {
     unsigned int threadIndex = GetThreadIndex();
@@ -104,6 +111,12 @@ Profiler* Profiler::GetProfilerForThread()
         pProfiler = &sPerThreadProfilers[threadIndex];
     }
     return pProfiler;
+}
+
+void Profiler::RemoveAllEvents()
+{
+    std::lock_guard<std::mutex> lock(sThreadIndexMutex);
+    mEvents.clear();
 }
 
 Result Profiler::RegisterEvent(ProfilerEventType type, const std::string& name, ProfileEventRecordAction recordAction, ProfilerEventToken* pToken)


### PR DESCRIPTION
Android activities lifecycles are not what we expect on desktop platforms:
 - we can be paused/stopped/restarted.
 - the window can be destroyed & recreated during execution.

BigWheels assumes you start once, and exit once. So the whole swapchain, initialization cannot handle android lifecycle events. Handling Android lifecycle events could either mean a deep, fine-grained integration, or what I'm implementing here.

This implementation hides the whole lifecycle concept to the application. Meaning we can have a simple, linear code when writing samples.

The downside is we cannot handle PAUSE like a real app does: our whole state is reset. I believe this downside is OK for the simplification this solution brings.

For now, I hard-assert on all messages handled in the default handler so we quickly find out new edge cases, and tried to keep the state tracking dead-simple: are we running, or waiting to be restarted.

This commit also allows resetting some global variables:
 the library lifecycle is not linked to the activity lifecycle, but to
 the class loader's. This means we can re-enter android_main multiple
 time! And globals won't be reset.
 This means we need to either stop using them, or just reinitialize
 them.