### PR TITLE
application: disable imgui on deterministic runs.

### DIFF
--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1020,8 +1020,9 @@ int Application::Run(int argc, char** argv)
         mRunTimeSeconds = mStandardOptions.run_time_ms / 1000.f;
     }
 
-    // Disable ImGui in headless mode.
-    if (mSettings.headless && mSettings.enableImGui) {
+    // Disable ImGui in headless or deterministic mode.
+    // ImGUI is not non-deterministic, but the visible informations (stats, timers) are.
+    if ((mSettings.headless || mStandardOptions.deterministic) && mSettings.enableImGui) {
         mSettings.enableImGui = false;
         PPX_LOG_WARN("Headless mode: disabling ImGui");
     }


### PR DESCRIPTION
ImGUI itself is not non-deterministic. But ImGUI is used to display metrics or data which is not deterministic.
I don't see a benefit in keeping imgui in deterministic mode, so the simplest option seem to disable it.