### PR TITLE
Add a new `--assets-path` flag to applications.

### DIFF
--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -30,24 +30,24 @@ namespace ppx {
 struct StandardOptions
 {
     // Flags
+    bool deterministic         = false;
+    bool headless              = false;
     bool help                  = false;
     bool list_gpus             = false;
     bool use_software_renderer = false;
-    bool headless              = false;
-    bool deterministic         = false;
 
     // Options
     int                 gpu_index          = -1;
-    std::pair<int, int> resolution         = {-1, -1};
     int                 frame_count        = 0;
     int                 run_time_ms        = 0;
+    std::pair<int, int> resolution         = {-1, -1};
+    int                 screenshot_frame_number                  = -1;
+    std::string         screenshot_path                          = "";
     uint32_t            stats_frame_window = 300;
 #if defined(PPX_BUILD_XR)
     std::pair<int, int> xrUIResolution = {-1, -1};
 #endif
 
-    int         screenshot_frame_number                  = -1;
-    std::string screenshot_path                          = "";
     bool        operator==(const StandardOptions&) const = default;
 };
 

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -177,6 +177,7 @@ private:
     std::string mUsageMsg = R"(
 --help                        Prints this help message and exits.
 
+--assets-path                 Add a path in front of the assets search path list.
 --deterministic               Disable non-deterministic behaviors, like clocks.
 --frame-count <N>             Shutdown the application after successfully rendering N frames.
 --run-time-ms <N>             Shutdown the application after N milliseconds.
@@ -197,6 +198,7 @@ private:
     std::string mUsageMsg = R"(
 --help                        Prints this help message and exits.
 
+--assets-path                 Add a path in front of the assets search path list.
 --deterministic               Disable non-deterministic behaviors, like clocks.
 --frame-count <N>             Shutdown the application after successfully rendering N frames. Default: 0 (infinite).
 --run-time-ms <N>             Shutdown the application after N milliseconds. Default: 0 (infinite).

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -37,6 +37,7 @@ struct StandardOptions
     bool use_software_renderer = false;
 
     // Options
+    std::string         assets_path        = "";
     int                 gpu_index          = -1;
     int                 frame_count        = 0;
     int                 run_time_ms        = 0;

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -37,13 +37,13 @@ struct StandardOptions
     bool use_software_renderer = false;
 
     // Options
-    std::string         assets_path        = "";
-    int                 gpu_index          = -1;
+    std::string         assets_path             = "";
+    int                 gpu_index               = -1;
     int                 frame_count        = 0;
     int                 run_time_ms        = 0;
-    std::pair<int, int> resolution         = {-1, -1};
-    int                 screenshot_frame_number                  = -1;
-    std::string         screenshot_path                          = "";
+    std::pair<int, int> resolution              = {-1, -1};
+    int                 screenshot_frame_number = -1;
+    std::string         screenshot_path         = "";
     uint32_t            stats_frame_window = 300;
 #if defined(PPX_BUILD_XR)
     std::pair<int, int> xrUIResolution = {-1, -1};

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -674,7 +674,7 @@ void Application::DispatchConfig()
         AddAssetDir(path / "third_party/assets");
     }
 
-    if (mStandardOptions.assets_path != "") {
+    if (!mStandardOptions.assets_path.empty()) {
         AddAssetDir(mStandardOptions.assets_path, /* insert_at_front= */ true);
     }
 }

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -675,7 +675,7 @@ void Application::DispatchConfig()
     }
 
     if (mStandardOptions.assets_path != "") {
-      AddAssetDir(mStandardOptions.assets_path, /* insert_at_front= */ true);
+        AddAssetDir(mStandardOptions.assets_path, /* insert_at_front= */ true);
     }
 }
 

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -673,6 +673,10 @@ void Application::DispatchConfig()
         path /= RELATIVE_PATH_TO_PROJECT_ROOT;
         AddAssetDir(path / "third_party/assets");
     }
+
+    if (mStandardOptions.assets_path != "") {
+      AddAssetDir(mStandardOptions.assets_path, /* insert_at_front= */ true);
+    }
 }
 
 void Application::DispatchSetup()

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -68,7 +68,13 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
 
     for (const auto& opt : options) {
         // Process standard options.
-        if (opt.GetName() == "deterministic") {
+        if (opt.GetName() == "assets-path") {
+            if (!opt.HasValue()) {
+                return std::string("Command-line option --assets-path requires a parameter");
+            }
+            mOpts.standardOptions.assets_path = opt.GetValueOrDefault<std::string>("");
+        }
+        else if (opt.GetName() == "deterministic") {
             mOpts.standardOptions.deterministic = true;
         }
         else if (opt.GetName() == "frame-count") {

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -68,20 +68,14 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
 
     for (const auto& opt : options) {
         // Process standard options.
-        if (opt.GetName() == "help") {
-            mOpts.standardOptions.help = true;
-        }
-        else if (opt.GetName() == "list-gpus") {
-            mOpts.standardOptions.list_gpus = true;
-        }
-        else if (opt.GetName() == "use-software-renderer") {
-            mOpts.standardOptions.use_software_renderer = true;
-        }
-        else if (opt.GetName() == "headless") {
-            mOpts.standardOptions.headless = true;
-        }
-        else if (opt.GetName() == "deterministic") {
+        if (opt.GetName() == "deterministic") {
             mOpts.standardOptions.deterministic = true;
+        }
+        else if (opt.GetName() == "frame-count") {
+            if (!opt.HasValue()) {
+                return std::string("Command-line option --frame-count requires a parameter");
+            }
+            mOpts.standardOptions.frame_count = opt.GetValueOrDefault<int>(0);
         }
         else if (opt.GetName() == "gpu") {
             if (!opt.HasValue()) {
@@ -91,6 +85,15 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             if (mOpts.standardOptions.gpu_index < 0) {
                 return std::string("Command-line option --gpu requires a positive integer as the parameter");
             }
+        }
+        else if (opt.GetName() == "headless") {
+            mOpts.standardOptions.headless = true;
+        }
+        else if (opt.GetName() == "help") {
+            mOpts.standardOptions.help = true;
+        }
+        else if (opt.GetName() == "list-gpus") {
+            mOpts.standardOptions.list_gpus = true;
         }
         else if (opt.GetName() == "resolution") {
             if (!opt.HasValue()) {
@@ -111,12 +114,6 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             }
 
             mOpts.standardOptions.resolution = {width, height};
-        }
-        else if (opt.GetName() == "frame-count") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --frame-count requires a parameter");
-            }
-            mOpts.standardOptions.frame_count = opt.GetValueOrDefault<int>(0);
         }
         else if (opt.GetName() == "run-time-ms") {
             if (!opt.HasValue()) {
@@ -141,6 +138,9 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
                 return std::string("Command-line option --screenshot-path requires a parameter");
             }
             mOpts.standardOptions.screenshot_path = opt.GetValueOrDefault<std::string>("");
+        }
+        else if (opt.GetName() == "use-software-renderer") {
+            mOpts.standardOptions.use_software_renderer = true;
         }
 #if defined(PPX_BUILD_XR)
         else if (opt.GetName() == "xr-ui-resolution") {


### PR DESCRIPTION
BigWheels applications try to guess assets locations from the executable directory.
This is fine for desktop, and most basic use cases.

When using BigWheels to run tests, we might want to swap assets between each run, to test different versions of shaders by ex.

On desktop, we were able to do that by changing the assets in the correct directory.
On Android however, the APK contains the assets. This means swapping assets requires a new APK compilation.

This new flags would allow us to add arbitrary asset paths to the search list, allowing a quick asset-swap without having to rebuild APKs.