### PR TITLE
Reorder initializer list for KnobCheckbox

### DIFF
--- a/src/ppx/knob.cpp
+++ b/src/ppx/knob.cpp
@@ -36,7 +36,7 @@ bool Knob::DigestUpdate()
 // -------------------------------------------------------------------------------------------------
 
 KnobCheckbox::KnobCheckbox(const std::string& flagName, bool defaultValue)
-    : Knob(flagName), mDefaultValue(defaultValue), mValue(defaultValue)
+    : Knob(flagName), mValue(defaultValue), mDefaultValue(defaultValue)
 {
     SetFlagParameters("<true|false>");
     RaiseUpdatedFlag();


### PR DESCRIPTION
Reorder initializer list for KnobCheckbox so that it's in the same order as the class members