### PR TITLE
Improves bad asset path error message.

### DIFF
--- a/src/ppx/base_application.cpp
+++ b/src/ppx/base_application.cpp
@@ -99,6 +99,7 @@ std::filesystem::path BaseApplication::GetAssetPath(const std::filesystem::path&
             break;
         }
     }
+    PPX_ASSERT_MSG(!assetPath.empty(), "Could not determine asset path for " << subPath);
     return assetPath;
 }
 


### PR DESCRIPTION
The pattern we use if `LoadFile(GetAssetPath("asset/toto"))`. If GetAssetPath fails, "" is returned, making LoadFile show this message:

*** PPX ASSERT ***
Message   : could not load file: ""
Condition : false

This is useless, as it doesn't tells us which asset failed. This commits adds en assert in GetAssetPath() in case it returns "". Giving us this message:

*** PPX ASSERT ***
Message   : Could not find valid path for asset "basic/shaders/spv/StaticVertexColors.vs.spv"
Condition : !assetPath.empty()
Function  : GetAssetPath