### PR TITLE
samples: fix asset paths loading for some samples

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -384,8 +384,8 @@ public:
     //     - loads shader file: some/path/shaders/dxil/Texture.vs.dxil for API_DX_12_0, API_DX_12_1
     //     - loads shader file: some/path/shaders/spv/Texture.vs.spv   for API_VK_1_1, API_VK_1_2
     //
-    std::vector<char> LoadShader(const std::filesystem::path& baseDir, const std::string& baseName) const;
-    Result            CreateShader(const std::filesystem::path& baseDir, const std::string& baseName, grfx::ShaderModule** ppShaderModule) const;
+    std::vector<char> LoadShader(const std::filesystem::path& baseDir, const std::filesystem::path& baseName) const;
+    Result            CreateShader(const std::filesystem::path& baseDir, const std::filesystem::path& baseName, grfx::ShaderModule** ppShaderModule) const;
 
     Window*           GetWindow() const { return mWindow.get(); }
     grfx::InstancePtr GetInstance() const { return mInstance; }

--- a/projects/16_gbuffer/Entity.cpp
+++ b/projects/16_gbuffer/Entity.cpp
@@ -110,14 +110,14 @@ ppx::Result Entity::CreatePipelines(ppx::grfx::DescriptorSetLayout* pSceneDataLa
 
         grfx::ShaderModulePtr VS;
 
-        std::vector<char> bytecode = pApp->LoadShader(pApp->GetAssetPath("gbuffer/shaders"), "VertexShader.vs");
+        std::vector<char> bytecode = pApp->LoadShader("gbuffer/shaders", "VertexShader.vs");
         PPX_ASSERT_MSG(!bytecode.empty(), "VS shader bytecode load failed");
         grfx::ShaderModuleCreateInfo shaderCreateInfo = {static_cast<uint32_t>(bytecode.size()), bytecode.data()};
         PPX_CHECKED_CALL(pDevice->CreateShaderModule(&shaderCreateInfo, &VS));
 
         grfx::ShaderModulePtr PS;
 
-        bytecode = pApp->LoadShader(pApp->GetAssetPath("gbuffer/shaders"), "DeferredRender.ps");
+        bytecode = pApp->LoadShader("gbuffer/shaders", "DeferredRender.ps");
         PPX_ASSERT_MSG(!bytecode.empty(), "PS shader bytecode load failed");
         shaderCreateInfo = {static_cast<uint32_t>(bytecode.size()), bytecode.data()};
         PPX_CHECKED_CALL(pDevice->CreateShaderModule(&shaderCreateInfo, &PS));

--- a/projects/fishtornado/FishTornado.cpp
+++ b/projects/fishtornado/FishTornado.cpp
@@ -374,7 +374,7 @@ void FishTornadoApp::SetupDebug()
 #if !defined(PPX_D3D12)
     // Debug draw
     {
-        mDebugDrawPipeline = CreateForwardPipeline(GetAssetPath("fishtornado/shaders"), "DebugDraw.vs", "DebugDraw.ps");
+        mDebugDrawPipeline = CreateForwardPipeline("fishtornado/shaders", "DebugDraw.vs", "DebugDraw.ps");
     }
 #endif
 }

--- a/projects/fishtornado/Flocking.cpp
+++ b/projects/fishtornado/Flocking.cpp
@@ -211,7 +211,7 @@ void Flocking::SetupPipelines()
     {
         grfx::ShaderModulePtr CS;
 
-        PPX_CHECKED_CALL(pApp->CreateShader(pApp->GetAssetPath("fishtornado/shaders"), "FlockingPosition.cs", &CS));
+        PPX_CHECKED_CALL(pApp->CreateShader("fishtornado/shaders", "FlockingPosition.cs", &CS));
         grfx::ComputePipelineCreateInfo createInfo = {};
         createInfo.CS                              = {CS, "csmain"};
         createInfo.pPipelineInterface              = mFlockingPositionPipelineInterface;
@@ -224,7 +224,7 @@ void Flocking::SetupPipelines()
     {
         grfx::ShaderModulePtr CS;
 
-        PPX_CHECKED_CALL(pApp->CreateShader(pApp->GetAssetPath("fishtornado/shaders"), "FlockingVelocity.cs", &CS));
+        PPX_CHECKED_CALL(pApp->CreateShader("fishtornado/shaders", "FlockingVelocity.cs", &CS));
         grfx::ComputePipelineCreateInfo createInfo = {};
         createInfo.CS                              = {CS, "csmain"};
         createInfo.pPipelineInterface              = mFlockingVelocityPipelineInterface;
@@ -234,10 +234,10 @@ void Flocking::SetupPipelines()
     }
 
     // Foward
-    mForwardPipeline = pApp->CreateForwardPipeline(pApp->GetAssetPath("fishtornado/shaders"), "FlockingRender.vs", "FlockingRender.ps", mForwardPipelineInterface);
+    mForwardPipeline = pApp->CreateForwardPipeline("fishtornado/shaders", "FlockingRender.vs", "FlockingRender.ps", mForwardPipelineInterface);
 
     // Shadow
-    mShadowPipeline = pApp->CreateShadowPipeline(pApp->GetAssetPath("fishtornado/shaders"), "FlockingShadow.vs", mForwardPipelineInterface);
+    mShadowPipeline = pApp->CreateShadowPipeline("fishtornado/shaders", "FlockingShadow.vs", mForwardPipelineInterface);
 }
 
 void Flocking::Setup(uint32_t numFramesInFlight, const FishTornadoSettings& settings)

--- a/projects/fishtornado/Ocean.cpp
+++ b/projects/fishtornado/Ocean.cpp
@@ -60,7 +60,7 @@ void Ocean::Setup(uint32_t numFramesInFlight)
 
     // Floor
     {
-        mFloorForwardPipeline = pApp->CreateForwardPipeline(pApp->GetAssetPath("fishtornado/shaders"), "OceanFloor.vs", "OceanFloor.ps");
+        mFloorForwardPipeline = pApp->CreateForwardPipeline("fishtornado/shaders", "OceanFloor.vs", "OceanFloor.ps");
 
         TriMeshOptions options = TriMeshOptions().Indices().AllAttributes().TexCoordScale(float2(25.0f));
         PPX_CHECKED_CALL(grfx_util::CreateMeshFromFile(queue, pApp->GetAssetPath("fishtornado/models/ocean/floor_lowRes.obj"), &mFloorMesh, options));
@@ -84,7 +84,7 @@ void Ocean::Setup(uint32_t numFramesInFlight)
 
     // Surface
     {
-        mSurfaceForwardPipeline = pApp->CreateForwardPipeline(pApp->GetAssetPath("fishtornado/shaders"), "OceanSurface.vs", "OceanSurface.ps");
+        mSurfaceForwardPipeline = pApp->CreateForwardPipeline("fishtornado/shaders", "OceanSurface.vs", "OceanSurface.ps");
 
         TriMeshOptions options = TriMeshOptions().Indices().AllAttributes().TexCoordScale(float2(1.0f));
         TriMesh        mesh    = TriMesh::CreatePlane(TRI_MESH_PLANE_NEGATIVE_Y, float2(2500.0f), 10, 10, options);
@@ -111,8 +111,8 @@ void Ocean::Setup(uint32_t numFramesInFlight)
         {
             grfx::ShaderModulePtr VS, PS;
 
-            PPX_CHECKED_CALL(pApp->CreateShader(pApp->GetAssetPath("fishtornado/shaders"), "OceanBeam.vs", &VS));
-            PPX_CHECKED_CALL(pApp->CreateShader(pApp->GetAssetPath("fishtornado/shaders"), "OceanBeam.ps", &PS));
+            PPX_CHECKED_CALL(pApp->CreateShader("fishtornado/shaders", "OceanBeam.vs", &VS));
+            PPX_CHECKED_CALL(pApp->CreateShader("fishtornado/shaders", "OceanBeam.ps", &PS));
             const grfx::VertexInputRate inputRate = grfx::VERTEX_INPUT_RATE_VERTEX;
             grfx::VertexDescription     vertexDescription;
             vertexDescription.AppendBinding(grfx::VertexAttribute{PPX_SEMANTIC_NAME_POSITION, 0, grfx::FORMAT_R32G32B32_FLOAT, 0, PPX_APPEND_OFFSET_ALIGNED, inputRate});

--- a/projects/fishtornado/Shark.cpp
+++ b/projects/fishtornado/Shark.cpp
@@ -46,8 +46,8 @@ void Shark::Setup(uint32_t numFramesInFlight)
         PPX_CHECKED_CALL(frame.modelSet->UpdateUniformBuffer(RENDER_MODEL_DATA_REGISTER, 0, frame.modelConstants.GetGpuBuffer()));
     }
 
-    mForwardPipeline = pApp->CreateForwardPipeline(pApp->GetAssetPath("fishtornado/shaders"), "Shark.vs", "Shark.ps");
-    mShadowPipeline  = pApp->CreateShadowPipeline(pApp->GetAssetPath("fishtornado/shaders"), "SharkShadow.vs");
+    mForwardPipeline = pApp->CreateForwardPipeline("fishtornado/shaders", "Shark.vs", "Shark.ps");
+    mShadowPipeline  = pApp->CreateShadowPipeline("fishtornado/shaders", "SharkShadow.vs");
 
     TriMeshOptions options = TriMeshOptions().Indices().AllAttributes().InvertTexCoordsV().InvertWinding();
     PPX_CHECKED_CALL(grfx_util::CreateMeshFromFile(queue, pApp->GetAssetPath("fishtornado/models/shark/shark.obj"), &mMesh, options));

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -388,7 +388,7 @@ void FishTornadoApp::SetupDebug()
 #if !defined(PPX_D3D12)
     // Debug draw
     {
-        mDebugDrawPipeline = CreateForwardPipeline(GetAssetPath("fishtornado/shaders"), "DebugDraw.vs", "DebugDraw.ps");
+        mDebugDrawPipeline = CreateForwardPipeline("fishtornado/shaders", "DebugDraw.vs", "DebugDraw.ps");
     }
 #endif
     mViewCount = IsXrEnabled() ? GetXrComponent().GetViewCount() : 1;

--- a/projects/fishtornado_xr/Flocking.cpp
+++ b/projects/fishtornado_xr/Flocking.cpp
@@ -211,7 +211,7 @@ void Flocking::SetupPipelines()
     {
         grfx::ShaderModulePtr CS;
 
-        PPX_CHECKED_CALL(pApp->CreateShader(pApp->GetAssetPath("fishtornado/shaders"), "FlockingPosition.cs", &CS));
+        PPX_CHECKED_CALL(pApp->CreateShader("fishtornado/shaders", "FlockingPosition.cs", &CS));
         grfx::ComputePipelineCreateInfo createInfo = {};
         createInfo.CS                              = {CS, "csmain"};
         createInfo.pPipelineInterface              = mFlockingPositionPipelineInterface;
@@ -224,7 +224,7 @@ void Flocking::SetupPipelines()
     {
         grfx::ShaderModulePtr CS;
 
-        PPX_CHECKED_CALL(pApp->CreateShader(pApp->GetAssetPath("fishtornado/shaders"), "FlockingVelocity.cs", &CS));
+        PPX_CHECKED_CALL(pApp->CreateShader("fishtornado/shaders", "FlockingVelocity.cs", &CS));
         grfx::ComputePipelineCreateInfo createInfo = {};
         createInfo.CS                              = {CS, "csmain"};
         createInfo.pPipelineInterface              = mFlockingVelocityPipelineInterface;
@@ -234,10 +234,10 @@ void Flocking::SetupPipelines()
     }
 
     // Foward
-    mForwardPipeline = pApp->CreateForwardPipeline(pApp->GetAssetPath("fishtornado/shaders"), "FlockingRender.vs", "FlockingRender.ps", mForwardPipelineInterface);
+    mForwardPipeline = pApp->CreateForwardPipeline("fishtornado/shaders", "FlockingRender.vs", "FlockingRender.ps", mForwardPipelineInterface);
 
     // Shadow
-    mShadowPipeline = pApp->CreateShadowPipeline(pApp->GetAssetPath("fishtornado/shaders"), "FlockingShadow.vs", mForwardPipelineInterface);
+    mShadowPipeline = pApp->CreateShadowPipeline("fishtornado/shaders", "FlockingShadow.vs", mForwardPipelineInterface);
 }
 
 void Flocking::Setup(uint32_t numFramesInFlight, const FishTornadoSettings& settings)

--- a/projects/fishtornado_xr/Ocean.cpp
+++ b/projects/fishtornado_xr/Ocean.cpp
@@ -60,7 +60,7 @@ void Ocean::Setup(uint32_t numFramesInFlight)
 
     // Floor
     {
-        mFloorForwardPipeline = pApp->CreateForwardPipeline(pApp->GetAssetPath("fishtornado/shaders"), "OceanFloor.vs", "OceanFloor.ps");
+        mFloorForwardPipeline = pApp->CreateForwardPipeline("fishtornado/shaders", "OceanFloor.vs", "OceanFloor.ps");
 
         TriMeshOptions options = TriMeshOptions().Indices().AllAttributes().TexCoordScale(float2(25.0f));
         PPX_CHECKED_CALL(grfx_util::CreateMeshFromFile(queue, pApp->GetAssetPath("fishtornado/models/ocean/floor_lowRes.obj"), &mFloorMesh, options));
@@ -84,7 +84,7 @@ void Ocean::Setup(uint32_t numFramesInFlight)
 
     // Surface
     {
-        mSurfaceForwardPipeline = pApp->CreateForwardPipeline(pApp->GetAssetPath("fishtornado/shaders"), "OceanSurface.vs", "OceanSurface.ps");
+        mSurfaceForwardPipeline = pApp->CreateForwardPipeline("fishtornado/shaders", "OceanSurface.vs", "OceanSurface.ps");
 
         TriMeshOptions options = TriMeshOptions().Indices().AllAttributes().TexCoordScale(float2(1.0f));
         TriMesh        mesh    = TriMesh::CreatePlane(TRI_MESH_PLANE_NEGATIVE_Y, float2(2500.0f), 10, 10, options);
@@ -111,8 +111,8 @@ void Ocean::Setup(uint32_t numFramesInFlight)
         {
             grfx::ShaderModulePtr VS, PS;
 
-            PPX_CHECKED_CALL(pApp->CreateShader(pApp->GetAssetPath("fishtornado/shaders"), "OceanBeam.vs", &VS));
-            PPX_CHECKED_CALL(pApp->CreateShader(pApp->GetAssetPath("fishtornado/shaders"), "OceanBeam.ps", &PS));
+            PPX_CHECKED_CALL(pApp->CreateShader("fishtornado/shaders", "OceanBeam.vs", &VS));
+            PPX_CHECKED_CALL(pApp->CreateShader("fishtornado/shaders", "OceanBeam.ps", &PS));
             const grfx::VertexInputRate inputRate = grfx::VERTEX_INPUT_RATE_VERTEX;
             grfx::VertexDescription     vertexDescription;
             vertexDescription.AppendBinding(grfx::VertexAttribute{PPX_SEMANTIC_NAME_POSITION, 0, grfx::FORMAT_R32G32B32_FLOAT, 0, PPX_APPEND_OFFSET_ALIGNED, inputRate});

--- a/projects/fishtornado_xr/Shark.cpp
+++ b/projects/fishtornado_xr/Shark.cpp
@@ -46,8 +46,8 @@ void Shark::Setup(uint32_t numFramesInFlight)
         PPX_CHECKED_CALL(frame.modelSet->UpdateUniformBuffer(RENDER_MODEL_DATA_REGISTER, 0, frame.modelConstants.GetGpuBuffer()));
     }
 
-    mForwardPipeline = pApp->CreateForwardPipeline(pApp->GetAssetPath("fishtornado/shaders"), "Shark.vs", "Shark.ps");
-    mShadowPipeline  = pApp->CreateShadowPipeline(pApp->GetAssetPath("fishtornado/shaders"), "SharkShadow.vs");
+    mForwardPipeline = pApp->CreateForwardPipeline("fishtornado/shaders", "Shark.vs", "Shark.ps");
+    mShadowPipeline  = pApp->CreateShadowPipeline("fishtornado/shaders", "SharkShadow.vs");
 
     TriMeshOptions options = TriMeshOptions().Indices().AllAttributes().InvertTexCoordsV().InvertWinding();
     PPX_CHECKED_CALL(grfx_util::CreateMeshFromFile(queue, pApp->GetAssetPath("fishtornado/models/shark/shark.obj"), &mMesh, options));

--- a/projects/fluid_simulation/shaders.cpp
+++ b/projects/fluid_simulation/shaders.cpp
@@ -112,7 +112,7 @@ ComputeShader::ComputeShader(FluidSimulation* sim, const std::string& shaderFile
     : Shader(sim, shaderFile)
 {
     ppx::grfx::ShaderModulePtr cs;
-    std::vector<char>          bytecode = GetApp()->LoadShader(GetApp()->GetAssetPath("fluid_simulation/shaders"), mShaderFile + ".cs");
+    std::vector<char>          bytecode = GetApp()->LoadShader("fluid_simulation/shaders", mShaderFile + ".cs");
     PPX_ASSERT_MSG(!bytecode.empty(), "CS shader bytecode load failed");
     ppx::grfx::ShaderModuleCreateInfo sci = {static_cast<uint32_t>(bytecode.size()), bytecode.data()};
     PPX_CHECKED_CALL(GetApp()->GetDevice()->CreateShaderModule(&sci, &cs));
@@ -267,13 +267,13 @@ GraphicsShader::GraphicsShader(FluidSimulation* sim)
 {
     // Graphics pipeline.
     ppx::grfx::ShaderModulePtr vs;
-    std::vector<char>          bytecode = GetApp()->LoadShader(GetApp()->GetAssetPath("basic/shaders"), mShaderFile + ".vs");
+    std::vector<char>          bytecode = GetApp()->LoadShader("basic/shaders", mShaderFile + ".vs");
     PPX_ASSERT_MSG(!bytecode.empty(), "VS shader bytecode load failed");
     ppx::grfx::ShaderModuleCreateInfo sci = {static_cast<uint32_t>(bytecode.size()), bytecode.data()};
     PPX_CHECKED_CALL(GetApp()->GetDevice()->CreateShaderModule(&sci, &vs));
 
     ppx::grfx::ShaderModulePtr ps;
-    bytecode = GetApp()->LoadShader(GetApp()->GetAssetPath("basic/shaders"), mShaderFile + ".ps");
+    bytecode = GetApp()->LoadShader("basic/shaders", mShaderFile + ".ps");
     PPX_ASSERT_MSG(!bytecode.empty(), "PS shader bytecode load failed");
     sci = {static_cast<uint32_t>(bytecode.size()), bytecode.data()};
     PPX_CHECKED_CALL(GetApp()->GetDevice()->CreateShaderModule(&sci, &ps));

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1385,8 +1385,10 @@ std::optional<std::filesystem::path> GetShaderPathSuffix(const ppx::ApplicationS
 
 } // namespace
 
-std::vector<char> Application::LoadShader(const std::filesystem::path& baseDir, const std::string& baseName) const
+std::vector<char> Application::LoadShader(const std::filesystem::path& baseDir, const std::filesystem::path& baseName) const
 {
+    PPX_ASSERT_MSG(baseDir.is_relative(), "baseDir must be relative. Do not call GetAssetPath() on the directory.");
+    PPX_ASSERT_MSG(baseName.is_relative(), "baseName must be relative. Do not call GetAssetPath() on the directory.");
     auto suffix = GetShaderPathSuffix(mSettings, baseName);
     if (!suffix.has_value()) {
         PPX_ASSERT_MSG(false, "unsupported API");
@@ -1404,7 +1406,7 @@ std::vector<char> Application::LoadShader(const std::filesystem::path& baseDir, 
     return bytecode.value();
 }
 
-Result Application::CreateShader(const std::filesystem::path& baseDir, const std::string& baseName, grfx::ShaderModule** ppShaderModule) const
+Result Application::CreateShader(const std::filesystem::path& baseDir, const std::filesystem::path& baseName, grfx::ShaderModule** ppShaderModule) const
 {
     std::vector<char> bytecode = LoadShader(baseDir, baseName);
     if (bytecode.empty()) {

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1369,15 +1369,15 @@ grfx::Viewport Application::GetViewport(float minDepth, float maxDepth) const
 
 namespace {
 
-std::optional<std::filesystem::path> GetShaderPathSuffix(const ppx::ApplicationSettings& settings, const std::string& baseName)
+std::optional<std::filesystem::path> GetShaderPathSuffix(const ppx::ApplicationSettings& settings, const std::filesystem::path& baseName)
 {
     switch (settings.grfx.api) {
         case grfx::API_DX_12_0:
         case grfx::API_DX_12_1:
-            return std::filesystem::path("dxil") / (baseName + ".dxil");
+            return (std::filesystem::path("dxil") / baseName).concat(".dxil");
         case grfx::API_VK_1_1:
         case grfx::API_VK_1_2:
-            return std::filesystem::path("spv") / (baseName + ".spv");
+            return (std::filesystem::path("spv") / baseName).concat(".spv");
         default:
             return std::nullopt;
     }

--- a/src/ppx/base_application.cpp
+++ b/src/ppx/base_application.cpp
@@ -92,7 +92,7 @@ void BaseApplication::AddAssetDir(const std::filesystem::path& path, bool insert
 std::filesystem::path BaseApplication::GetAssetPath(const std::filesystem::path& subPath) const
 {
     std::filesystem::path assetPath;
-    for (auto& assetDir : mAssetDirs) {
+    for (const auto& assetDir : mAssetDirs) {
         std::filesystem::path path = assetDir / subPath;
         if (ppx::fs::path_exists(path)) {
             assetPath = path;


### PR DESCRIPTION
LoadShader take a subdir, and a shader name. Those 2 are then combined, and GetAssetPath is called.
2 Samples however called GetAssetPath on the subdir before. This was fine as long as the path returned was absolute because std::filesystem::path ignores the first part when
concatenating to an absolute path:

```
"/tmp/titi/" / "/tmp/toto" == "/tmp/toto"
"/tmp/titi/" / "tmp/toto" == "/tmp/titi/tmp/toto"
```

Now what we use "--assets-path", the asset dir could be relative, and this bugs becomes visible.