### PR TITLE
Add runtime parameter to limit test in realtime; fix frame-count argument to use 0 as infinite.

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -466,7 +466,8 @@ private:
 private:
     CommandLineParser               mCommandLineParser;
     StandardOptions                 mStandardOptions;
-    uint64_t                        mMaxFrame;
+    uint64_t                        mMaxFrames;
+    float                           mRunTimeSeconds;
     ApplicationSettings             mSettings = {};
     std::string                     mDecoratedApiName;
     Timer                           mTimer;

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -40,6 +40,7 @@ struct StandardOptions
     int                 gpu_index          = -1;
     std::pair<int, int> resolution         = {-1, -1};
     int                 frame_count        = -1;
+    int                 run_time_ms        = -1;
     uint32_t            stats_frame_window = 300;
 #if defined(PPX_BUILD_XR)
     std::pair<int, int> xrUIResolution = {-1, -1};
@@ -177,6 +178,7 @@ private:
 
 --deterministic               Disable non-deterministic behaviors, like clocks.
 --frame-count <N>             Shutdown the application after successfully rendering N frames.
+--run-time-ms <N>             Shutdown the application after N milliseconds.
 --gpu <index>                 Select the gpu with the given index. To determine the set of valid indices use --list-gpus.
 --headless                    Run the sample without creating windows.
 --list-gpus                   Prints a list of the available GPUs on the current system with their index and exits (see --gpu).
@@ -196,6 +198,7 @@ private:
 
 --deterministic               Disable non-deterministic behaviors, like clocks.
 --frame-count <N>             Shutdown the application after successfully rendering N frames.
+--run-time-ms <N>             Shutdown the application after N milliseconds.
 --gpu <index>                 Select the gpu with the given index. To determine the set of valid indices use --list-gpus.
 --headless                    Run the sample without creating windows.
 --list-gpus                   Prints a list of the available GPUs on the current system with their index and exits (see --gpu).

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -197,8 +197,8 @@ private:
 --help                        Prints this help message and exits.
 
 --deterministic               Disable non-deterministic behaviors, like clocks.
---frame-count <N>             Shutdown the application after successfully rendering N frames.
---run-time-ms <N>             Shutdown the application after N milliseconds.
+--frame-count <N>             Shutdown the application after successfully rendering N frames. Default: 0 (infinite).
+--run-time-ms <N>             Shutdown the application after N milliseconds. Default: 0 (infinite).
 --gpu <index>                 Select the gpu with the given index. To determine the set of valid indices use --list-gpus.
 --headless                    Run the sample without creating windows.
 --list-gpus                   Prints a list of the available GPUs on the current system with their index and exits (see --gpu).

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -39,8 +39,8 @@ struct StandardOptions
     // Options
     int                 gpu_index          = -1;
     std::pair<int, int> resolution         = {-1, -1};
-    int                 frame_count        = -1;
-    int                 run_time_ms        = -1;
+    int                 frame_count        = 0;
+    int                 run_time_ms        = 0;
     uint32_t            stats_frame_window = 300;
 #if defined(PPX_BUILD_XR)
     std::pair<int, int> xrUIResolution = {-1, -1};

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1009,12 +1009,13 @@ int Application::Run(int argc, char** argv)
 #endif
 
     mMaxFrames = UINT64_MAX;
-    // If command line provided a maximum number of frames to draw
-    if (mStandardOptions.frame_count != -1) {
+    // If command line provided a maximum number of frames to draw.
+    if (mStandardOptions.frame_count > 0) {
         mMaxFrames = mStandardOptions.frame_count;
     }
 
     mRunTimeSeconds = std::numeric_limits<float>::max();
+    // If command line provides a maximum number of milliseconds to run.
     if (mStandardOptions.run_time_ms > 0) {
         mRunTimeSeconds = mStandardOptions.run_time_ms / 1000.f;
     }

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -118,6 +118,12 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             }
             mOpts.standardOptions.frame_count = opt.GetValueOrDefault<int>(-1);
         }
+        else if (opt.GetName() == "run-time-ms") {
+            if (!opt.HasValue()) {
+                return std::string("Command-line option --run-time-ms requires a parameter");
+            }
+            mOpts.standardOptions.run_time_ms = opt.GetValueOrDefault<int>(-1);
+        }
         else if (opt.GetName() == "stats-frame-window") {
             if (!opt.HasValue()) {
                 return std::string("Command-line option --stats-frame-window requires a parameter");

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -116,13 +116,13 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             if (!opt.HasValue()) {
                 return std::string("Command-line option --frame-count requires a parameter");
             }
-            mOpts.standardOptions.frame_count = opt.GetValueOrDefault<int>(-1);
+            mOpts.standardOptions.frame_count = opt.GetValueOrDefault<int>(0);
         }
         else if (opt.GetName() == "run-time-ms") {
             if (!opt.HasValue()) {
                 return std::string("Command-line option --run-time-ms requires a parameter");
             }
-            mOpts.standardOptions.run_time_ms = opt.GetValueOrDefault<int>(-1);
+            mOpts.standardOptions.run_time_ms = opt.GetValueOrDefault<int>(0);
         }
         else if (opt.GetName() == "stats-frame-window") {
             if (!opt.HasValue()) {


### PR DESCRIPTION
This change introduces the 'run-time-ms' parameter which dictates how long to run a bigwheels application for before automatically quitting. It also cleans up a little bit around the use of timestamps and MaxFrames.