### PR TITLE
Cleanup Metrics - Pull Report internal to Manager and use unique_ptrs

### DIFF
--- a/include/ppx/metrics.h
+++ b/include/ppx/metrics.h
@@ -176,6 +176,9 @@ class Run final
     friend class Manager;
 
 public:
+    // TODO(slumpwuffle): The lifetime of the pointer returned by this function is not well-defined
+    // to the caller, and its expiration cannot be known directly. Instead, we may want to use either
+    // strong/weak pointers or functional access to help prevent unexpected use-after-free situations.
     template <typename T>
     T* AddMetric(MetricMetadata metadata)
     {

--- a/include/ppx/metrics.h
+++ b/include/ppx/metrics.h
@@ -124,7 +124,7 @@ private:
 
 private:
     MetricGauge(const MetricMetadata& metadata)
-        : mMetadata(metadata), mAccumulatedValue(0) {}
+        : mMetadata(metadata) {}
     METRICS_NO_COPY(MetricGauge)
 
     void UpdateBasicStatistics(double seconds, double value);

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -686,24 +686,8 @@ void Application::SaveMetricsReportToDisk()
         return;
     }
 
-    // Build a unique name for the report
-    std::stringstream                                        reportFilename;
-    const std::chrono::time_point<std::chrono::system_clock> now          = std::chrono::system_clock::now();
-    const time_t                                             current_time = std::chrono::system_clock::to_time_t(now);
-    reportFilename << "report_" << current_time << metrics::Report::kFileExtension;
-
-    // Check whether the file already exists
-    if (std::filesystem::exists(reportFilename.str())) {
-        PPX_LOG_ERROR("Metrics report file cannot be written to disk as file [" << reportFilename.str() << "] already exists");
-        return;
-    }
-
-    // Export the report from the metrics manager
-    const metrics::Report report = mMetrics.manager.Export(reportFilename.str().c_str());
-    // Serialize the report to disk
-    report.WriteToFile(reportFilename.str().c_str());
-    // Report the filename for convenience
-    PPX_LOG_INFO("Metrics report written to file [" << reportFilename.str() << "]");
+    // Export the report from the metrics manager to the disk.
+    mMetrics.manager.ExportToDisk("report");
 }
 
 void Application::DispatchShutdown()

--- a/src/ppx/metrics.cpp
+++ b/src/ppx/metrics.cpp
@@ -23,30 +23,18 @@ namespace metrics {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static nlohmann::json ExportMetadata(const MetricMetadata& metadata)
+nlohmann::json MetricMetadata::Export() const
 {
     nlohmann::json object;
-    object["name"]                 = metadata.name;
-    object["unit"]                 = metadata.unit;
-    object["interpretation"]       = metadata.interpretation;
-    object["expected_lower_bound"] = metadata.expectedRange.lowerBound;
-    object["expected_upper_bound"] = metadata.expectedRange.upperBound;
+    object["name"]                 = name;
+    object["unit"]                 = unit;
+    object["interpretation"]       = interpretation;
+    object["expected_lower_bound"] = expectedRange.lowerBound;
+    object["expected_upper_bound"] = expectedRange.upperBound;
     return object;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
-MetricGauge::MetricGauge(const MetricMetadata& metadata)
-    : mMetadata(metadata), mAccumulatedValue(0)
-{
-    memset(&mBasicStatistics, 0, sizeof(mBasicStatistics));
-    mBasicStatistics.min = std::numeric_limits<double>::max();
-    mBasicStatistics.max = std::numeric_limits<double>::min();
-}
-
-MetricGauge::~MetricGauge()
-{
-}
 
 void MetricGauge::RecordEntry(double seconds, double value)
 {
@@ -146,31 +134,26 @@ void MetricGauge::UpdateBasicStatistics(double seconds, double value)
 nlohmann::json MetricGauge::Export() const
 {
     nlohmann::json metricObject;
+    nlohmann::json statisticsObject;
 
-    {
-        metricObject["metadata"] = ExportMetadata(mMetadata);
-    }
+    metricObject["metadata"] = mMetadata.Export();
 
-    {
-        nlohmann::json statisticsObject;
+    const GaugeBasicStatistics basicStatistics = GetBasicStatistics();
+    statisticsObject["min"]                    = basicStatistics.min;
+    statisticsObject["max"]                    = basicStatistics.max;
+    statisticsObject["average"]                = basicStatistics.average;
+    statisticsObject["time_ratio"]             = basicStatistics.timeRatio;
 
-        const GaugeBasicStatistics basicStatistics = GetBasicStatistics();
-        statisticsObject["min"]                    = basicStatistics.min;
-        statisticsObject["max"]                    = basicStatistics.max;
-        statisticsObject["average"]                = basicStatistics.average;
-        statisticsObject["time_ratio"]             = basicStatistics.timeRatio;
+    const GaugeComplexStatistics complexStatistics = ComputeComplexStatistics();
+    statisticsObject["median"]                     = complexStatistics.median;
+    statisticsObject["standard_deviation"]         = complexStatistics.standardDeviation;
+    statisticsObject["percentile_90"]              = complexStatistics.percentile90;
+    statisticsObject["percentile_95"]              = complexStatistics.percentile95;
+    statisticsObject["percentile_99"]              = complexStatistics.percentile99;
 
-        const GaugeComplexStatistics complexStatistics = ComputeComplexStatistics();
-        statisticsObject["median"]                     = complexStatistics.median;
-        statisticsObject["standard_deviation"]         = complexStatistics.standardDeviation;
-        statisticsObject["percentile_90"]              = complexStatistics.percentile90;
-        statisticsObject["percentile_95"]              = complexStatistics.percentile95;
-        statisticsObject["percentile_99"]              = complexStatistics.percentile99;
+    metricObject["statistics"] = statisticsObject;
 
-        metricObject["statistics"] = statisticsObject;
-    }
-
-    for (const TimeSeriesEntry& entry : mTimeSeries) {
+    for (const auto& entry : mTimeSeries) {
         metricObject["time_series"] += nlohmann::json::array({entry.seconds, entry.value});
     }
 
@@ -178,15 +161,6 @@ nlohmann::json MetricGauge::Export() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
-MetricCounter::MetricCounter(const MetricMetadata& metadata)
-    : mMetadata(metadata), mCounter(0U)
-{
-}
-
-MetricCounter::~MetricCounter()
-{
-}
 
 void MetricCounter::Increment(uint64_t add)
 {
@@ -201,58 +175,36 @@ uint64_t MetricCounter::Get() const
 nlohmann::json MetricCounter::Export() const
 {
     nlohmann::json metricObject;
-    metricObject["metadata"] = ExportMetadata(mMetadata);
+    metricObject["metadata"] = mMetadata.Export();
     metricObject["value"]    = mCounter;
     return metricObject;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Run::Run(const char* pName)
-    : mName(pName)
+void Run::AddMetric(std::unique_ptr<MetricGauge>&& metric)
 {
-    PPX_ASSERT_MSG(pName != nullptr, "A run name cannot be null");
+    mGauges.emplace(metric->GetName(), std::move(metric));
 }
 
-Run::~Run()
+void Run::AddMetric(std::unique_ptr<MetricCounter>&& metric)
 {
-    for (auto [name, pMetric] : mGauges) {
-        delete pMetric;
-    }
-    mGauges.clear();
-    for (auto [name, pMetric] : mCounters) {
-        delete pMetric;
-    }
-    mCounters.clear();
+    mCounters.emplace(metric->GetName(), std::move(metric));
 }
 
-void Run::AddMetric(MetricGauge* pMetric)
+bool Run::HasMetric(const std::string& name) const
 {
-    PPX_ASSERT_NULL_ARG(pMetric);
-    const auto ret = mGauges.insert({pMetric->GetName(), pMetric});
-    PPX_ASSERT_MSG(ret.second, "An insertion shall always take place when adding a metric");
-}
-
-void Run::AddMetric(MetricCounter* pMetric)
-{
-    PPX_ASSERT_NULL_ARG(pMetric);
-    const auto ret = mCounters.insert({pMetric->GetName(), pMetric});
-    PPX_ASSERT_MSG(ret.second, "An insertion shall always take place when adding a metric");
-}
-
-bool Run::HasMetric(const char* pName) const
-{
-    return mGauges.find(pName) != mGauges.end() || mCounters.find(pName) != mCounters.end();
+    return mGauges.find(name) != mGauges.end() || mCounters.find(name) != mCounters.end();
 }
 
 nlohmann::json Run::Export() const
 {
     nlohmann::json object;
     object["name"] = mName;
-    for (auto [name, pMetric] : mGauges) {
+    for (const auto& [name, pMetric] : mGauges) {
         object["gauges"] += pMetric->Export();
     }
-    for (auto [name, pMetric] : mCounters) {
+    for (const auto& [name, pMetric] : mCounters) {
         object["counters"] += pMetric->Export();
     }
     return object;
@@ -260,30 +212,14 @@ nlohmann::json Run::Export() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Manager::Manager()
+Run* Manager::AddRun(const std::string& name)
 {
-}
+    PPX_ASSERT_MSG(!name.empty(), "A run name must not be empty");
+    PPX_ASSERT_MSG(mRuns.find(name) == mRuns.end(), "Runs must have unique names (duplicate name detected)");
 
-Manager::~Manager()
-{
-    for (auto [name, pRun] : mRuns) {
-        delete pRun;
-    }
-    mRuns.clear();
-}
-
-Run* Manager::AddRun(const char* pName)
-{
-    PPX_ASSERT_MSG(pName != nullptr, "A run name must not be null");
-    PPX_ASSERT_MSG(mRuns.find(pName) == mRuns.end(), "Runs must have unique names (duplicate name detected)");
-
-    Run* pRun = new Run(pName);
-    if (pRun == nullptr) {
-        return nullptr;
-    }
-
-    const auto ret = mRuns.insert({pName, pRun});
-    PPX_ASSERT_MSG(ret.second, "An insertion shall always take place when adding a run");
+    auto* pRun = new Run(name);
+    auto  run  = std::unique_ptr<Run>(pRun);
+    mRuns.emplace(name, std::move(run));
     return pRun;
 }
 
@@ -292,7 +228,7 @@ void Manager::ExportToDisk(const std::string& baseReportName) const
     PPX_ASSERT_MSG(!baseReportName.empty(), "Base report name must not be empty!");
 
     nlohmann::json content;
-    for (auto [name, pRun] : mRuns) {
+    for (const auto& [name, pRun] : mRuns) {
         content["runs"] += pRun->Export();
     }
 

--- a/src/ppx/metrics.cpp
+++ b/src/ppx/metrics.cpp
@@ -212,6 +212,9 @@ nlohmann::json Run::Export() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// TODO(slumpwuffle): The lifetime of the pointer returned by this function is not well-defined
+// to the caller, and its expiration cannot be known directly. Instead, we may want to use either
+// strong/weak pointers or functional access to help prevent unexpected use-after-free situations.
 Run* Manager::AddRun(const std::string& name)
 {
     PPX_ASSERT_MSG(!name.empty(), "A run name must not be empty");

--- a/src/ppx/metrics.cpp
+++ b/src/ppx/metrics.cpp
@@ -264,6 +264,10 @@ void Manager::Report::WriteToDisk(bool overwriteExisting) const
 
     std::filesystem::create_directories(mFilePath.parent_path());
     std::ofstream outputFile(mFilePath.c_str(), std::ofstream::out);
+    if (!outputFile.is_open()) {
+        PPX_LOG_ERROR("Failed to open metrics file at path [" << mFilePath << "] for writing!");
+        return;
+    }
     outputFile << mContent.dump(4) << std::endl;
     outputFile.close();
 


### PR DESCRIPTION
This set of changes includes two key pieces:
1. The report object is now internal to the manager, as the lifetime of strings used by the json object cannot be guaranteed outside of the scope of the manager regardless. This cleans up the application-side piece of the report writing.
2. Unique_ptrs are now used for the metrics. This helps clean up several pieces of the metrics code, especially around destructors and constructors.