### PR TITLE
Move CSVFileLog to use filesystem::path

### DIFF
--- a/benchmarks/compute_operations/main.cpp
+++ b/benchmarks/compute_operations/main.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
+
 #include "ppx/config.h"
 #include "ppx/math_config.h"
 #include "ppx/graphics_util.h"
@@ -115,7 +117,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 
 void ProjApp::SaveResultsToFile()
 {
-    CSVFileLog fileLogger = {mCSVFileName};
+    CSVFileLog fileLogger{std::filesystem::path(mCSVFileName)};
     for (const auto& row : mFrameRegisters) {
         fileLogger.LogField(row.frameNumber);
         fileLogger.LogField(row.gpuWorkDurationMs);

--- a/benchmarks/draw_call/main.cpp
+++ b/benchmarks/draw_call/main.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
+
 #include "ppx/config.h"
 #include "ppx/math_config.h"
 #include "ppx/graphics_util.h"
@@ -90,7 +92,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 
 void ProjApp::SaveResultsToFile()
 {
-    CSVFileLog fileLogger = {mCSVFileName};
+    CSVFileLog fileLogger{std::filesystem::path(mCSVFileName)};
     for (const auto& row : mFrameRegisters) {
         fileLogger.LogField(row.frameNumber);
         fileLogger.LogField(row.gpuWorkDuration);

--- a/benchmarks/headless_compute/main.cpp
+++ b/benchmarks/headless_compute/main.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
+
 #include "ppx/config.h"
 #include "ppx/math_config.h"
 #include "ppx/graphics_util.h"
@@ -97,7 +99,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 
 void ProjApp::SaveResultsToFile()
 {
-    CSVFileLog fileLogger = {mCSVFileName};
+    CSVFileLog fileLogger{std::filesystem::path(mCSVFileName)};
     for (const auto& row : mFrameRegisters) {
         fileLogger.LogField(row.frameNumber);
         fileLogger.LogField(row.gpuWorkDurationMs);

--- a/benchmarks/overdraw/main.cpp
+++ b/benchmarks/overdraw/main.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
+
 #include "ppx/config.h"
 #include "ppx/math_config.h"
 #include "ppx/graphics_util.h"
@@ -116,7 +118,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 
 void ProjApp::SaveResultsToFile()
 {
-    CSVFileLog fileLogger = {mCSVFileName};
+    CSVFileLog fileLogger{std::filesystem::path(mCSVFileName)};
     for (const auto& row : mFrameRegisters) {
         fileLogger.LogField(row.frameNumber);
         fileLogger.LogField(row.gpuWorkDurationMs);

--- a/benchmarks/primitive_assembly/main.cpp
+++ b/benchmarks/primitive_assembly/main.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <deque>
+#include <filesystem>
+
 #include "ppx/ppx.h"
 #include "ppx/csv_file_log.h"
 
@@ -89,7 +91,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 
 void ProjApp::SaveResultsToFile()
 {
-    CSVFileLog fileLogger = {mCSVFileName};
+    CSVFileLog fileLogger{std::filesystem::path(mCSVFileName)};
     for (const auto& row : mFrameRegisters) {
         fileLogger.LogField(row.frameNumber);
         fileLogger.LogField(row.gpuWorkDurationMs);

--- a/benchmarks/render_target/main.cpp
+++ b/benchmarks/render_target/main.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
+
 #include "ppx/config.h"
 #include "ppx/math_config.h"
 #include "ppx/graphics_util.h"
@@ -101,7 +103,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 
 void ProjApp::SaveResultsToFile()
 {
-    CSVFileLog fileLogger = {mCSVFileName};
+    CSVFileLog fileLogger{std::filesystem::path(mCSVFileName)};
     for (const auto& row : mFrameRegisters) {
         fileLogger.LogField(row.frameNumber);
         fileLogger.LogField(row.gpuWorkDurationMs);

--- a/benchmarks/texture_load/main.cpp
+++ b/benchmarks/texture_load/main.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
+
 #include "ppx/config.h"
 #include "ppx/math_config.h"
 #include "ppx/graphics_util.h"
@@ -94,7 +96,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 
 void ProjApp::SaveResultsToFile()
 {
-    CSVFileLog fileLogger = {mCSVFileName};
+    CSVFileLog fileLogger{std::filesystem::path(mCSVFileName)};
     for (const auto& row : mFrameRegisters) {
         fileLogger.LogField(row.frameNumber);
         fileLogger.LogField(row.gpuWorkDuration);

--- a/benchmarks/texture_sample/main.cpp
+++ b/benchmarks/texture_sample/main.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <filesystem>
+
 #include "ppx/config.h"
 #include "ppx/math_config.h"
 #include "ppx/graphics_util.h"
@@ -108,7 +110,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 
 void ProjApp::SaveResultsToFile()
 {
-    CSVFileLog fileLogger = {mCSVFileName};
+    CSVFileLog fileLogger{std::filesystem::path(mCSVFileName)};
     for (const auto& row : mFrameRegisters) {
         fileLogger.LogField(row.frameNumber);
         fileLogger.LogField(row.gpuWorkDuration);

--- a/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
+++ b/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
@@ -14,6 +14,7 @@
 
 #include <deque>
 #include <fstream>
+#include <filesystem>
 
 #include "ppx/grfx/grfx_scope.h"
 
@@ -91,7 +92,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 
 void ProjApp::SaveResultsToFile()
 {
-    CSVFileLog fileLogger = {mCSVFileName};
+    CSVFileLog fileLogger{std::filesystem::path(mCSVFileName)};
     for (const auto& row : mFrameRegisters) {
         fileLogger.LogField(row.frameNumber);
         fileLogger.LogField(row.cpuTransferTimeMs);

--- a/include/ppx/csv_file_log.h
+++ b/include/ppx/csv_file_log.h
@@ -21,6 +21,7 @@
 #include <iomanip>
 #include <mutex>
 #include <sstream>
+#include <filesystem>
 
 const std::string PPX_DEFAULT_CSV_FILE{"stats.csv"};
 
@@ -33,7 +34,7 @@ class CSVFileLog
 {
 public:
     CSVFileLog();
-    CSVFileLog(const std::string& filepath);
+    CSVFileLog(const std::filesystem::path& filepath);
     ~CSVFileLog();
 
     template <typename T>
@@ -65,7 +66,6 @@ private:
     void Flush();
 
 private:
-    std::string       mFilePath;
     std::ofstream     mFileStream;
     std::stringstream mBuffer;
     std::mutex        mWriteMutex;

--- a/src/ppx/csv_file_log.cpp
+++ b/src/ppx/csv_file_log.cpp
@@ -21,11 +21,10 @@ CSVFileLog::CSVFileLog()
 {
 }
 
-CSVFileLog::CSVFileLog(const std::string& filepath)
+CSVFileLog::CSVFileLog(const std::filesystem::path& filepath)
 {
-    mFilePath = filepath;
-    if (!mFilePath.empty()) {
-        mFileStream.open(mFilePath.c_str());
+    if (!filepath.empty()) {
+        mFileStream.open(filepath.c_str());
     }
     Lock();
 }


### PR DESCRIPTION
This change moves CSVFileLog to use filesystem::path for its target, rather than std::string. This is because filesystem::path.c_str() resolves to wchar_t on MSVC, and char on other compilers, making it difficult to pass a filename processed via filesystem::path into the function otherwise.