### PR TITLE
utils: add ScopedTimer class.

### DIFF
--- a/include/ppx/timer.h
+++ b/include/ppx/timer.h
@@ -22,6 +22,7 @@
 //   Use PPX_TIMER_FORCE_MONOTONIC to force CLOCK_MONOTONIC.
 //
 
+#include <string>
 #include <cstdint>
 
 // clang-format off
@@ -88,6 +89,21 @@ private:
     bool     mInitialized    = false;
     uint64_t mStartTimestamp = 0;
     uint64_t mStopTimestamp  = 0;
+};
+
+// Helper class to display a timer result using RAII pattern.
+class ScopedTimer
+{
+    Timer             mTimer;
+    const std::string mMessage;
+
+public:
+    // Create a timer. The logged message will have the format "<message>: %f ms elapsed".
+    ScopedTimer(const std::string& message);
+    ~ScopedTimer();
+
+    ScopedTimer(const ScopedTimer&) = delete;
+    ScopedTimer(ScopedTimer&&)      = delete;
 };
 
 } // namespace ppx

--- a/include/ppx/timer.h
+++ b/include/ppx/timer.h
@@ -98,7 +98,7 @@ class ScopedTimer
     const std::string mMessage;
 
 public:
-    // Create a timer. The logged message will have the format "<message>: %f ms elapsed".
+    // Creates a timer. The logged message will have the format "<message>: %f ms elapsed".
     ScopedTimer(const std::string& message);
     ~ScopedTimer();
 

--- a/projects/fishtornado/FishTornado.cpp
+++ b/projects/fishtornado/FishTornado.cpp
@@ -357,22 +357,15 @@ void FishTornadoApp::SetupCaustics()
 void FishTornadoApp::UploadCaustics()
 {
     for (uint32_t i = 0; i < kCausticsImageCount; ++i) {
-        Timer timer;
-        PPX_ASSERT_MSG(timer.Start() == ppx::TIMER_RESULT_SUCCESS, "timer start failed");
-        double fnStartTime = timer.SecondsSinceStart();
-
         std::stringstream filename;
         filename << "fishtornado/textures/ocean/caustics/save." << std::setw(2) << std::setfill('0') << i << ".png";
         std::filesystem::path path = GetAssetPath(filename.str());
+        ScopedTimer           timer("Image creation from file '" + path.string() + "'");
 
         Bitmap bitmap;
         PPX_CHECKED_CALL(Bitmap::LoadFile(path, &bitmap));
 
         PPX_CHECKED_CALL(grfx_util::CopyBitmapToTexture(GetGraphicsQueue(), &bitmap, mCausticsTexture, 0, i, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_SHADER_RESOURCE));
-
-        double fnEndTime = timer.SecondsSinceStart();
-        float  fnElapsed = static_cast<float>(fnEndTime - fnStartTime);
-        PPX_LOG_INFO("Created image from image file: " << path << " (" << FloatString(fnElapsed) << " seconds)");
     }
 }
 

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -371,22 +371,15 @@ void FishTornadoApp::SetupCaustics()
 void FishTornadoApp::UploadCaustics()
 {
     for (uint32_t i = 0; i < kCausticsImageCount; ++i) {
-        Timer timer;
-        PPX_ASSERT_MSG(timer.Start() == ppx::TIMER_RESULT_SUCCESS, "timer start failed");
-        double fnStartTime = timer.SecondsSinceStart();
-
         std::stringstream filename;
         filename << "fishtornado/textures/ocean/caustics/save." << std::setw(2) << std::setfill('0') << i << ".png";
         std::filesystem::path path = GetAssetPath(filename.str());
+        ScopedTimer           timer("Image creation from file '" + path.string() + "'");
 
         Bitmap bitmap;
         PPX_CHECKED_CALL(Bitmap::LoadFile(path, &bitmap));
 
         PPX_CHECKED_CALL(grfx_util::CopyBitmapToTexture(GetGraphicsQueue(), &bitmap, mCausticsTexture, 0, i, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_SHADER_RESOURCE));
-
-        double fnEndTime = timer.SecondsSinceStart();
-        float  fnElapsed = static_cast<float>(fnEndTime - fnStartTime);
-        PPX_LOG_INFO("Created image from image file: " << path << " (" << FloatString(fnElapsed) << " seconds)");
     }
 }
 

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1153,15 +1153,8 @@ int Application::Run(int argc, char** argv)
 
     // Call setup
     {
-        Timer timer;
-        PPX_ASSERT_MSG(timer.Start() == ppx::TIMER_RESULT_SUCCESS, "timer start failed");
-        double setupStartTime = timer.SecondsSinceStart();
-
+        ScopedTimer("Setup() finished");
         DispatchSetup();
-
-        double setupEndTime = timer.SecondsSinceStart();
-        float  fnElapsed    = static_cast<float>(setupEndTime - setupStartTime);
-        PPX_LOG_INFO("Setup() took " << FloatString(fnElapsed) << " seconds to complete");
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/src/ppx/graphics_util.cpp
+++ b/src/ppx/graphics_util.cpp
@@ -1180,11 +1180,9 @@ Result CreateIBLTexturesFromFile(
 
     // Load IBL environment map - this is stored as a bitmap on disk
     std::filesystem::path envFilePath = path.parent_path() / envFile;
+    ScopedTimer           timer("Texture creation from mipmap file '" + envFilePath.string() + "'");
     Mipmap                mipmap      = {};
-    {
-        ScopedTimer timer("Texture creation from mipmap file '" + envFilePath.string() + "'");
-        ppxres = Mipmap::LoadFile(envFilePath, baseWidth, baseHeight, &mipmap, levelCount);
-    }
+    ppxres                            = Mipmap::LoadFile(envFilePath, baseWidth, baseHeight, &mipmap, levelCount);
     if (Failed(ppxres)) {
         return ppxres;
     }

--- a/src/ppx/graphics_util.cpp
+++ b/src/ppx/graphics_util.cpp
@@ -802,9 +802,7 @@ Result CreateImageFromFile(
     PPX_ASSERT_NULL_ARG(pQueue);
     PPX_ASSERT_NULL_ARG(ppImage);
 
-    Timer timer;
-    PPX_ASSERT_MSG(timer.Start() == ppx::TIMER_RESULT_SUCCESS, "timer start failed");
-    double fnStartTime = timer.SecondsSinceStart();
+    ScopedTimer timer("Image creation from file '" + path.string() + "'");
 
     Result ppxres;
     if (Bitmap::IsBitmapFile(path)) {
@@ -839,15 +837,9 @@ Result CreateImageFromFile(
         ppxres = Result::ERROR_IMAGE_FILE_LOAD_FAILED;
     }
 
-    double fnEndTime = timer.SecondsSinceStart();
-    float  fnElapsed = static_cast<float>(fnEndTime - fnStartTime);
-    if (ppxres == Result::SUCCESS) {
-        PPX_LOG_INFO("Created image from image file: " << path << " (" << FloatString(fnElapsed) << " seconds)");
-    }
-    else {
+    if (ppxres != Result::SUCCESS) {
         PPX_LOG_INFO("Failed to create image from image file: " << path);
     }
-
     return ppx::SUCCESS;
 }
 
@@ -1059,9 +1051,7 @@ Result CreateTextureFromFile(
     PPX_ASSERT_NULL_ARG(pQueue);
     PPX_ASSERT_NULL_ARG(ppTexture);
 
-    Timer timer;
-    PPX_ASSERT_MSG(timer.Start() == ppx::TIMER_RESULT_SUCCESS, "timer start failed");
-    double fnStartTime = timer.SecondsSinceStart();
+    ScopedTimer timer("Texture creation from image file '" + path.string() + "'");
 
     // Load bitmap
     Bitmap bitmap;
@@ -1069,17 +1059,7 @@ Result CreateTextureFromFile(
     if (Failed(ppxres)) {
         return ppxres;
     }
-
-    ppxres = CreateTextureFromBitmap(pQueue, &bitmap, ppTexture, options);
-    if (Failed(ppxres)) {
-        return ppxres;
-    }
-
-    double fnEndTime = timer.SecondsSinceStart();
-    float  fnElapsed = static_cast<float>(fnEndTime - fnStartTime);
-    PPX_LOG_INFO("Created texture from image file: " << path << " (" << FloatString(fnElapsed) << " seconds)");
-
-    return ppx::SUCCESS;
+    return CreateTextureFromBitmap(pQueue, &bitmap, ppTexture, options);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -1189,34 +1169,28 @@ Result CreateIBLTexturesFromFile(
 
     // Create irradiance texture - does not require mip maps
     std::filesystem::path irrFilePath = path.parent_path() / irrFile;
-    Result                ppxres      = CreateTextureFromFile(pQueue, irrFilePath, ppIrradianceTexture);
+    Result                ppxres;
+    {
+        ScopedTimer timer("Texture creation from file '" + irrFilePath.string() + "'");
+        ppxres = CreateTextureFromFile(pQueue, irrFilePath, ppIrradianceTexture);
+    }
     if (Failed(ppxres)) {
         return ppxres;
     }
 
-    Timer timer;
-    PPX_ASSERT_MSG(timer.Start() == ppx::TIMER_RESULT_SUCCESS, "timer start failed");
-    double fnStartTime = timer.SecondsSinceStart();
-
     // Load IBL environment map - this is stored as a bitmap on disk
     std::filesystem::path envFilePath = path.parent_path() / envFile;
     Mipmap                mipmap      = {};
-    ppxres                            = Mipmap::LoadFile(envFilePath, baseWidth, baseHeight, &mipmap, levelCount);
+    {
+        ScopedTimer timer("Texture creation from mipmap file '" + envFilePath.string() + "'");
+        ppxres = Mipmap::LoadFile(envFilePath, baseWidth, baseHeight, &mipmap, levelCount);
+    }
     if (Failed(ppxres)) {
         return ppxres;
     }
 
     // Create environment texture
-    ppxres = CreateTextureFromMipmap(pQueue, &mipmap, ppEnvironmentTexture);
-    if (Failed(ppxres)) {
-        return ppxres;
-    }
-
-    double fnEndTime = timer.SecondsSinceStart();
-    float  fnElapsed = static_cast<float>(fnEndTime - fnStartTime);
-    PPX_LOG_INFO("Created texture from mipmap file: " << envFilePath << " (" << FloatString(fnElapsed) << " seconds)");
-
-    return ppx::SUCCESS;
+    return CreateTextureFromMipmap(pQueue, &mipmap, ppEnvironmentTexture);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -1230,6 +1204,7 @@ Result CreateCubeMapFromFile(
 {
     PPX_ASSERT_NULL_ARG(pQueue);
     PPX_ASSERT_NULL_ARG(ppImage);
+    ScopedTimer timer("Cubemap creation from file '" + path.string() + "'");
 
     // Load bitmap
     Bitmap bitmap;

--- a/src/ppx/timer.cpp
+++ b/src/ppx/timer.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ppx/timer.h"
+#include "ppx/config.h"
 
 #include <cassert>
 #include <cmath>
@@ -468,6 +469,19 @@ double Timer::NanosSinceStart() const
     }
     double nanos = TimestampToMicros(diff);
     return nanos;
+}
+
+ScopedTimer::ScopedTimer(const std::string& message)
+    : mMessage(message)
+{
+    PPX_ASSERT_MSG(mTimer.Start() == TIMER_RESULT_SUCCESS, "Timer start failed.");
+}
+
+ScopedTimer::~ScopedTimer()
+{
+    PPX_ASSERT_MSG(mTimer.Stop() == TIMER_RESULT_SUCCESS, "Timer stop failed.");
+    const float elapsed = static_cast<float>(mTimer.SecondsSinceStart());
+    PPX_LOG_INFO(mMessage + ": " + FloatString(elapsed) << " seconds.");
 }
 
 } // namespace ppx


### PR DESCRIPTION
A lot of timer patterns we have is start, do something, and stop in the same function to measure some process.

The Scopedtimer wraps this logic in a class using RAII. An alternative implementation could be to not print, but use a float& which is set to the elapsed time in the destructor. This would allow more control over the format, and print additional info not available on timer initialization.
But for now, this is a simple pattern we can start with.