### PR TITLE
Minor improvements for knob framework

### DIFF
--- a/include/ppx/knob.h
+++ b/include/ppx/knob.h
@@ -61,12 +61,14 @@ public:
     // Returns true if there has been an update to the knob value
     bool DigestUpdate();
 
+    virtual void ResetToDefault() = 0;
+
 protected:
     void RaiseUpdatedFlag() { mUpdatedFlag = true; }
 
 private:
-    virtual void Draw()           = 0;
-    virtual void ResetToDefault() = 0;
+    // Only called from KnobManager
+    virtual void Draw() = 0;
 
     // Updates knob value from commandline flag
     virtual void UpdateFromFlags(const CliOptions& opts) = 0;
@@ -126,7 +128,7 @@ public:
     {
         PPX_ASSERT_MSG(minValue < maxValue, "invalid range to initialize slider");
         PPX_ASSERT_MSG(minValue <= defaultValue && defaultValue <= maxValue, "defaultValue is out of range");
-        SetFlagParameters(" <" + std::to_string(mMinValue) + "~" + std::to_string(mMaxValue) + ">");
+        SetFlagParameters("<" + std::to_string(mMinValue) + "~" + std::to_string(mMaxValue) + ">");
         RaiseUpdatedFlag();
     }
 
@@ -215,7 +217,7 @@ public:
         if (!choiceStr.empty()) {
             choiceStr.pop_back();
         }
-        choiceStr = " <" + choiceStr + ">";
+        choiceStr = "<" + choiceStr + ">";
         SetFlagParameters(choiceStr);
         RaiseUpdatedFlag();
     }

--- a/include/ppx/knob.h
+++ b/include/ppx/knob.h
@@ -51,7 +51,7 @@ public:
     virtual ~Knob() = default;
 
     // Customize flag usage message
-    void SetFlagDesc(const std::string& flagDesc) { mFlagDesc = flagDesc; }
+    void SetFlagDescription(const std::string& flagDescription) { mFlagDescription = flagDescription; }
     void SetFlagParameters(const std::string& flagParameters) { mFlagParameters = flagParameters; }
 
     // Customize how knob is drawn in the UI
@@ -77,7 +77,7 @@ protected:
 
 private:
     std::string mFlagParameters;
-    std::string mFlagDesc;
+    std::string mFlagDescription;
     size_t      mIndent; // Indent for when knob is drawn in the UI
     bool        mUpdatedFlag;
 

--- a/src/ppx/knob.cpp
+++ b/src/ppx/knob.cpp
@@ -113,8 +113,8 @@ std::string KnobManager::GetUsageMsg()
     // --flag_name <params> : description
     for (const auto& knobPtr : mKnobs) {
         usageMsg += "--" + knobPtr->mFlagName + knobPtr->mFlagParameters;
-        if (knobPtr->mFlagDesc != "") {
-            usageMsg += " : " + knobPtr->mFlagDesc;
+        if (knobPtr->mFlagDescription != "") {
+            usageMsg += " : " + knobPtr->mFlagDescription;
         }
         usageMsg += "\n";
     }

--- a/src/ppx/knob.cpp
+++ b/src/ppx/knob.cpp
@@ -38,13 +38,13 @@ bool Knob::DigestUpdate()
 KnobCheckbox::KnobCheckbox(const std::string& flagName, bool defaultValue)
     : Knob(flagName), mDefaultValue(defaultValue), mValue(defaultValue)
 {
-    SetHelpParams(" <true|false>");
+    SetFlagParameters(" <true|false>");
     RaiseUpdatedFlag();
 }
 
 void KnobCheckbox::Draw()
 {
-    if (!ImGui::Checkbox(GetDisplayName().c_str(), &mValue)) {
+    if (!ImGui::Checkbox(mDisplayName.c_str(), &mValue)) {
         return;
     }
     RaiseUpdatedFlag();
@@ -52,7 +52,7 @@ void KnobCheckbox::Draw()
 
 void KnobCheckbox::UpdateFromFlags(const CliOptions& opts)
 {
-    SetDefaultAndValue(opts.GetExtraOptionValueOrDefault(GetFlagName(), mValue));
+    SetDefaultAndValue(opts.GetExtraOptionValueOrDefault(mFlagName, mValue));
 }
 
 void KnobCheckbox::SetValue(bool newValue)
@@ -88,11 +88,11 @@ void KnobManager::DrawAllKnobs(bool inExistingWindow)
     }
 
     for (const auto& knobPtr : mKnobs) {
-        for (size_t i = 0; i < knobPtr->GetIndent(); i++) {
+        for (size_t i = 0; i < knobPtr->mIndent; i++) {
             ImGui::Indent();
         }
         knobPtr->Draw();
-        for (size_t i = 0; i < knobPtr->GetIndent(); i++) {
+        for (size_t i = 0; i < knobPtr->mIndent; i++) {
             ImGui::Unindent();
         }
     }
@@ -112,9 +112,9 @@ std::string KnobManager::GetUsageMsg()
     // Tends to have longer params, do not attempt to align description
     // --flag_name <params> : description
     for (const auto& knobPtr : mKnobs) {
-        usageMsg += "--" + knobPtr->GetFlagName() + knobPtr->GetHelpParams();
-        if (knobPtr->GetFlagHelp() != "") {
-            usageMsg += " : " + knobPtr->GetFlagHelp();
+        usageMsg += "--" + knobPtr->mFlagName + knobPtr->mFlagParameters;
+        if (knobPtr->mFlagDesc != "") {
+            usageMsg += " : " + knobPtr->mFlagDesc;
         }
         usageMsg += "\n";
     }

--- a/src/ppx/knob.cpp
+++ b/src/ppx/knob.cpp
@@ -38,7 +38,7 @@ bool Knob::DigestUpdate()
 KnobCheckbox::KnobCheckbox(const std::string& flagName, bool defaultValue)
     : Knob(flagName), mDefaultValue(defaultValue), mValue(defaultValue)
 {
-    SetFlagParameters(" <true|false>");
+    SetFlagParameters("<true|false>");
     RaiseUpdatedFlag();
 }
 
@@ -112,7 +112,10 @@ std::string KnobManager::GetUsageMsg()
     // Tends to have longer params, do not attempt to align description
     // --flag_name <params> : description
     for (const auto& knobPtr : mKnobs) {
-        usageMsg += "--" + knobPtr->mFlagName + knobPtr->mFlagParameters;
+        usageMsg += "--" + knobPtr->mFlagName;
+        if (knobPtr->mFlagParameters != "") {
+            usageMsg += " " + knobPtr->mFlagParameters;
+        }
         if (knobPtr->mFlagDescription != "") {
             usageMsg += " : " + knobPtr->mFlagDescription;
         }

--- a/src/ppx/knob.cpp
+++ b/src/ppx/knob.cpp
@@ -32,6 +32,45 @@ bool Knob::DigestUpdate()
 }
 
 // -------------------------------------------------------------------------------------------------
+// KnobCheckbox
+// -------------------------------------------------------------------------------------------------
+
+KnobCheckbox::KnobCheckbox(const std::string& flagName, bool defaultValue)
+    : Knob(flagName), mDefaultValue(defaultValue), mValue(defaultValue)
+{
+    SetHelpParams(" <true|false>");
+    RaiseUpdatedFlag();
+}
+
+void KnobCheckbox::Draw()
+{
+    if (!ImGui::Checkbox(GetDisplayName().c_str(), &mValue)) {
+        return;
+    }
+    RaiseUpdatedFlag();
+}
+
+void KnobCheckbox::UpdateFromFlags(const CliOptions& opts)
+{
+    SetDefaultAndValue(opts.GetExtraOptionValueOrDefault(GetFlagName(), mValue));
+}
+
+void KnobCheckbox::SetValue(bool newValue)
+{
+    if (newValue == mValue) {
+        return;
+    }
+    mValue = newValue;
+    RaiseUpdatedFlag();
+}
+
+void KnobCheckbox::SetDefaultAndValue(bool newValue)
+{
+    mDefaultValue = newValue;
+    ResetToDefault();
+}
+
+// -------------------------------------------------------------------------------------------------
 // KnobManager
 // -------------------------------------------------------------------------------------------------
 
@@ -69,9 +108,15 @@ void KnobManager::DrawAllKnobs(bool inExistingWindow)
 
 std::string KnobManager::GetUsageMsg()
 {
-    std::string usageMsg = "\nApplication-specific flags\n";
+    std::string usageMsg = "\nApplication-Specific Flags:\n";
+    // Tends to have longer params, do not attempt to align description
+    // --flag_name <params> : description
     for (const auto& knobPtr : mKnobs) {
-        usageMsg += knobPtr->GetFlagHelpText();
+        usageMsg += "--" + knobPtr->GetFlagName() + knobPtr->GetHelpParams();
+        if (knobPtr->GetFlagHelp() != "") {
+            usageMsg += " : " + knobPtr->GetFlagHelp();
+        }
+        usageMsg += "\n";
     }
     return usageMsg;
 }

--- a/src/test/knob_test.cpp
+++ b/src/test/knob_test.cpp
@@ -355,14 +355,14 @@ TEST_F(KnobManagerTestFixture, KnobManager_GetCustomizedUsageMsg)
 {
     std::shared_ptr<KnobCheckbox> k1(km.CreateKnob<KnobCheckbox>("flag_name1", true));
     k1->SetFlagParameters(" <bool>");
-    k1->SetFlagDesc("description1");
+    k1->SetFlagDescription("description1");
     std::shared_ptr<KnobCheckbox>    k2(km.CreateKnob<KnobCheckbox>("flag_name2", true));
     std::shared_ptr<KnobSlider<int>> k3(km.CreateKnob<KnobSlider<int>>("flag_name3", 5, 0, 10));
     k3->SetFlagParameters(" <N>");
-    k3->SetFlagDesc("description3");
+    k3->SetFlagDescription("description3");
     std::vector<std::string>                   choices4 = {"c1", "c2", "c3 and more"};
     std::shared_ptr<KnobDropdown<std::string>> k4(km.CreateKnob<KnobDropdown<std::string>>("flag_name4", 1, choices4.cbegin(), choices4.cend()));
-    k4->SetFlagDesc("description4");
+    k4->SetFlagDescription("description4");
 
     std::string usageMsg = R"(
 Application-Specific Flags:

--- a/src/test/knob_test.cpp
+++ b/src/test/knob_test.cpp
@@ -354,11 +354,11 @@ Application-Specific Flags:
 TEST_F(KnobManagerTestFixture, KnobManager_GetCustomizedUsageMsg)
 {
     std::shared_ptr<KnobCheckbox> k1(km.CreateKnob<KnobCheckbox>("flag_name1", true));
-    k1->SetFlagParameters(" <bool>");
+    k1->SetFlagParameters("<bool>");
     k1->SetFlagDescription("description1");
     std::shared_ptr<KnobCheckbox>    k2(km.CreateKnob<KnobCheckbox>("flag_name2", true));
     std::shared_ptr<KnobSlider<int>> k3(km.CreateKnob<KnobSlider<int>>("flag_name3", 5, 0, 10));
-    k3->SetFlagParameters(" <N>");
+    k3->SetFlagParameters("<N>");
     k3->SetFlagDescription("description3");
     std::vector<std::string>                   choices4 = {"c1", "c2", "c3 and more"};
     std::shared_ptr<KnobDropdown<std::string>> k4(km.CreateKnob<KnobDropdown<std::string>>("flag_name4", 1, choices4.cbegin(), choices4.cend()));

--- a/src/test/knob_test.cpp
+++ b/src/test/knob_test.cpp
@@ -52,18 +52,9 @@ namespace ppx {
 // KnobCheckbox
 // -------------------------------------------------------------------------------------------------
 
-TEST_F(KnobTestFixture, KnobCheckbox_CreateAndSetBasicMembers)
+TEST_F(KnobTestFixture, KnobCheckbox_Create)
 {
     KnobCheckbox boolKnob = KnobCheckbox("flag_name1", true);
-
-    boolKnob.SetDisplayName("Knob Name 1");
-    boolKnob.SetFlagDesc("description1");
-    boolKnob.SetIndent(3);
-
-    EXPECT_EQ(boolKnob.GetDisplayName(), "Knob Name 1");
-    EXPECT_EQ(boolKnob.GetFlagName(), "flag_name1");
-    EXPECT_EQ(boolKnob.GetFlagHelp(), "description1");
-    EXPECT_EQ(boolKnob.GetIndent(), 3);
     EXPECT_TRUE(boolKnob.GetValue());
 }
 
@@ -104,15 +95,6 @@ TEST_F(KnobTestFixture, KnobCheckbox_ResetToDefault)
 TEST_F(KnobTestFixture, KnobSlider_CreateAndSetBasicMembers)
 {
     KnobSlider<int> intKnob = KnobSlider<int>("flag_name1", 5, 0, 10);
-
-    intKnob.SetDisplayName("Knob Name 1");
-    intKnob.SetFlagDesc("description1");
-    intKnob.SetIndent(3);
-
-    EXPECT_EQ(intKnob.GetDisplayName(), "Knob Name 1");
-    EXPECT_EQ(intKnob.GetFlagName(), "flag_name1");
-    EXPECT_EQ(intKnob.GetFlagHelp(), "description1");
-    EXPECT_EQ(intKnob.GetIndent(), 3);
     EXPECT_EQ(intKnob.GetValue(), 5);
 }
 
@@ -197,15 +179,6 @@ TEST_F(KnobTestFixture, KnobDropdown_CreateAndSetBasicMembers)
 {
     std::vector<std::string>  choices = {"c1", "c2"};
     KnobDropdown<std::string> strKnob = KnobDropdown<std::string>("flag_name1", 1, choices.cbegin(), choices.cend());
-
-    strKnob.SetDisplayName("Knob Name 1");
-    strKnob.SetFlagDesc("description1");
-    strKnob.SetIndent(3);
-
-    EXPECT_EQ(strKnob.GetDisplayName(), "Knob Name 1");
-    EXPECT_EQ(strKnob.GetFlagName(), "flag_name1");
-    EXPECT_EQ(strKnob.GetFlagHelp(), "description1");
-    EXPECT_EQ(strKnob.GetIndent(), 3);
     EXPECT_EQ(strKnob.GetIndex(), 1);
     EXPECT_EQ(strKnob.GetValue(), "c2");
 }
@@ -360,13 +333,13 @@ TEST_F(KnobManagerTestFixture, KnobManager_CreateUniqueName)
 }
 #endif
 
-TEST_F(KnobManagerTestFixture, KnobManager_GetUsageMsg)
+TEST_F(KnobManagerTestFixture, KnobManager_GetBasicUsageMsg)
 {
-    std::shared_ptr<KnobCheckbox>              boolKnobPtr1(km.CreateKnob<KnobCheckbox>("flag_name1", true));
-    std::shared_ptr<KnobCheckbox>              boolKnobPtr2(km.CreateKnob<KnobCheckbox>("flag_name2", true));
-    std::shared_ptr<KnobSlider<int>>           intKnobPtr1(km.CreateKnob<KnobSlider<int>>("flag_name3", 5, 0, 10));
-    std::vector<std::string>                   choices1 = {"c1", "c2", "c3 and more"};
-    std::shared_ptr<KnobDropdown<std::string>> strKnobPtr1(km.CreateKnob<KnobDropdown<std::string>>("flag_name4", 1, choices1.cbegin(), choices1.cend()));
+    std::shared_ptr<KnobCheckbox>              k1(km.CreateKnob<KnobCheckbox>("flag_name1", true));
+    std::shared_ptr<KnobCheckbox>              k2(km.CreateKnob<KnobCheckbox>("flag_name2", true));
+    std::shared_ptr<KnobSlider<int>>           k3(km.CreateKnob<KnobSlider<int>>("flag_name3", 5, 0, 10));
+    std::vector<std::string>                   choices4 = {"c1", "c2", "c3 and more"};
+    std::shared_ptr<KnobDropdown<std::string>> k4(km.CreateKnob<KnobDropdown<std::string>>("flag_name4", 1, choices4.cbegin(), choices4.cend()));
 
     std::string usageMsg = R"(
 Application-Specific Flags:
@@ -374,6 +347,29 @@ Application-Specific Flags:
 --flag_name2 <true|false>
 --flag_name3 <0~10>
 --flag_name4 <c1|c2|"c3 and more">
+)";
+    EXPECT_EQ(km.GetUsageMsg(), usageMsg);
+}
+
+TEST_F(KnobManagerTestFixture, KnobManager_GetCustomizedUsageMsg)
+{
+    std::shared_ptr<KnobCheckbox> k1(km.CreateKnob<KnobCheckbox>("flag_name1", true));
+    k1->SetFlagParameters(" <bool>");
+    k1->SetFlagDesc("description1");
+    std::shared_ptr<KnobCheckbox>    k2(km.CreateKnob<KnobCheckbox>("flag_name2", true));
+    std::shared_ptr<KnobSlider<int>> k3(km.CreateKnob<KnobSlider<int>>("flag_name3", 5, 0, 10));
+    k3->SetFlagParameters(" <N>");
+    k3->SetFlagDesc("description3");
+    std::vector<std::string>                   choices4 = {"c1", "c2", "c3 and more"};
+    std::shared_ptr<KnobDropdown<std::string>> k4(km.CreateKnob<KnobDropdown<std::string>>("flag_name4", 1, choices4.cbegin(), choices4.cend()));
+    k4->SetFlagDesc("description4");
+
+    std::string usageMsg = R"(
+Application-Specific Flags:
+--flag_name1 <bool> : description1
+--flag_name2 <true|false>
+--flag_name3 <N> : description3
+--flag_name4 <c1|c2|"c3 and more"> : description4
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);
 }

--- a/src/test/knob_test.cpp
+++ b/src/test/knob_test.cpp
@@ -55,7 +55,6 @@ namespace ppx {
 TEST_F(KnobTestFixture, KnobCheckbox_CreateAndSetBasicMembers)
 {
     KnobCheckbox boolKnob = KnobCheckbox("flag_name1", true);
-    EXPECT_EQ(boolKnob.GetFlagHelpText(), "--flag_name1 <true|false>\n");
 
     boolKnob.SetDisplayName("Knob Name 1");
     boolKnob.SetFlagDesc("description1");
@@ -66,7 +65,6 @@ TEST_F(KnobTestFixture, KnobCheckbox_CreateAndSetBasicMembers)
     EXPECT_EQ(boolKnob.GetFlagHelp(), "description1");
     EXPECT_EQ(boolKnob.GetIndent(), 3);
     EXPECT_TRUE(boolKnob.GetValue());
-    EXPECT_EQ(boolKnob.GetFlagHelpText(), "--flag_name1 <true|false> : description1\n");
 }
 
 TEST_F(KnobTestFixture, KnobCheckbox_CanSetBoolValue)
@@ -106,7 +104,6 @@ TEST_F(KnobTestFixture, KnobCheckbox_ResetToDefault)
 TEST_F(KnobTestFixture, KnobSlider_CreateAndSetBasicMembers)
 {
     KnobSlider<int> intKnob = KnobSlider<int>("flag_name1", 5, 0, 10);
-    EXPECT_EQ(intKnob.GetFlagHelpText(), "--flag_name1 <0~10>\n");
 
     intKnob.SetDisplayName("Knob Name 1");
     intKnob.SetFlagDesc("description1");
@@ -117,7 +114,6 @@ TEST_F(KnobTestFixture, KnobSlider_CreateAndSetBasicMembers)
     EXPECT_EQ(intKnob.GetFlagHelp(), "description1");
     EXPECT_EQ(intKnob.GetIndent(), 3);
     EXPECT_EQ(intKnob.GetValue(), 5);
-    EXPECT_EQ(intKnob.GetFlagHelpText(), "--flag_name1 <0~10> : description1\n");
 }
 
 #if defined(PERFORM_DEATH_TESTS)
@@ -201,7 +197,6 @@ TEST_F(KnobTestFixture, KnobDropdown_CreateAndSetBasicMembers)
 {
     std::vector<std::string>  choices = {"c1", "c2"};
     KnobDropdown<std::string> strKnob = KnobDropdown<std::string>("flag_name1", 1, choices.cbegin(), choices.cend());
-    EXPECT_EQ(strKnob.GetFlagHelpText(), "--flag_name1 <\"c1\"|\"c2\">\n");
 
     strKnob.SetDisplayName("Knob Name 1");
     strKnob.SetFlagDesc("description1");
@@ -213,7 +208,6 @@ TEST_F(KnobTestFixture, KnobDropdown_CreateAndSetBasicMembers)
     EXPECT_EQ(strKnob.GetIndent(), 3);
     EXPECT_EQ(strKnob.GetIndex(), 1);
     EXPECT_EQ(strKnob.GetValue(), "c2");
-    EXPECT_EQ(strKnob.GetFlagHelpText(), "--flag_name1 <\"c1\"|\"c2\"> : description1\n");
 }
 
 TEST_F(KnobTestFixture, KnobDropdown_CreateVaried)
@@ -371,15 +365,15 @@ TEST_F(KnobManagerTestFixture, KnobManager_GetUsageMsg)
     std::shared_ptr<KnobCheckbox>              boolKnobPtr1(km.CreateKnob<KnobCheckbox>("flag_name1", true));
     std::shared_ptr<KnobCheckbox>              boolKnobPtr2(km.CreateKnob<KnobCheckbox>("flag_name2", true));
     std::shared_ptr<KnobSlider<int>>           intKnobPtr1(km.CreateKnob<KnobSlider<int>>("flag_name3", 5, 0, 10));
-    std::vector<std::string>                   choices1 = {"c1", "c2", "c3"};
+    std::vector<std::string>                   choices1 = {"c1", "c2", "c3 and more"};
     std::shared_ptr<KnobDropdown<std::string>> strKnobPtr1(km.CreateKnob<KnobDropdown<std::string>>("flag_name4", 1, choices1.cbegin(), choices1.cend()));
 
     std::string usageMsg = R"(
-Application-specific flags
+Application-Specific Flags:
 --flag_name1 <true|false>
 --flag_name2 <true|false>
 --flag_name3 <0~10>
---flag_name4 <"c1"|"c2"|"c3">
+--flag_name4 <c1|c2|"c3 and more">
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);
 }


### PR DESCRIPTION
* Replace `GetFlagHelpText()` with storing help parameters separately and assembling in `KnobManager::GetUsageMsg()`
* Move `KnobCheckbox` member functions to `knob.cpp`
* When listing `KnobDropdown` choices in usage message, only add quotation marks if there are spaces
* Made KnobManager a friend class of Knob and removed some of the getters/setters, preferring to have protected/private members where possible
* Renamed `SetFlagDesc` -> `SetFlagDescription`