### PR TITLE
Promote ImGui debug info callback to lifecycle method.

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -240,7 +240,7 @@ struct ApplicationSettings
 
         // Whether to create depth swapchains in addition to color swapchains,
         // and submit the depth info to the runtime as an additional layer.
-        bool enableDepthSwapchain = false;
+        bool     enableDepthSwapchain = false;
         uint32_t uiWidth              = 0;
         uint32_t uiHeight             = 0;
     } xr;
@@ -326,7 +326,7 @@ protected:
     virtual void DispatchScroll(float dx, float dy);
     virtual void DispatchRender();
     virtual void DispatchInitKnobs();
-    virtual void DrawGui() {}; // Draw additional project-related information to ImGui.
+    virtual void DrawGui(){}; // Draw additional project-related information to ImGui.
 
     void TakeScreenshot();
 
@@ -363,9 +363,9 @@ public:
         return mSettings.window.height;
 #endif
     }
-    float                      GetWindowAspect() const { return static_cast<float>(mSettings.window.width) / static_cast<float>(mSettings.window.height); }
-    grfx::Rect                 GetScissor() const;
-    grfx::Viewport             GetViewport(float minDepth = 0.0f, float maxDepth = 1.0f) const;
+    float          GetWindowAspect() const { return static_cast<float>(mSettings.window.width) / static_cast<float>(mSettings.window.height); }
+    grfx::Rect     GetScissor() const;
+    grfx::Viewport GetViewport(float minDepth = 0.0f, float maxDepth = 1.0f) const;
 
     // Loads a DXIL or SPV shader from baseDir.
     //

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -326,11 +326,12 @@ protected:
     virtual void DispatchScroll(float dx, float dy);
     virtual void DispatchRender();
     virtual void DispatchInitKnobs();
+    virtual void DrawGui() {}; // Draw additional project-related information to ImGui.
 
     void TakeScreenshot();
 
     void DrawImGui(grfx::CommandBuffer* pCommandBuffer);
-    void DrawDebugInfo(std::function<void(void)> drawAdditionalFn = []() {});
+    void DrawDebugInfo();
     void DrawProfilerGrfxApiFunctions();
 
     KnobManager& GetKnobManager() { return mKnobManager; }

--- a/projects/10_cube_map/main.cpp
+++ b/projects/10_cube_map/main.cpp
@@ -33,8 +33,8 @@ public:
     virtual void MouseMove(int32_t x, int32_t y, int32_t dx, int32_t dy, uint32_t buttons) override;
     virtual void Render() override;
 
-private:
-    void DrawGui();
+protected:
+    virtual void DrawGui() override;
 
 private:
     struct PerFrame
@@ -397,7 +397,7 @@ void ProjApp::Render()
 
             // Draw ImGui
             if (GetSettings()->enableImGui) {
-                DrawDebugInfo([this]() { this->DrawGui(); });
+                DrawDebugInfo();
                 DrawImGui(frame.cmd);
             }
         }

--- a/projects/12_shadows/main.cpp
+++ b/projects/12_shadows/main.cpp
@@ -33,8 +33,8 @@ public:
     virtual void Setup() override;
     virtual void Render() override;
 
-private:
-    void DrawGui();
+protected:
+    virtual void DrawGui() override;
 
 private:
     struct PerFrame
@@ -562,7 +562,7 @@ void ProjApp::Render()
             frame.cmd->DrawIndexed(mLight.mesh->GetIndexCount());
 
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
             DrawImGui(frame.cmd);
         }
         frame.cmd->EndRenderPass();

--- a/projects/13_normal_map/main.cpp
+++ b/projects/13_normal_map/main.cpp
@@ -31,8 +31,8 @@ public:
     virtual void Setup() override;
     virtual void Render() override;
 
-private:
-    void DrawGui();
+protected:
+    virtual void DrawGui() override;
 
 private:
     struct PerFrame
@@ -443,7 +443,7 @@ void ProjApp::Render()
             frame.cmd->DrawIndexed(mLight.mesh->GetIndexCount());
 
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
             DrawImGui(frame.cmd);
         }
         frame.cmd->EndRenderPass();

--- a/projects/14_input/main.cpp
+++ b/projects/14_input/main.cpp
@@ -34,8 +34,8 @@ public:
     virtual void MouseUp(int32_t x, int32_t y, uint32_t buttons) override;
     virtual void Render() override;
 
-private:
-    void DrawGui();
+protected:
+    virtual void DrawGui() override;
 
 private:
     struct PerFrame
@@ -144,7 +144,7 @@ void ProjApp::Render()
         frame.cmd->BeginRenderPass(&beginInfo);
         {
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
             DrawImGui(frame.cmd);
         }
         frame.cmd->EndRenderPass();

--- a/projects/15_basic_material/main.cpp
+++ b/projects/15_basic_material/main.cpp
@@ -294,7 +294,9 @@ private:
         MaterialResources&           materialResources);
     void SetupMaterials();
     void SetupIBL();
-    void DrawGui();
+
+protected:
+    virtual void DrawGui() override;
 };
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
@@ -1384,7 +1386,7 @@ void ProjApp::Render()
 #endif
 
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
             DrawImGui(frame.cmd);
         }
         frame.cmd->EndRenderPass();

--- a/projects/15_basic_material/main.cpp
+++ b/projects/15_basic_material/main.cpp
@@ -1032,11 +1032,11 @@ void ProjApp::Setup()
             shaderCreateInfo = {static_cast<uint32_t>(bytecode.size()), bytecode.data()};
             PPX_CHECKED_CALL(GetDevice()->CreateShaderModule(&shaderCreateInfo, &PS));
 
-            gpCreateInfo.vertexInputState.bindingCount     = CountU32(mEnvDrawMesh->GetDerivedVertexBindings());
-            gpCreateInfo.vertexInputState.bindings[0]      = mEnvDrawMesh->GetDerivedVertexBindings()[0];
-            gpCreateInfo.vertexInputState.bindings[1]      = mEnvDrawMesh->GetDerivedVertexBindings()[1];
-            gpCreateInfo.cullMode                          = grfx::CULL_MODE_FRONT;
-            gpCreateInfo.pPipelineInterface                = mEnvDrawPipelineInterface;
+            gpCreateInfo.vertexInputState.bindingCount = CountU32(mEnvDrawMesh->GetDerivedVertexBindings());
+            gpCreateInfo.vertexInputState.bindings[0]  = mEnvDrawMesh->GetDerivedVertexBindings()[0];
+            gpCreateInfo.vertexInputState.bindings[1]  = mEnvDrawMesh->GetDerivedVertexBindings()[1];
+            gpCreateInfo.cullMode                      = grfx::CULL_MODE_FRONT;
+            gpCreateInfo.pPipelineInterface            = mEnvDrawPipelineInterface;
 
             gpCreateInfo.VS = {VS.Get(), "vsmain"};
             gpCreateInfo.PS = {PS.Get(), "psmain"};

--- a/projects/16_gbuffer/main.cpp
+++ b/projects/16_gbuffer/main.cpp
@@ -116,7 +116,9 @@ private:
     void SetupDebugDraw();
     void SetupDrawToSwapchain();
     void UpdateConstants();
-    void DrawGui();
+
+protected:
+    virtual void DrawGui() override;
 };
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
@@ -840,7 +842,7 @@ void ProjApp::Render()
             frame.cmd->Draw(mDrawToSwapchain, 1, &mDrawToSwapchainSet);
 
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
             DrawImGui(frame.cmd);
         }
         frame.cmd->EndRenderPass();

--- a/projects/20_camera_motion/main.cpp
+++ b/projects/20_camera_motion/main.cpp
@@ -767,9 +767,10 @@ void ProjApp::Render()
     PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
-ProjApp::DrawGui() {
-  DrawCameraInfo();
-  DrawInstructions();
+ProjApp::DrawGui()
+{
+    DrawCameraInfo();
+    DrawInstructions();
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/20_camera_motion/main.cpp
+++ b/projects/20_camera_motion/main.cpp
@@ -767,7 +767,7 @@ void ProjApp::Render()
     PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
-ProjApp::DrawGui()
+void ProjApp::DrawGui()
 {
     DrawCameraInfo();
     DrawInstructions();

--- a/projects/20_camera_motion/main.cpp
+++ b/projects/20_camera_motion/main.cpp
@@ -225,6 +225,9 @@ private:
     void ProcessInput();
     void DrawCameraInfo();
     void DrawInstructions();
+
+protected:
+    virtual void DrawGui() override;
 };
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
@@ -742,7 +745,7 @@ void ProjApp::Render()
             }
 
             // Draw ImGui
-            DrawDebugInfo([this]() { DrawCameraInfo(); DrawInstructions(); });
+            DrawDebugInfo();
             DrawImGui(frame.cmd);
         }
         frame.cmd->EndRenderPass();
@@ -762,6 +765,11 @@ void ProjApp::Render()
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
     PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+}
+
+ProjApp::DrawGui() {
+  DrawCameraInfo();
+  DrawInstructions();
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/22_image_filter/main.cpp
+++ b/projects/22_image_filter/main.cpp
@@ -459,7 +459,7 @@ void ProjApp::Render()
     // Update graphics uniform buffer
     {
         float4x4 mat = calculateTransform(float2(mFilteredImages[mImageOption]->GetWidth(), mFilteredImages[mImageOption]->GetHeight()));
-        //This shader only takes a floa4x4 as uniform
+        // This shader only takes a floa4x4 as uniform
         void* pData = nullptr;
         PPX_CHECKED_CALL(mUniformBuffer->MapMemory(0, &pData));
         memcpy(pData, &mat, sizeof(float4x4));

--- a/projects/22_image_filter/main.cpp
+++ b/projects/22_image_filter/main.cpp
@@ -35,8 +35,10 @@ public:
     virtual void Setup() override;
     virtual void Render() override;
 
+protected:
+    virtual void DrawGui() override;
+
 private:
-    void DrawGui();
     struct PerFrame
     {
         grfx::CommandBufferPtr cmd;
@@ -502,7 +504,7 @@ void ProjApp::Render()
             frame.cmd->Draw(6, 1, 0, 0);
 
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
             DrawImGui(frame.cmd);
         }
         frame.cmd->EndRenderPass();

--- a/projects/23_async_compute/main.cpp
+++ b/projects/23_async_compute/main.cpp
@@ -32,6 +32,9 @@ public:
     virtual void Setup() override;
     virtual void Render() override;
 
+protected:
+    virtual void DrawGui() override;
+
 private:
     void SetupComposition();
     void SetupCompute();
@@ -92,7 +95,6 @@ private:
     std::vector<PerFrame> mPerFrame;
     const uint32_t        mNumFramesInFlight = 2;
 
-    void     DrawGui();
     void     UpdateTransforms(PerFrame& frame);
     uint32_t AcquireFrame(PerFrame& frame);
     void     BlitAndPresent(PerFrame& frame, uint32_t swapchainImageIndex);
@@ -911,7 +913,7 @@ void ProjApp::BlitAndPresent(PerFrame& frame, uint32_t swapchainImageIndex)
             cmd->Draw(mDrawToSwapchainPipeline, 1, &frame.drawToSwapchainData.descriptorSet);
 
             // Draw ImGui.
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
             DrawImGui(cmd);
         }
         cmd->EndRenderPass();

--- a/projects/27_mipmap_demo/main.cpp
+++ b/projects/27_mipmap_demo/main.cpp
@@ -30,8 +30,10 @@ public:
     virtual void Setup() override;
     virtual void Render() override;
 
+protected:
+    virtual void DrawGui() override;
+
 private:
-    void DrawGui();
     struct PerFrame
     {
         ppx::grfx::CommandBufferPtr cmd;
@@ -323,7 +325,7 @@ void ProjApp::Render()
             frame.cmd->Draw(6, 1, 0, 0);
 
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
             DrawImGui(frame.cmd);
         }
         frame.cmd->EndRenderPass();

--- a/projects/27_mipmap_demo/main.cpp
+++ b/projects/27_mipmap_demo/main.cpp
@@ -94,7 +94,7 @@ void ProjApp::Setup()
 
     // Texture image, view, and sampler
     {
-        //std::vector<std::string> textureFiles = {"box_panel.jpg", "statue.jpg"};
+        // std::vector<std::string> textureFiles = {"box_panel.jpg", "statue.jpg"};
         for (uint32_t i = 0; i < 2; ++i) {
             grfx_util::ImageOptions options = grfx_util::ImageOptions().MipLevelCount(PPX_REMAINING_MIP_LEVELS);
             PPX_CHECKED_CALL(grfx_util::CreateImageFromFile(GetDevice()->GetGraphicsQueue(), GetAssetPath("basic/textures/hanging_lights.jpg"), &mImage[i], options, i == 1));

--- a/projects/fishtornado/FishTornado.cpp
+++ b/projects/fishtornado/FishTornado.cpp
@@ -612,7 +612,7 @@ void FishTornadoApp::RenderSceneUsingSingleCommandBuffer(
             }
 
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
 #if defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
             DrawProfilerGrfxApiFunctions();
 #endif // defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
@@ -853,7 +853,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
             }
 
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
 #if defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
             DrawProfilerGrfxApiFunctions();
 #endif // defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)

--- a/projects/fishtornado/FishTornado.h
+++ b/projects/fishtornado/FishTornado.h
@@ -168,7 +168,9 @@ private:
         PerFrame&           prevFrame,
         grfx::SwapchainPtr& swapchain,
         uint32_t            imageIndex);
-    void DrawGui();
+
+ protected:
+    virtual void DrawGui() override;
 };
 
 #endif // FISHTORNADO_H

--- a/projects/fishtornado/FishTornado.h
+++ b/projects/fishtornado/FishTornado.h
@@ -169,7 +169,7 @@ private:
         grfx::SwapchainPtr& swapchain,
         uint32_t            imageIndex);
 
- protected:
+protected:
     virtual void DrawGui() override;
 };
 

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -642,7 +642,7 @@ void FishTornadoApp::RenderSceneUsingSingleCommandBuffer(
 
             if (!IsXrEnabled()) {
                 // Draw ImGui
-                DrawDebugInfo([this]() { this->DrawGui(); });
+                DrawDebugInfo();
 #if defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
                 DrawProfilerGrfxApiFunctions();
 #endif // defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
@@ -904,7 +904,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
 
             if (!IsXrEnabled()) {
                 // Draw ImGui
-                DrawDebugInfo([this]() { this->DrawGui(); });
+                DrawDebugInfo();
 #if defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
                 DrawProfilerGrfxApiFunctions();
 #endif // defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
@@ -1041,7 +1041,7 @@ void FishTornadoApp::Render()
 
             frame.uiCmd->BeginRenderPass(&beginInfo);
             // Draw ImGui
-            DrawDebugInfo([this]() { this->DrawGui(); });
+            DrawDebugInfo();
             DrawImGui(frame.uiCmd);
             frame.uiCmd->EndRenderPass();
         }

--- a/projects/fishtornado_xr/FishTornado.h
+++ b/projects/fishtornado_xr/FishTornado.h
@@ -175,7 +175,7 @@ private:
         grfx::SwapchainPtr& swapchain,
         uint32_t            imageIndex);
 
- protected:
+protected:
     virtual void DrawGui() override;
 };
 

--- a/projects/fishtornado_xr/FishTornado.h
+++ b/projects/fishtornado_xr/FishTornado.h
@@ -174,7 +174,9 @@ private:
         PerFrame&           prevFrame,
         grfx::SwapchainPtr& swapchain,
         uint32_t            imageIndex);
-    void DrawGui();
+
+ protected:
+    virtual void DrawGui() override;
 };
 
 #endif // FISHTORNADO_H

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1424,7 +1424,7 @@ float2 Application::GetNormalizedDeviceCoordinates(int32_t x, int32_t y) const
     return ndc;
 }
 
-void Application::DrawDebugInfo(std::function<void(void)> drawAdditionalFn)
+void Application::DrawDebugInfo()
 {
     if (!mImGui) {
         return;
@@ -1555,9 +1555,7 @@ void Application::DrawDebugInfo(std::function<void(void)> drawAdditionalFn)
         ImGui::Columns(1);
 
         // Draw additional elements
-        if (drawAdditionalFn) {
-            drawAdditionalFn();
-        }
+        DrawGui();
     }
 #if defined(PPX_BUILD_XR)
     lastImGuiWindowSize = ImGui::GetWindowSize();


### PR DESCRIPTION
Instead of `ppx::Application::DrawDebugInfo` accepting a callback to display additional info through ImGui, the callback has been converted into a method called `DrawGui`. This makes it quick to override, and keeps the projects consistent.