### PR TITLE
fluidsim: remove sources of non-determism

### DIFF
--- a/projects/fluid_simulation/sim.cpp
+++ b/projects/fluid_simulation/sim.cpp
@@ -20,7 +20,7 @@ namespace FluidSim {
 
 // In a normal game, animations are linked to the frame delta-time to make then run
 // as a fixed perceptible speed. For our use-case (benchmarking), determinism is important.
-// Targeting 60ips.
+// Targeting 60 images per second.
 constexpr float kFrameDeltaTime = 1.f / 60.f;
 
 // Color formats used by textures.

--- a/projects/fluid_simulation/sim.cpp
+++ b/projects/fluid_simulation/sim.cpp
@@ -12,12 +12,16 @@
 #include "ppx/application.h"
 #include "ppx/config.h"
 #include "ppx/grfx/grfx_format.h"
-#include "ppx/timer.h"
 
 #include <algorithm>
 #include <cmath>
 
 namespace FluidSim {
+
+// In a normal game, animations are linked to the frame delta-time to make then run
+// as a fixed perceptible speed. For our use-case (benchmarking), determinism is important.
+// Targeting 60ips.
+constexpr float kFrameDeltaTime = 1.f / 60.f;
 
 // Color formats used by textures.
 const ppx::grfx::Format kR    = ppx::grfx::FORMAT_R16_FLOAT;
@@ -51,9 +55,6 @@ FluidSimulation::FluidSimulation(ProjApp* app)
     fci = {true}; // Create signaled
     PPX_CHECKED_CALL(GetApp()->GetDevice()->CreateFence(&fci, &frame.renderCompleteFence));
     mPerFrame.push_back(frame);
-
-    // Initialize simulation state.
-    mTimer.Start();
 
     // Set up all the filters to use.
     InitComputeShaders();
@@ -458,8 +459,6 @@ void FluidSimulation::DrawTextures()
 
 void FluidSimulation::Update()
 {
-    float delta = CalcDeltaTime();
-
     // If the marble has been selected, move it around and drop it at random.
     if (GetConfig().marble) {
         MoveMarble();
@@ -481,17 +480,8 @@ void FluidSimulation::Update()
         MultipleSplats(1);
     }
 
-    Step(delta);
+    Step(kFrameDeltaTime);
     Render();
-}
-
-float FluidSimulation::CalcDeltaTime()
-{
-    double now      = mTimer.MillisSinceStart();
-    float  delta    = static_cast<float>((now - mLastUpdateTime) / 1000.0);
-    delta           = std::min(delta, 0.016666f);
-    mLastUpdateTime = now;
-    return delta;
 }
 
 void FluidSimulation::MoveMarble()

--- a/projects/fluid_simulation/sim.h
+++ b/projects/fluid_simulation/sim.h
@@ -13,7 +13,6 @@
 #include "ppx/application.h"
 #include "ppx/math_config.h"
 #include "ppx/random.h"
-#include "ppx/timer.h"
 
 #include <queue>
 
@@ -114,10 +113,6 @@ private:
     // Graphics resources (pipeline interface, descriptor layout, sampler, etc).
     GraphicsResources mGraphics;
 
-    // Time tracker to determine the delta since we called FluidSimulation::Update.  Used to
-    // pass to compute values like decay and velocity to cycle colors.
-    double mLastUpdateTime;
-
     // Textures used for filtering.
     std::unique_ptr<Texture>              mBloomTexture;
     std::vector<std::unique_ptr<Texture>> mBloomTextures;
@@ -168,9 +163,6 @@ private:
     // Random numbers used to initialize the simulation.
     ppx::Random mRandom;
 
-    // Time tracker used to cycle colours as the pointer moves.
-    ppx::Timer mTimer;
-
     // Virtual object moving through the simulation field causing wakes in the fluid.
     Bouncer mMarble;
 
@@ -183,7 +175,6 @@ private:
     void        DrawDisplay();
     void        DrawTextures();
     ppx::float3 GenerateColor();
-    float       CalcDeltaTime();
     void        MoveMarble();
     void        Step(float deltaTime);
 


### PR DESCRIPTION
GetElapsedTime() works well with --deterministic.
Timers don't.
But in this case, maybe removing deltatime computation entirely is fine?