### PR TITLE
Add xr-ui-resolution flag

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -240,6 +240,8 @@ struct ApplicationSettings
         // Whether to create depth swapchains in addition to color swapchains,
         // and submit the depth info to the runtime as an additional layer.
         bool enableDepthSwapchain = false;
+        uint32_t uiWidth              = 0;
+        uint32_t uiHeight             = 0;
     } xr;
 
     struct
@@ -338,6 +340,22 @@ public:
     const ApplicationSettings* GetSettings() const { return &mSettings; }
     uint32_t                   GetWindowWidth() const { return mSettings.window.width; }
     uint32_t                   GetWindowHeight() const { return mSettings.window.height; }
+    uint32_t                   GetUIWidth() const
+    {
+#if defined(PPX_BUILD_XR)
+        return (mSettings.xr.enable && mSettings.xr.uiWidth > 0) ? mSettings.xr.uiWidth : mSettings.window.width;
+#else
+        return mSettings.window.width;
+#endif
+    }
+    uint32_t GetUIHeight() const
+    {
+#if defined(PPX_BUILD_XR)
+        return (mSettings.xr.enable && mSettings.xr.uiHeight > 0) ? mSettings.xr.uiHeight : mSettings.window.height;
+#else
+        return mSettings.window.height;
+#endif
+    }
     float                      GetWindowAspect() const { return static_cast<float>(mSettings.window.width) / static_cast<float>(mSettings.window.height); }
     grfx::Rect                 GetScissor() const;
     grfx::Viewport             GetViewport(float minDepth = 0.0f, float maxDepth = 1.0f) const;

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -41,6 +41,9 @@ struct StandardOptions
     std::pair<int, int> resolution         = {-1, -1};
     int                 frame_count        = -1;
     uint32_t            stats_frame_window = 300;
+#if defined(PPX_BUILD_XR)
+    std::pair<int, int> xrUIResolution = {-1, -1};
+#endif
 
     int         screenshot_frame_number                  = -1;
     std::string screenshot_path                          = "";
@@ -164,6 +167,26 @@ public:
 
 private:
     CliOptions        mOpts;
+#if defined(PPX_BUILD_XR)
+    const std::string mUsageMsg = R"(
+--help                        Prints this help message and exits.
+
+--deterministic               Disable non-deterministic behaviors, like clocks.
+--frame-count <N>             Shutdown the application after successfully rendering N frames.
+--gpu <index>                 Select the gpu with the given index. To determine the set of valid indices use --list-gpus.
+--headless                    Run the sample without creating windows.
+--list-gpus                   Prints a list of the available GPUs on the current system with their index and exits (see --gpu).
+--resolution <Width>x<Height> Specify the per-eye resolution in pixels. Width and Height must be two positive integers greater or equal to 1.
+--xr-ui-resolution <Width>x<Height> Specify the UI quad resolution in pixels. Width and Height must be two positive integers greater or equal to 1.
+--screenshot-frame-number <N> Take a screenshot of frame number N and save it in PPM format.
+                              See also `--screenshot-path`.
+--screenshot-path             Save the screenshot to this path. If not specified, BigWheels will create a
+                              "screenshot_frameN" file in the current working directory.
+--stats-frame-window <N>      Calculate frame statistics over the last N frames only.
+                              Set to 0 to use all frames since the beginning of the application.
+--use-software-renderer       Use a software renderer instead of a hardware device, if available.
+)";
+#else
     const std::string mUsageMsg = R"(
 --help                        Prints this help message and exits.
 
@@ -181,6 +204,7 @@ private:
                               Set to 0 to use all frames since the beginning of the application.
 --use-software-renderer       Use a software renderer instead of a hardware device, if available.
 )";
+#endif
 };
 } // namespace ppx
 

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -37,8 +37,11 @@
 
 #include <optional>
 
-#define CHECK_XR_CALL(cmd) \
-    PPX_ASSERT_MSG(cmd == XR_SUCCESS, "XR call failed!");
+#define CHECK_XR_CALL(CMD__)                                                                       \
+    {                                                                                              \
+        auto RESULT__ = CMD__;                                                                     \
+        PPX_ASSERT_MSG(RESULT__ == XR_SUCCESS, "XR call failed with result: " << RESULT__ << "!"); \
+    }
 
 namespace ppx {
 
@@ -82,6 +85,7 @@ struct XrComponentCreateInfo
     bool                    enableQuadLayer      = false;
     bool                    enableDepthSwapchain = false;
     XrComponentResolution   resolution           = {0, 0};
+    XrComponentResolution   uiResolution         = {0, 0};
 };
 
 //! @class XrComponent
@@ -117,6 +121,14 @@ public:
         if (mCreateInfo.resolution.height > 0)
             return mCreateInfo.resolution.height;
         return mConfigViews[0].recommendedImageRectHeight;
+    }
+    uint32_t GetUIWidth() const
+    {
+        return (mCreateInfo.uiResolution.width > 0) ? mCreateInfo.uiResolution.width : GetWidth();
+    }
+    uint32_t GetUIHeight() const
+    {
+        return (mCreateInfo.uiResolution.height > 0) ? mCreateInfo.uiResolution.height : GetHeight();
     }
     uint32_t GetSampleCount() const
     {

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -435,16 +435,23 @@ Result Application::CreateSwapchains()
         ci.pXrComponent              = &mXrComponent;
 
         // We have one swapchain for each view, and one swapchain for the UI.
-        const size_t swapchainCount = viewCount + 1;
+        mSwapchains.resize(viewCount + 1);
         mStereoscopicSwapchainIndex = 0;
-        mUISwapchainIndex           = static_cast<uint32_t>(viewCount);
-        mSwapchains.resize(swapchainCount);
-        for (size_t k = 0; k < swapchainCount; ++k) {
+        for (size_t k = 0; k < viewCount; ++k) {
             Result ppxres = mDevice->CreateSwapchain(&ci, &mSwapchains[k]);
             if (Failed(ppxres)) {
                 PPX_ASSERT_MSG(false, "grfx::Device::CreateSwapchain failed");
                 return ppxres;
             }
+        }
+
+        mUISwapchainIndex = static_cast<uint32_t>(viewCount);
+        ci.width          = GetUIWidth();
+        ci.height         = GetUIHeight();
+        Result ppxres     = mDevice->CreateSwapchain(&ci, &mSwapchains[mUISwapchainIndex]);
+        if (Failed(ppxres)) {
+            PPX_ASSERT_MSG(false, "grfx::Device::CreateSwapchain failed");
+            return ppxres;
         }
 
         // Image count is from xrEnumerateSwapchainImages
@@ -970,11 +977,18 @@ int Application::Run(int argc, char** argv)
     }
 
     // If command line argument provided width and height
-    bool resolutionFlag = (mStandardOptions.resolution.first != -1) && (mStandardOptions.resolution.second != -1);
-    if (resolutionFlag) {
+    bool hasResolutionFlag = (mStandardOptions.resolution.first > 0 && mStandardOptions.resolution.second > 0);
+    if (hasResolutionFlag) {
         mSettings.window.width  = mStandardOptions.resolution.first;
         mSettings.window.height = mStandardOptions.resolution.second;
     }
+
+#if defined(PPX_BUILD_XR)
+    if (mStandardOptions.xrUIResolution.first > 0 && mStandardOptions.xrUIResolution.second > 0) {
+        mSettings.xr.uiWidth  = mStandardOptions.xrUIResolution.first;
+        mSettings.xr.uiHeight = mStandardOptions.xrUIResolution.second;
+    }
+#endif
 
     mMaxFrame = UINT64_MAX;
     // If command line provided a maximum number of frames to draw
@@ -1011,10 +1025,12 @@ int Application::Run(int argc, char** argv)
         createInfo.enableDebug          = mSettings.grfx.enableDebug;
         createInfo.enableQuadLayer      = mSettings.enableImGui;
         createInfo.enableDepthSwapchain = mSettings.xr.enableDepthSwapchain;
-        if (resolutionFlag) {
+        if (hasResolutionFlag) {
             createInfo.resolution.width  = mSettings.window.width;
             createInfo.resolution.height = mSettings.window.height;
         }
+        createInfo.uiResolution.width  = mSettings.xr.uiWidth;
+        createInfo.uiResolution.height = mSettings.xr.uiHeight;
 
         mXrComponent.InitializeBeforeGrfxDeviceInit(createInfo);
     }
@@ -1396,12 +1412,12 @@ void Application::DrawDebugInfo(std::function<void(void)> drawAdditionalFn)
     if (!mImGui) {
         return;
     }
-    uint32_t minWidth  = std::min(kImGuiMinWidth, GetWindowWidth() / 2);
-    uint32_t minHeight = std::min(kImGuiMinHeight, GetWindowHeight() / 2);
+    uint32_t minWidth  = std::min(kImGuiMinWidth, GetUIWidth() / 2);
+    uint32_t minHeight = std::min(kImGuiMinHeight, GetUIHeight() / 2);
 #if defined(PPX_BUILD_XR)
     if (mSettings.xr.enable) {
         // For XR, force the diagnostic window to the center with automatic sizing for legibility and since control is limited.
-        ImGui::SetNextWindowPos({(GetWindowWidth() - lastImGuiWindowSize.x) / 2, (GetWindowHeight() - lastImGuiWindowSize.y) / 2}, 0, {0.0f, 0.0f});
+        ImGui::SetNextWindowPos({(GetUIWidth() - lastImGuiWindowSize.x) / 2, (GetUIHeight() - lastImGuiWindowSize.y) / 2}, 0, {0.0f, 0.0f});
         ImGui::SetNextWindowSize({0, 0});
     }
 #endif

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -136,6 +136,28 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             }
             mOpts.standardOptions.screenshot_path = opt.GetValueOrDefault<std::string>("");
         }
+#if defined(PPX_BUILD_XR)
+        else if (opt.GetName() == "xr-ui-resolution") {
+            if (!opt.HasValue()) {
+                return std::string("Command-line option --xr-ui-resolution requires a parameter");
+            }
+
+            // Resolution is passed as <Width>x<Height>.
+            std::string       val = opt.GetValueOrDefault<std::string>("");
+            std::stringstream ss{val};
+            int               width = -1, height = -1;
+            char              x;
+            ss >> width >> x >> height;
+            if (ss.fail() || x != 'x') {
+                return std::string("Parameter for command-line option --xr-ui-resolution must be in <Width>x<Height> format, got " + val + " instead");
+            }
+            if (width < 1 || height < 1) {
+                return std::string("Parameter for command-line option --xr-ui-resolution must be in <Width>x<Height> format where Width and Height are integers greater or equal to 1");
+            }
+
+            mOpts.standardOptions.xrUIResolution = {width, height};
+        }
+#endif
         else {
             // Non-standard option.
             mOpts.AddExtraOption(opt);

--- a/src/ppx/grfx/vk/vk_swapchain.cpp
+++ b/src/ppx/grfx/vk/vk_swapchain.cpp
@@ -251,15 +251,15 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
     if (isXREnabled) {
         const XrComponent& xrComponent = *mCreateInfo.pXrComponent;
 
-        PPX_ASSERT_MSG(xrComponent.GetColorFormat() == pCreateInfo->colorFormat, "XR color format differs from requested swapchain format");
+        PPX_ASSERT_MSG(pCreateInfo->colorFormat == xrComponent.GetColorFormat(), "XR color format differs from requested swapchain format");
 
         XrSwapchainCreateInfo info = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
         info.arraySize             = 1;
         info.mipCount              = 1;
         info.faceCount             = 1;
-        info.format                = ToVkFormat(xrComponent.GetColorFormat());
-        info.width                 = xrComponent.GetWidth();
-        info.height                = xrComponent.GetHeight();
+        info.format                = ToVkFormat(pCreateInfo->colorFormat);
+        info.width                 = pCreateInfo->width;
+        info.height                = pCreateInfo->height;
         info.sampleCount           = xrComponent.GetSampleCount();
         info.usageFlags            = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
         CHECK_XR_CALL(xrCreateSwapchain(xrComponent.GetSession(), &info, &mXrColorSwapchain));
@@ -275,15 +275,15 @@ Result Swapchain::CreateApiObjects(const grfx::SwapchainCreateInfo* pCreateInfo)
         }
 
         if (xrComponent.GetDepthFormat() != grfx::FORMAT_UNDEFINED && xrComponent.UsesDepthSwapchains()) {
-            PPX_ASSERT_MSG(xrComponent.GetDepthFormat() == pCreateInfo->depthFormat, "XR depth format differs from requested swapchain format");
+            PPX_ASSERT_MSG(pCreateInfo->depthFormat == xrComponent.GetDepthFormat(), "XR depth format differs from requested swapchain format");
 
             XrSwapchainCreateInfo info = {XR_TYPE_SWAPCHAIN_CREATE_INFO};
             info.arraySize             = 1;
             info.mipCount              = 1;
             info.faceCount             = 1;
-            info.format                = ToVkFormat(xrComponent.GetDepthFormat());
-            info.width                 = xrComponent.GetWidth();
-            info.height                = xrComponent.GetHeight();
+            info.format                = ToVkFormat(pCreateInfo->depthFormat);
+            info.width                 = pCreateInfo->width;
+            info.height                = pCreateInfo->height;
             info.sampleCount           = xrComponent.GetSampleCount();
             info.usageFlags            = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
             CHECK_XR_CALL(xrCreateSwapchain(xrComponent.GetSession(), &info, &mXrDepthSwapchain));

--- a/src/ppx/imgui_impl.cpp
+++ b/src/ppx/imgui_impl.cpp
@@ -145,8 +145,8 @@ void ImGuiImpl::NewFrame()
     Application* pApp = Application::Get();
 
     ImGuiIO& io      = ImGui::GetIO();
-    io.DisplaySize.x = static_cast<float>(pApp->GetWindowWidth());
-    io.DisplaySize.y = static_cast<float>(pApp->GetWindowHeight());
+    io.DisplaySize.x = static_cast<float>(pApp->GetUIWidth());
+    io.DisplaySize.y = static_cast<float>(pApp->GetUIHeight());
     NewFrameApi();
 }
 
@@ -187,7 +187,7 @@ Result ImGuiImplDx12::InitApiObjects(ppx::Application* pApp)
     bool result = ImGui_ImplDX12_Init(
         grfx::dx12::ToApi(pApp->GetDevice())->GetDxDevice(),
         static_cast<int>(pApp->GetNumFramesInFlight()),
-        grfx::dx::ToDxgiFormat(pApp->GetSwapchain()->GetColorFormat()),
+        grfx::dx::ToDxgiFormat(pApp->GetUISwapchain()->GetColorFormat()),
         mHeapCBVSRVUAV,
         mHeapCBVSRVUAV->GetCPUDescriptorHandleForHeapStart(),
         mHeapCBVSRVUAV->GetGPUDescriptorHandleForHeapStart());
@@ -267,12 +267,12 @@ Result ImGuiImplVk::InitApiObjects(ppx::Application* pApp)
         init_info.Queue                     = grfx::vk::ToApi(pApp->GetGraphicsQueue())->GetVkQueue();
         init_info.PipelineCache             = VK_NULL_HANDLE;
         init_info.DescriptorPool            = grfx::vk::ToApi(mPool)->GetVkDescriptorPool();
-        init_info.MinImageCount             = pApp->GetSwapchain()->GetImageCount();
-        init_info.ImageCount                = pApp->GetSwapchain()->GetImageCount();
+        init_info.MinImageCount             = pApp->GetUISwapchain()->GetImageCount();
+        init_info.ImageCount                = pApp->GetUISwapchain()->GetImageCount();
         init_info.Allocator                 = VK_NULL_HANDLE;
         init_info.CheckVkResultFn           = nullptr;
 
-        grfx::RenderPassPtr renderPass = pApp->GetSwapchain()->GetRenderPass(0, grfx::ATTACHMENT_LOAD_OP_LOAD);
+        grfx::RenderPassPtr renderPass = pApp->GetUISwapchain()->GetRenderPass(0, grfx::ATTACHMENT_LOAD_OP_LOAD);
         PPX_ASSERT_MSG(!renderPass.IsNull(), "[imgui:vk] failed to get swapchain renderpass");
 
         bool result = ImGui_ImplVulkan_Init(&init_info, grfx::vk::ToApi(renderPass)->GetVkRenderPass());

--- a/src/ppx/xr_component.cpp
+++ b/src/ppx/xr_component.cpp
@@ -547,7 +547,7 @@ void XrComponent::EndFrame(const std::vector<grfx::SwapchainPtr>& swapchains, ui
             compositionLayerQuad.eyeVisibility             = XR_EYE_VISIBILITY_BOTH;
             compositionLayerQuad.subImage.swapchain        = swapchains[layerQuadStartIndex]->GetXrColorSwapchain();
             compositionLayerQuad.subImage.imageRect.offset = {0, 0};
-            compositionLayerQuad.subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
+            compositionLayerQuad.subImage.imageRect.extent = {static_cast<int>(GetUIWidth()), static_cast<int>(GetUIHeight())};
             compositionLayerQuad.pose                      = {{0, 0, 0, 1}, {0, 0, -0.5f}};
             compositionLayerQuad.size                      = {1, 1};
         }


### PR DESCRIPTION
This change includes the following:
1. Introduces the xr-ui-resolution command-line flag, which allows users to select a separate resolution for the UI quad when in XR mode.
2. Address an issue where the vulkan swapchain creation was ignoring the provided arguments in favor of xrComponent sizes.
3. Fixes incorrect swapchain references inside the UI component.
4. Includes the XR call result in the output of CHECK_XR_CALL.