### PR TITLE
fs: tries to uniformize Android/Desktop FS ops.

### DIFF
--- a/include/ppx/fs.h
+++ b/include/ppx/fs.h
@@ -90,13 +90,13 @@ public:
 
     // Returns true if the file is readable.
     bool IsValid() const;
-    // Returns true if the file is mapped in memory. See `File::GetPointer()`.
+    // Returns true if the file is mapped in memory. See `File::GetMappedData()`.
     bool IsMapped() const;
 
     // Returns the total size in bytes of the file from the start.
     size_t GetLength() const;
     // Returns a readable pointer to a beginning of the file. Behavior undefined if `File::IsMapped()` is false.
-    const void* GetPointer() const;
+    const void* GetMappedData() const;
 
 private:
 #if !defined(PPX_ANDROID)

--- a/include/ppx/fs.h
+++ b/include/ppx/fs.h
@@ -46,27 +46,69 @@ namespace ppx::fs {
 void set_android_context(android_app* androidContext);
 #endif
 
-//! @class File
-//!
-//!
+// Abstract a static, regular file on all platforms.
+// This class doesn't handle sockets, or file which content is not constant
+// for the lifetime of this class.
 class File
 {
+    // Internal enum to know which handle is currently valid.
+    enum FileHandleType
+    {
+        // Default handle, no file associated.
+        BAD_HANDLE = 0,
+        // The file is accessible throught a stream.
+        STREAM_HANDLE = 1,
+        // The file is accessible through an Android asset handle.
+        ASSET_HANDLE = 3
+    };
+
 public:
-    bool   Open(const std::filesystem::path& path);
-    bool   IsOpen() const;
-    size_t Read(void* buf, size_t count);
-    size_t GetLength();
-    void   Close();
-#if defined(PPX_ANDROID)
-    const void* GetBuffer();
-#endif
+    File();
+    File(const File& other)  = delete;
+    File(const File&& other) = delete;
+    ~File();
+
+    // Open a file given a specific path.
+    // path: the path of the file to open.
+    //  - On desktop, loads the regular file at `path`. (memory-mapping availability is implementation defined).
+    //  - On Android, relative path are assumed to be loaded from the APK, those are memory mapped.
+    //                absolute path are loaded as regular files (mapping availability is implementation defined).
+    //
+    // - This API only supports regular files.
+    // - This API expects the file not to change size or content while this handle is open.
+    // - This class supports RAII. File will be closed on destroy.
+    bool Open(const std::filesystem::path& path);
+
+    // Read `size` bytes from the file into `buffer`.
+    // buffer: a pointer to a buffer with at least `count` writable bytes.
+    // count: the maximum number of bytes to write to `buffer`.
+    // Returns the number of bytes written to `buffer`.
+    //
+    // - The file has an internal cursor, meaning the next read will start at the end of the last read.
+    // - If the file size is larger than `count`, the read stops at `count` bytes.
+    size_t Read(void* buffer, size_t count);
+
+    // Is this file readable?
+    bool IsValid() const;
+    // Is this file mapped in memory? See `File::GetPointer()`.
+    bool IsMapped() const;
+
+    // Gets the total size in bytes of the file from the start.
+    size_t GetLength() const;
+    // Gets a readable pointer to a beginning of the file. Behavior undefined is `File::IsMapped()` is false.
+    const void* GetPointer() const;
 
 private:
-#if defined(PPX_ANDROID)
-    AAsset* mFile = nullptr;
-#else
-    std::ifstream mStream;
+#if !defined(PPX_ANDROID)
+    typedef void AAsset;
 #endif
+
+    FileHandleType mHandleType = BAD_HANDLE;
+    AAsset*        mAsset      = nullptr;
+    const void*    mBuffer     = nullptr;
+    std::ifstream  mStream;
+    size_t         mFileSize   = 0;
+    size_t         mFileOffset = 0;
 };
 
 class FileStream : public std::streambuf
@@ -78,8 +120,19 @@ private:
     std::vector<char> mBuffer;
 };
 
+// Opens a regular file and returns its content if the read succeeded.
+// `path`: the path of the file to load.
+// The path is handled differently depending on the platform:
+//  - desktop: all path are treated the same.
+//  - android: relative path are assumed to be in APK's storage (Asset API). Absolute are loaded from disk.
 std::optional<std::vector<char>> load_file(const std::filesystem::path& path);
-bool                             path_exists(const std::filesystem::path& path);
+
+// Returns true if a given path exists (file or directory).
+// `path`: the path to check.
+// The path is handled differently depending on the platform:
+//  - desktop: all path are treated the same.
+//  - android: relative path are assumed to be in APK's storage (Asset API). Absolute are loaded from disk.
+bool path_exists(const std::filesystem::path& path);
 
 #if defined(PPX_ANDROID)
 // Returns a path to the application's internal data directory (can be used for output).

--- a/include/ppx/fs.h
+++ b/include/ppx/fs.h
@@ -56,10 +56,10 @@ class File
     {
         // Default handle, no file associated.
         BAD_HANDLE = 0,
-        // The file is accessible throught a stream.
+        // The file is accessible through a stream.
         STREAM_HANDLE = 1,
         // The file is accessible through an Android asset handle.
-        ASSET_HANDLE = 3
+        ASSET_HANDLE = 2,
     };
 
 public:
@@ -68,7 +68,7 @@ public:
     File(const File&& other) = delete;
     ~File();
 
-    // Open a file given a specific path.
+    // Opens a file given a specific path.
     // path: the path of the file to open.
     //  - On desktop, loads the regular file at `path`. (memory-mapping availability is implementation defined).
     //  - On Android, relative path are assumed to be loaded from the APK, those are memory mapped.
@@ -79,7 +79,7 @@ public:
     // - This class supports RAII. File will be closed on destroy.
     bool Open(const std::filesystem::path& path);
 
-    // Read `size` bytes from the file into `buffer`.
+    // Reads `size` bytes from the file into `buffer`.
     // buffer: a pointer to a buffer with at least `count` writable bytes.
     // count: the maximum number of bytes to write to `buffer`.
     // Returns the number of bytes written to `buffer`.
@@ -88,14 +88,14 @@ public:
     // - If the file size is larger than `count`, the read stops at `count` bytes.
     size_t Read(void* buffer, size_t count);
 
-    // Is this file readable?
+    // Returns true if the file is readable.
     bool IsValid() const;
-    // Is this file mapped in memory? See `File::GetPointer()`.
+    // Returns true if the file is mapped in memory. See `File::GetPointer()`.
     bool IsMapped() const;
 
-    // Gets the total size in bytes of the file from the start.
+    // Returns the total size in bytes of the file from the start.
     size_t GetLength() const;
-    // Gets a readable pointer to a beginning of the file. Behavior undefined is `File::IsMapped()` is false.
+    // Returns a readable pointer to a beginning of the file. Behavior undefined if `File::IsMapped()` is false.
     const void* GetPointer() const;
 
 private:
@@ -123,8 +123,8 @@ private:
 // Opens a regular file and returns its content if the read succeeded.
 // `path`: the path of the file to load.
 // The path is handled differently depending on the platform:
-//  - desktop: all path are treated the same.
-//  - android: relative path are assumed to be in APK's storage (Asset API). Absolute are loaded from disk.
+//  - desktop: all paths are treated the same.
+//  - android: relative paths are assumed to be in APK's storage (Asset API). Absolute are loaded from disk.
 std::optional<std::vector<char>> load_file(const std::filesystem::path& path);
 
 // Returns true if a given path exists (file or directory).

--- a/src/ppx/bitmap.cpp
+++ b/src/ppx/bitmap.cpp
@@ -533,7 +533,7 @@ Result Bitmap::StbiInfo(const std::filesystem::path& path, int* pX, int* pY, int
 
     int stbiResult = 0;
     if (file.IsMapped()) {
-        stbiResult = stbi_info_from_memory(reinterpret_cast<const stbi_uc*>(file.GetPointer()), file.GetLength(), pX, pY, pComp);
+        stbiResult = stbi_info_from_memory(reinterpret_cast<const stbi_uc*>(file.GetMappedData()), file.GetLength(), pX, pY, pComp);
     }
     else {
         std::vector<uint8_t> buffer(file.GetLength());
@@ -596,7 +596,7 @@ char* Bitmap::StbiLoad(const std::filesystem::path& path, Bitmap::Format format,
         file.Read(buffer.data(), buffer.size());
     }
 
-    const stbi_uc* readPtr = file.IsMapped() ? reinterpret_cast<const stbi_uc*>(file.GetPointer()) : buffer.data();
+    const stbi_uc* readPtr = file.IsMapped() ? reinterpret_cast<const stbi_uc*>(file.GetMappedData()) : buffer.data();
     if (format == Bitmap::FORMAT_RGBA_FLOAT) {
         return reinterpret_cast<char*>(stbi_loadf_from_memory(readPtr, file.GetLength(), pWidth, pHeight, pChannels, desiredChannels));
     }

--- a/src/ppx/bitmap.cpp
+++ b/src/ppx/bitmap.cpp
@@ -595,9 +595,8 @@ char* Bitmap::StbiLoad(const std::filesystem::path& path, Bitmap::Format format,
         buffer.resize(file.GetLength());
         file.Read(buffer.data(), buffer.size());
     }
-    const stbi_uc* readPtr = file.IsMapped() ? reinterpret_cast<const stbi_uc*>(file.GetPointer()) : buffer.data();
-    ;
 
+    const stbi_uc* readPtr = file.IsMapped() ? reinterpret_cast<const stbi_uc*>(file.GetPointer()) : buffer.data();
     if (format == Bitmap::FORMAT_RGBA_FLOAT) {
         return reinterpret_cast<char*>(stbi_loadf_from_memory(readPtr, file.GetLength(), pWidth, pHeight, pChannels, desiredChannels));
     }
@@ -624,6 +623,7 @@ Result Bitmap::LoadFile(const std::filesystem::path& path, Bitmap* pBitmap)
     char*          dataPtr          = StbiLoad(path, format, &width, &height, &channels, requiredChannels);
 
     if (IsNull(dataPtr)) {
+        PPX_LOG_ERROR("Failed to open file '" + path.string() + "'");
         return ppx::ERROR_IMAGE_FILE_LOAD_FAILED;
     }
     ppxres = Bitmap::Create(width, height, format, dataPtr, pBitmap);

--- a/src/ppx/fs.cpp
+++ b/src/ppx/fs.cpp
@@ -103,7 +103,7 @@ size_t File::Read(void* buffer, size_t count)
 
     if (IsMapped()) {
         readCount = std::min(count, GetLength() - mFileOffset);
-        memcpy(buffer, reinterpret_cast<const uint8_t*>(GetPointer()) + mFileOffset, readCount);
+        memcpy(buffer, reinterpret_cast<const uint8_t*>(GetMappedData()) + mFileOffset, readCount);
     }
     else if (mHandleType == STREAM_HANDLE) {
         mStream.read(reinterpret_cast<char*>(buffer), count);
@@ -124,9 +124,9 @@ size_t File::GetLength() const
     return mFileSize;
 }
 
-const void* File::GetPointer() const
+const void* File::GetMappedData() const
 {
-    PPX_ASSERT_MSG(IsMapped(), "Called GetPointer() on an non-mapped file.");
+    PPX_ASSERT_MSG(IsMapped(), "Called GetMappedData() on an non-mapped file.");
     return mBuffer;
 }
 

--- a/src/ppx/fs.cpp
+++ b/src/ppx/fs.cpp
@@ -33,64 +33,102 @@ void set_android_context(android_app* androidContext)
 }
 #endif
 
+File::File()
+    : mHandleType(BAD_HANDLE)
+{
+}
+
+File::~File()
+{
+    switch (mHandleType) {
+        case ASSET_HANDLE:
+#if defined(PPX_ANDROID)
+            AAsset_close(mAsset);
+#else
+            PPX_ASSERT_MSG(false, "Bad implem. This case should never be reached.");
+#endif
+            break;
+        case STREAM_HANDLE:
+            mStream.close();
+            break;
+        default:
+            break;
+    }
+}
+
 bool File::Open(const std::filesystem::path& path)
 {
 #if defined(PPX_ANDROID)
-    mFile = AAssetManager_open(gAndroidContext->activity->assetManager, path.c_str(), AASSET_MODE_BUFFER);
-    return mFile != nullptr;
-#else
+    if (!path.is_absolute()) {
+        mAsset      = AAssetManager_open(gAndroidContext->activity->assetManager, path.c_str(), AASSET_MODE_BUFFER);
+        mHandleType = mAsset != nullptr ? ASSET_HANDLE : BAD_HANDLE;
+        mFileSize   = mHandleType == ASSET_HANDLE ? AAsset_getLength(mAsset) : 0;
+        mFileOffset = 0;
+        mBuffer     = AAsset_getBuffer(mAsset);
+        return mHandleType == ASSET_HANDLE;
+    }
+#endif
+
     mStream.open(path, std::ios::binary);
-    return mStream.good();
-#endif
-}
+    if (!mStream.good()) {
+        return false;
+    }
 
-bool File::IsOpen() const
-{
-#if defined(PPX_ANDROID)
-    return mFile != nullptr;
-#else
-    return mStream.is_open();
-#endif
-}
-
-size_t File::Read(void* buf, size_t count)
-{
-#if defined(PPX_ANDROID)
-    return AAsset_read(mFile, buf, count);
-#else
-    mStream.read(reinterpret_cast<char*>(buf), count);
-    return mStream.gcount();
-#endif
-}
-
-size_t File::GetLength()
-{
-#if defined(PPX_ANDROID)
-    return AAsset_getLength(mFile);
-#else
-    std::streamoff pos = mStream.tellg();
     mStream.seekg(0, std::ios::end);
-    size_t size = mStream.tellg();
-    mStream.seekg(pos, std::ios::beg);
-    return size;
-#endif
+    mFileSize = mStream.tellg();
+    mStream.seekg(0, std::ios::beg);
+    mFileOffset = 0;
+    mHandleType = STREAM_HANDLE;
+    return true;
 }
 
-void File::Close()
+bool File::IsValid() const
 {
-#if defined(PPX_ANDROID)
-    AAsset_close(mFile);
-#else
-    mStream.close();
-#endif
+    if (mHandleType == STREAM_HANDLE) {
+        return mStream.good();
+    }
+    return mHandleType == ASSET_HANDLE && mAsset != nullptr;
 }
 
-#if defined(PPX_ANDROID)
-const void* File::GetBuffer()
+bool File::IsMapped() const
 {
-    return AAsset_getBuffer(mFile);
+    return IsValid() && mBuffer != nullptr;
 }
+
+size_t File::Read(void* buffer, size_t count)
+{
+    PPX_ASSERT_MSG(IsValid(), "Calling File::read() on an invalid file.");
+
+    size_t readCount = 0;
+
+    if (IsMapped()) {
+        readCount = std::min(count, GetLength() - mFileOffset);
+        memcpy(buffer, reinterpret_cast<const uint8_t*>(GetPointer()) + mFileOffset, readCount);
+    }
+    else if (mHandleType == STREAM_HANDLE) {
+        mStream.read(reinterpret_cast<char*>(buffer), count);
+        readCount = mStream.gcount();
+    }
+#if defined(PPX_ANDROID)
+    else if (mHandleType == ASSET_HANDLE) {
+        readCount = AAsset_read(mAsset, buffer, count);
+    }
 #endif
+
+    mFileOffset += readCount;
+    return readCount;
+}
+
+size_t File::GetLength() const
+{
+    return mFileSize;
+}
+
+const void* File::GetPointer() const
+{
+    PPX_ASSERT_MSG(IsMapped(), "Called GetPointer() on an non-mapped file.");
+    return mBuffer;
+}
 
 bool FileStream::Open(const char* path)
 {
@@ -104,46 +142,40 @@ bool FileStream::Open(const char* path)
 
 std::optional<std::vector<char>> load_file(const std::filesystem::path& path)
 {
-    std::vector<char> data;
-
     ppx::fs::File file;
     if (!file.Open(path)) {
         return std::nullopt;
     }
-    size_t size = file.GetLength();
-    data.resize(size);
-
-#if defined(PPX_ANDROID)
-    // Allow the system to use MMIO if available.
-    const void* buf = file.GetBuffer();
-    memcpy(data.data(), buf, size);
-#else
-    file.Read(data.data(), size);
-#endif
-    file.Close();
-    return data;
+    const size_t      size = file.GetLength();
+    std::vector<char> buffer(size);
+    const size_t      readSize = file.Read(buffer.data(), size);
+    if (readSize != size) {
+        return std::nullopt;
+    }
+    return buffer;
 }
 
 bool path_exists(const std::filesystem::path& path)
 {
 #if defined(PPX_ANDROID)
-    AAsset* temp_file = AAssetManager_open(gAndroidContext->activity->assetManager, path.c_str(), AASSET_MODE_BUFFER);
-    if (temp_file != nullptr) {
-        AAsset_close(temp_file);
-        return true;
-    }
+    if (!path.is_absolute()) {
+        AAsset* temp_file = AAssetManager_open(gAndroidContext->activity->assetManager, path.c_str(), AASSET_MODE_BUFFER);
+        if (temp_file != nullptr) {
+            AAsset_close(temp_file);
+            return true;
+        }
 
-    // So it's not a file. Check if it's a subdirectory
-    AAssetDir* temp_dir = AAssetManager_openDir(gAndroidContext->activity->assetManager, path.c_str());
-    if (temp_dir != nullptr) {
-        AAssetDir_close(temp_dir);
-        return true;
+        // So it's not a file. Check if it's a subdirectory
+        AAssetDir* temp_dir = AAssetManager_openDir(gAndroidContext->activity->assetManager, path.c_str());
+        if (temp_dir != nullptr) {
+            AAssetDir_close(temp_dir);
+            return true;
+        }
+        return false;
     }
-
-    return false;
-#else
-    return std::filesystem::exists(path);
 #endif
+
+    return std::filesystem::exists(path);
 }
 
 #if defined(PPX_ANDROID)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -53,5 +53,6 @@ list(
     ppm_export_test.cpp
     string_util_test.cpp
     transform_test.cpp
+    filesystem_test.cpp
 )
 package_add_test(ppx_tests ${TEST_SOURCES})

--- a/src/test/filesystem_test.cpp
+++ b/src/test/filesystem_test.cpp
@@ -37,13 +37,13 @@ static size_t getOpenFDCount()
     DIR* fdDir = opendir("/proc/self/fd");
     assert(fdDir != nullptr);
 
-    size_t fd_count = 0;
+    size_t fdCount = 0;
     while (readdir(fdDir)) {
-        ++fd_count;
+        ++fdCount;
     }
 
     closedir(fdDir);
-    return fd_count;
+    return fdCount;
 }
 
 class FsTest : public ::testing::Test
@@ -124,7 +124,7 @@ TEST_F(FsTest, OpenNonExistantFileFails)
     EXPECT_FALSE(file.IsValid());
 }
 
-TEST_F(FsTest, OpenDirectoryFaile)
+TEST_F(FsTest, OpenDirectoryFails)
 {
     fs::File file;
     EXPECT_FALSE(file.Open(nonExistantFile));

--- a/src/test/filesystem_test.cpp
+++ b/src/test/filesystem_test.cpp
@@ -1,0 +1,183 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Those tests uses some OS-specific libraries to handled filesystem and make sure the FS library
+// behaves correctly. This should probably be implemented on other platforms, but for now we test is on
+// linux and relies on the app working for other platforms.
+#if defined(PPX_LINUX)
+
+#include "gtest/gtest.h"
+#include "ppx/config.h"
+#include "ppx/fs.h"
+
+#include <dirent.h>
+#include <filesystem>
+#include <stdio.h>
+#include <string>
+#include <string_view>
+#include <sys/types.h>
+#include <unistd.h>
+
+constexpr std::string_view kDefaultFileContent = "some content";
+
+// Counts the number of filedescriptors open by the current process.
+static size_t getOpenFDCount()
+{
+    DIR* fdDir = opendir("/proc/self/fd");
+    assert(fdDir != nullptr);
+
+    size_t fd_count = 0;
+    while (readdir(fdDir)) {
+        ++fd_count;
+    }
+
+    closedir(fdDir);
+    return fd_count;
+}
+
+class FsTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        readableFileHandle = createFile(kDefaultFileContent);
+        readableFile       = filenameFromFile(readableFileHandle);
+
+        directory = readableFile.parent_path();
+
+        {
+            char* filename  = tmpnam(nullptr);
+            nonExistantFile = std::filesystem::path(filename);
+        }
+    }
+
+    void TearDown() override
+    {
+        fclose(readableFileHandle);
+    }
+
+    std::filesystem::path readableFile;
+    FILE*                 readableFileHandle;
+
+    std::filesystem::path nonExistantFile;
+    std::filesystem::path directory;
+
+private:
+    static std::filesystem::path filenameFromFile(FILE* file)
+    {
+        return std::filesystem::path("/proc/self/fd/") / std::to_string(fileno(file));
+    }
+
+    FILE* createFile(const std::string_view& content)
+    {
+        FILE* file = tmpfile();
+        assert(file != nullptr);
+
+        const size_t totalSize = content.size() * sizeof(content[0]);
+        const size_t written   = fwrite(content.data(), sizeof(content[0]), content.size(), file);
+        assert(written == totalSize);
+
+        // See man(3) fopen: it is required to call a fseek/fsetpos between output and input to a File
+        // to make sure buffers are flushed.
+        // rewind is a wrapper to fseek(file, 0, SEEK_SET);
+        rewind(file);
+
+        return file;
+    }
+};
+
+namespace ppx {
+
+TEST_F(FsTest, InitializedFileIsBad)
+{
+    fs::File file;
+
+    EXPECT_FALSE(file.IsValid());
+}
+
+TEST_F(FsTest, SimpleOpen)
+{
+    fs::File file;
+    EXPECT_TRUE(file.Open(readableFile));
+}
+
+TEST_F(FsTest, SimpleOpenValid)
+{
+    fs::File file;
+    EXPECT_TRUE(file.Open(readableFile));
+
+    EXPECT_TRUE(file.IsValid());
+}
+
+TEST_F(FsTest, OpenAndRead)
+{
+    fs::File file;
+    EXPECT_TRUE(file.Open(readableFile));
+
+    std::string  buffer(kDefaultFileContent.size(), '\0');
+    const size_t readCount = file.Read(buffer.data(), buffer.size());
+    EXPECT_EQ(readCount, kDefaultFileContent.size());
+    EXPECT_EQ(buffer, kDefaultFileContent);
+}
+
+TEST_F(FsTest, OpenAndReadCursor)
+{
+    fs::File file;
+    EXPECT_TRUE(file.Open(readableFile));
+
+    assert(kDefaultFileContent.size() == 12 && "Test needs update if the value changes.");
+    std::string part1(6, '\0');
+    std::string part2(6, '\0');
+
+    {
+        const size_t readCount = file.Read(part1.data(), part1.size());
+        EXPECT_EQ(readCount, part1.size());
+    }
+    {
+        const size_t readCount = file.Read(part2.data(), part2.size());
+        EXPECT_EQ(readCount, part2.size());
+    }
+
+    EXPECT_EQ(part1, "some c");
+    EXPECT_EQ(part2, "ontent");
+}
+
+TEST_F(FsTest, GetSizeIgnoresCursor)
+{
+    fs::File file;
+    EXPECT_TRUE(file.Open(readableFile));
+    EXPECT_EQ(file.GetLength(), kDefaultFileContent.size());
+
+    std::string buffer(kDefaultFileContent.size(), '\0');
+    EXPECT_EQ(file.Read(buffer.data(), buffer.size()), kDefaultFileContent.size());
+
+    EXPECT_EQ(file.GetLength(), kDefaultFileContent.size());
+}
+
+TEST_F(FsTest, RAIIClosure)
+{
+    const size_t fdCountBefore = getOpenFDCount();
+
+    {
+        fs::File file;
+        EXPECT_TRUE(file.Open(readableFile));
+        // Sanity check, in case some weird libc implems uses the same FD.
+        EXPECT_EQ(getOpenFDCount(), fdCountBefore + 1);
+    }
+
+    EXPECT_EQ(getOpenFDCount(), fdCountBefore);
+}
+
+} // namespace ppx
+#endif


### PR DESCRIPTION
Android has 2 ways to access assets:
 - the Assets NDK API
 - normal disk read. Desktop only has the latter.

The FS API built today was preventing Android to load assets from the disk, and API diverged a bit (ex memory-mapped usage was Android only).

This commit tried to re-uniformize this. To limit the PR scope, the memory mapping is not added for desktop, but is trivial to add now.

Adding this code would also unblock Android application to load assets not from the APK folder, but from the disk. The issue I had was APK/disk duality is only valid on desktop.
I solved this by assuming relative path on Android means in-APK, and absolute means "I know what I'm doing, disk access".

This seems to work for most use-cases I found, but we might need to revisit this in the future if need be.. Maybe we should stop try to guess path between 3p and 1p assets, and maybe we could add some `apk:/some/path` or `storage:/some/other/path` indicator? but that would require apps to know in advance what we do with their assets..