### PR TITLE
Converting benchmark graphics_pipeline parameters to knobs

### DIFF
--- a/benchmarks/graphics_pipeline/main.cpp
+++ b/benchmarks/graphics_pipeline/main.cpp
@@ -123,7 +123,6 @@ private:
 private:
     std::shared_ptr<KnobDropdown<std::string>> pKnobVs;
     std::shared_ptr<KnobDropdown<std::string>> pKnobPs;
-    std::shared_ptr<KnobCheckbox>              pKnobAlphaBlend; // alpha blend functionality unimplemented
 
 private:
     void LoadScene(
@@ -191,15 +190,15 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 
 void ProjApp::InitKnobs()
 {
+    const auto& cl_options = GetExtraOptions();
+    PPX_ASSERT_MSG(!cl_options.HasExtraOption("vs-shader-index"), "--vs-shader-index flag has been replaced, instead use --vs and specify the name of the vertex shader");
+    PPX_ASSERT_MSG(!cl_options.HasExtraOption("ps-shader-index"), "--ps-shader-index flag has been replaced, instead use --ps and specify the name of the pixel shader");
+
     pKnobVs = GetKnobManager().CreateKnob<ppx::KnobDropdown<std::string>>("vs", 0, kAvailableVsShaders);
     pKnobVs->SetDisplayName("Vertex Shader");
 
     pKnobPs = GetKnobManager().CreateKnob<ppx::KnobDropdown<std::string>>("ps", 0, kAvailablePsShaders);
     pKnobPs->SetDisplayName("Pixel Shader");
-
-    pKnobAlphaBlend = GetKnobManager().CreateKnob<ppx::KnobCheckbox>("alpha_blend", false);
-    pKnobAlphaBlend->SetDisplayName("Placeholder1");
-    pKnobAlphaBlend->SetIndent(1);
 }
 
 void ProjApp::LoadTexture(


### PR DESCRIPTION
Converting benchmark graphics_pipeline parameters (Vertex Shader, Pixel Shader) to knobs, also removing placeholder knob --alpha_blend

Example usage:
--vs "Benchmark_VsAluBound"
--ps "Benchmark_PsMemBound"