### PR TITLE
Migrate FishTornado onto new metrics, add application-level metrics management wrappers, smaller fixes, etc.

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -235,6 +235,7 @@ struct ApplicationSettings
     bool        allowThirdPartyAssets = false;
     // Set to true to opt-in for metrics.
     bool enableMetrics = false;
+    std::string reportPath    = "";
 
     struct
     {

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -33,6 +33,7 @@ struct StandardOptions
 {
     // Flags
     bool deterministic         = false;
+    bool enable_metrics        = false;
     bool headless              = false;
     bool help                  = false;
     bool list_gpus             = false;
@@ -40,10 +41,11 @@ struct StandardOptions
 
     // Options
     std::vector<std::string> assets_paths            = {};
-    int                      gpu_index               = -1;
     int                      frame_count             = 0;
-    int                      run_time_ms             = 0;
+    int                      gpu_index               = -1;
+    std::string              metrics_filename        = "";
     std::pair<int, int>      resolution              = {-1, -1};
+    int                      run_time_ms             = 0;
     int                      screenshot_frame_number = -1;
     std::string              screenshot_path         = "";
     uint32_t                 stats_frame_window      = 300;
@@ -184,6 +186,9 @@ private:
 --deterministic               Disable non-deterministic behaviors, like clocks
                               and diagnostic display.
 
+--enable-metrics              Enable metrics report output. See also:
+                              `--metrics-filename`.
+
 --frame-count <N>             Shutdown the application after successfully
                               rendering N frames. Default: 0 (infinite).
 
@@ -198,6 +203,14 @@ private:
 --list-gpus                   Prints a list of the available GPUs on the
                               current system with their index and exits
                               (see --gpu).
+
+--metrics-filename            If metrics are enabled, save the metrics report
+                              to the provided filename (including path). If
+                              used, any "@" symbols in the filename (not the
+                              path) will be replaced with the current
+                              timestamp. If the filename does not end in .json,
+                              it will be appended. Default: "report_@". See
+                              also: `--enable-metrics`.
 )"
 #if defined(PPX_BUILD_XR)
                             R"(

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -174,50 +174,70 @@ public:
     }
 
 private:
-    CliOptions mOpts;
-#if defined(PPX_BUILD_XR)
+    CliOptions  mOpts;
     std::string mUsageMsg = R"(
 --help                        Prints this help message and exits.
 
---assets-path                 Add a path in front of the assets search path list (Can be specified multiple times).
---deterministic               Disable non-deterministic behaviors, like clocks.
---frame-count <N>             Shutdown the application after successfully rendering N frames.
+--assets-path                 Add a path in front of the assets search path
+                              list (Can be specified multiple times).
+
+--deterministic               Disable non-deterministic behaviors, like clocks
+                              and diagnostic display.
+
+--frame-count <N>             Shutdown the application after successfully
+                              rendering N frames. Default: 0 (infinite).
+
 --run-time-ms <N>             Shutdown the application after N milliseconds.
---gpu <index>                 Select the gpu with the given index. To determine the set of valid indices use --list-gpus.
---headless                    Run the sample without creating windows.
---list-gpus                   Prints a list of the available GPUs on the current system with their index and exits (see --gpu).
---resolution <Width>x<Height> Specify the per-eye resolution in pixels. Width and Height must be two positive integers greater or equal to 1.
---xr-ui-resolution <Width>x<Height> Specify the UI quad resolution in pixels. Width and Height must be two positive integers greater or equal to 1.
---screenshot-frame-number <N> Take a screenshot of frame number N and save it in PPM format.
-                              See also `--screenshot-path`.
---screenshot-path             Save the screenshot to this path. If not specified, BigWheels will create a
-                              "screenshot_frameN" file in the current working directory.
---stats-frame-window <N>      Calculate frame statistics over the last N frames only.
-                              Set to 0 to use all frames since the beginning of the application.
---use-software-renderer       Use a software renderer instead of a hardware device, if available.
-)";
-#else
-    std::string mUsageMsg = R"(
---help                        Prints this help message and exits.
+                              Default: 0 (infinite).
 
---assets-path                 Add a path in front of the assets search path list (Can be specified multiple times).
---deterministic               Disable non-deterministic behaviors, like clocks.
---frame-count <N>             Shutdown the application after successfully rendering N frames. Default: 0 (infinite).
---run-time-ms <N>             Shutdown the application after N milliseconds. Default: 0 (infinite).
---gpu <index>                 Select the gpu with the given index. To determine the set of valid indices use --list-gpus.
+--gpu <index>                 Select the gpu with the given index. To determine
+                              the set of valid indices use --list-gpus.
+
 --headless                    Run the sample without creating windows.
---list-gpus                   Prints a list of the available GPUs on the current system with their index and exits (see --gpu).
---resolution <Width>x<Height> Specify the main window resolution in pixels. Width and Height must be two positive integers greater or equal to 1.
---screenshot-frame-number <N> Take a screenshot of frame number N and save it in PPM format.
-                              See also `--screenshot-path`.
---screenshot-path             Save the screenshot to this path. If not specified, BigWheels will create a
-                              "screenshot_frameN" file in the current working directory.
---stats-frame-window <N>      Calculate frame statistics over the last N frames only.
-                              Set to 0 to use all frames since the beginning of the application.
---use-software-renderer       Use a software renderer instead of a hardware device, if available.
-)";
+
+--list-gpus                   Prints a list of the available GPUs on the
+                              current system with their index and exits
+                              (see --gpu).
+)"
+#if defined(PPX_BUILD_XR)
+                            R"(
+--resolution <Width>x<Height> Specify the per-eye resolution in pixels. Width
+                              and Height must be two positive integers greater
+                              or equal to 1.
+)"
+#else
+                            R"(
+--resolution <Width>x<Height> Specify the main window resolution in pixels.
+                              Width and Height must be two positive integers
+                              greater or equal to 1.
+)"
 #endif
+                            R"(
+--screenshot-frame-number <N> Take a screenshot of frame number N and save it
+                              in PPM format. See also `--screenshot-path`.
+
+--screenshot-path             Save the screenshot to this destination. If not
+                              specified, BigWheels will create a
+                              "screenshot_frameN" file in the current working
+                              directory.
+
+--stats-frame-window <N>      Calculate frame statistics over the last N frames
+                              only. Set to 0 to use all frames since the
+                              beginning of the application.
+
+--use-software-renderer       Use a software renderer instead of a hardware
+                              device, if available.
+)"
+#if defined(PPX_BUILD_XR)
+                            R"(
+--xr-ui-res <Width>x<Height>  Specify the UI quad resolution in pixels.
+                              Width and Height must be two positive integers
+                              greater or equal to 1.
+)"
+#endif
+        ; // mUsageMsg
 };
+
 } // namespace ppx
 
 #endif // ppx_command_line_parser_h

--- a/include/ppx/metrics.h
+++ b/include/ppx/metrics.h
@@ -29,7 +29,7 @@ namespace ppx {
 namespace metrics {
 
 #define METRICS_NO_COPY(TYPE__)     \
-    TYPE__(TYPE__&)       = delete; \
+    TYPE__(TYPE__&&)      = delete; \
     TYPE__(const TYPE__&) = delete; \
     TYPE__& operator=(const TYPE__&) = delete;
 
@@ -180,7 +180,7 @@ public:
     // to the caller, and its expiration cannot be known directly. Instead, we may want to use either
     // strong/weak pointers or functional access to help prevent unexpected use-after-free situations.
     template <typename T>
-    T* AddMetric(MetricMetadata metadata)
+    T* AddMetric(const MetricMetadata& metadata)
     {
         PPX_ASSERT_MSG(!metadata.name.empty(), "The metric name must not be empty");
         PPX_ASSERT_MSG(!HasMetric(metadata.name), "Metrics must have unique names (duplicate name detected)");

--- a/include/ppx/metrics.h
+++ b/include/ppx/metrics.h
@@ -176,9 +176,8 @@ class Run final
     friend class Manager;
 
 public:
-    // TODO(slumpwuffle): The lifetime of the pointer returned by this function is not well-defined
-    // to the caller, and its expiration cannot be known directly. Instead, we may want to use either
-    // strong/weak pointers or functional access to help prevent unexpected use-after-free situations.
+    // The lifetime of this pointer aligns with the lifetime of the parent Run.
+    // It is the responsibility of the caller to guard against use-after-free accordingly.
     template <typename T>
     T* AddMetric(const MetricMetadata& metadata)
     {

--- a/include/ppx/metrics.h
+++ b/include/ppx/metrics.h
@@ -218,7 +218,7 @@ public:
     Run* AddRun(const std::string& name);
 
     // Exports all the runs and metrics information into a report to disk.
-    void ExportToDisk(const std::string& baseReportName) const;
+    void ExportToDisk(const std::string& reportPath) const;
 
 private:
     METRICS_NO_COPY(Manager)
@@ -232,20 +232,20 @@ private:
     {
     public:
         static constexpr const char* kFileExtension = ".json";
+        static constexpr const char* kDefaultReportPath = "report_@";
 
     public:
         // Copy constructor for content.
-        Report(const nlohmann::json& content, const std::string& baseReportName);
+        Report(const nlohmann::json& content, const std::string& reportPath);
         // Move constructor for content.
-        Report(nlohmann::json&& content, const std::string& baseReportName);
+        Report(nlohmann::json&& content, const std::string& reportPath);
 
         void WriteToDisk(bool overwriteExisting = false) const;
 
     private:
-        void SetReportName(const std::string& baseReportName);
+        void SetReportPath(const std::string& reportPath);
 
         nlohmann::json        mContent;
-        std::string           mReportName;
         std::filesystem::path mFilePath;
     };
 

--- a/projects/fishtornado_xr/FishTornado.h
+++ b/projects/fishtornado_xr/FishTornado.h
@@ -48,7 +48,6 @@ struct FishTornadoSettings
     uint32_t fishResY                 = kDefaultFishResY;
     uint32_t fishThreadsX             = kDefaultFishThreadsX;
     uint32_t fishThreadsY             = kDefaultFishThreadsY;
-    bool     outputMetrics            = false;
 };
 
 class FishTornadoApp
@@ -93,6 +92,10 @@ public:
 
     bool WasLastFrameAsync() { return mLastFrameWasAsyncCompute; }
 
+protected:
+    virtual void DrawGui() override;
+    virtual void UpdateMetrics() override;
+
 private:
     struct PerFrame
     {
@@ -128,18 +131,17 @@ private:
     struct MetricsData
     {
         static constexpr size_t kTypeGpuFrameTime  = 0;
-        static constexpr size_t kTypeCpuFrameTime  = 1;
-        static constexpr size_t kTypeIAVertices    = 2;
-        static constexpr size_t kTypeIAPrimitives  = 3;
-        static constexpr size_t kTypeVSInvocations = 4;
-        static constexpr size_t kTypeCInvocations  = 5;
-        static constexpr size_t kTypeCPrimitives   = 6;
-        static constexpr size_t kTypePSInvocations = 7;
-        static constexpr size_t kCount             = 8;
+        static constexpr size_t kTypeIAVertices    = 1;
+        static constexpr size_t kTypeIAPrimitives  = 2;
+        static constexpr size_t kTypeVSInvocations = 3;
+        static constexpr size_t kTypeCInvocations  = 4;
+        static constexpr size_t kTypeCPrimitives   = 5;
+        static constexpr size_t kTypePSInvocations = 6;
+        static constexpr size_t kCount             = 7;
 
-        ppx::metrics::Manager      manager;
-        ppx::metrics::MetricGauge* metrics[kCount]      = {};
-        float                      lastMetricsWriteTime = 0;
+        MetricID metrics[kCount]      = {};
+        float    lastMetricsWriteTime = 0;
+        uint64_t data[kCount]         = {};
     };
 
     grfx::DescriptorPoolPtr               mDescriptorPool;
@@ -177,8 +179,7 @@ private:
     void SetupPerFrame();
     void SetupCaustics();
     void SetupDebug();
-    // TODO(slumpwuffle): Replace these one-off metrics with the new metrics system when it arrives.
-    void SetupMetrics();
+    void SetupFtMetrics();
     void SetupScene();
     void UploadCaustics();
     void UpdateTime();
@@ -197,11 +198,6 @@ private:
         PerFrame&           prevFrame,
         grfx::SwapchainPtr& swapchain,
         uint32_t            imageIndex);
-    // TODO(slumpwuffle): Replace these one-off metrics with the new metrics system when it arrives.
-    void WriteMetrics();
-
-protected:
-    virtual void DrawGui() override;
 };
 
 #endif // FISHTORNADO_H

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -694,7 +694,7 @@ void Application::SaveMetricsReportToDisk()
     }
 
     // Export the report from the metrics manager to the disk.
-    mMetrics.manager.ExportToDisk("report");
+    mMetrics.manager.ExportToDisk(mSettings.reportPath);
 }
 
 void Application::DispatchShutdown()
@@ -1068,7 +1068,13 @@ int Application::Run(int argc, char** argv)
     // ImGUI is not non-deterministic, but the visible informations (stats, timers) are.
     if ((mSettings.headless || mStandardOptions.deterministic) && mSettings.enableImGui) {
         mSettings.enableImGui = false;
-        PPX_LOG_WARN("Headless mode: disabling ImGui");
+        PPX_LOG_WARN("Headless or deterministic mode: disabling ImGui");
+    }
+
+    if (mStandardOptions.enable_metrics) {
+        mSettings.enableMetrics = true;
+        // An empty reportPath will be replaced with the default.
+        mSettings.reportPath = mStandardOptions.metrics_filename;
     }
 
     // Initialize the platform

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -149,9 +149,9 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             mOpts.standardOptions.use_software_renderer = opt.GetValueOrDefault<bool>(true);
         }
 #if defined(PPX_BUILD_XR)
-        else if (opt.GetName() == "xr-ui-resolution") {
+        else if (opt.GetName() == "xr-ui-res") {
             if (!opt.HasValue()) {
-                return std::string("Command-line option --xr-ui-resolution requires a parameter");
+                return std::string("Command-line option --xr-ui-res requires a parameter");
             }
 
             // Resolution is passed as <Width>x<Height>.
@@ -161,10 +161,10 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             char              x;
             ss >> width >> x >> height;
             if (ss.fail() || x != 'x') {
-                return std::string("Parameter for command-line option --xr-ui-resolution must be in <Width>x<Height> format, got " + val + " instead");
+                return std::string("Parameter for command-line option --xr-ui-res must be in <Width>x<Height> format, got " + val + " instead");
             }
             if (width < 1 || height < 1) {
-                return std::string("Parameter for command-line option --xr-ui-resolution must be in <Width>x<Height> format where Width and Height are integers greater or equal to 1");
+                return std::string("Parameter for command-line option --xr-ui-res must be in <Width>x<Height> format where Width and Height are integers greater or equal to 1");
             }
 
             mOpts.standardOptions.xrUIResolution = {width, height};

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -75,7 +75,7 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             mOpts.standardOptions.assets_paths.push_back(opt.GetValueOrDefault<std::string>(""));
         }
         else if (opt.GetName() == "deterministic") {
-            mOpts.standardOptions.deterministic = true;
+            mOpts.standardOptions.deterministic = opt.GetValueOrDefault<bool>(true);
         }
         else if (opt.GetName() == "frame-count") {
             if (!opt.HasValue()) {
@@ -93,13 +93,13 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             }
         }
         else if (opt.GetName() == "headless") {
-            mOpts.standardOptions.headless = true;
+            mOpts.standardOptions.headless = opt.GetValueOrDefault<bool>(true);
         }
         else if (opt.GetName() == "help") {
-            mOpts.standardOptions.help = true;
+            mOpts.standardOptions.help = opt.GetValueOrDefault<bool>(true);
         }
         else if (opt.GetName() == "list-gpus") {
-            mOpts.standardOptions.list_gpus = true;
+            mOpts.standardOptions.list_gpus = opt.GetValueOrDefault<bool>(true);
         }
         else if (opt.GetName() == "resolution") {
             if (!opt.HasValue()) {
@@ -146,7 +146,7 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             mOpts.standardOptions.screenshot_path = opt.GetValueOrDefault<std::string>("");
         }
         else if (opt.GetName() == "use-software-renderer") {
-            mOpts.standardOptions.use_software_renderer = true;
+            mOpts.standardOptions.use_software_renderer = opt.GetValueOrDefault<bool>(true);
         }
 #if defined(PPX_BUILD_XR)
         else if (opt.GetName() == "xr-ui-resolution") {

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -77,6 +77,9 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
         else if (opt.GetName() == "deterministic") {
             mOpts.standardOptions.deterministic = opt.GetValueOrDefault<bool>(true);
         }
+        else if (opt.GetName() == "enable-metrics") {
+            mOpts.standardOptions.enable_metrics = opt.GetValueOrDefault<bool>(true);
+        }
         else if (opt.GetName() == "frame-count") {
             if (!opt.HasValue()) {
                 return std::string("Command-line option --frame-count requires a parameter");
@@ -100,6 +103,12 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
         }
         else if (opt.GetName() == "list-gpus") {
             mOpts.standardOptions.list_gpus = opt.GetValueOrDefault<bool>(true);
+        }
+        else if (opt.GetName() == "metrics-filename") {
+            if (!opt.HasValue()) {
+                return std::string("Command-line option --metrics-filename requires a parameter");
+            }
+            mOpts.standardOptions.metrics_filename = opt.GetValueOrDefault<std::string>("");
         }
         else if (opt.GetName() == "resolution") {
             if (!opt.HasValue()) {

--- a/src/ppx/metrics.cpp
+++ b/src/ppx/metrics.cpp
@@ -212,9 +212,8 @@ nlohmann::json Run::Export() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// TODO(slumpwuffle): The lifetime of the pointer returned by this function is not well-defined
-// to the caller, and its expiration cannot be known directly. Instead, we may want to use either
-// strong/weak pointers or functional access to help prevent unexpected use-after-free situations.
+// The lifetime of this pointer aligns with the lifetime of the parent Manager.
+// It is the responsibility of the caller to guard against use-after-free accordingly.
 Run* Manager::AddRun(const std::string& name)
 {
     PPX_ASSERT_MSG(!name.empty(), "A run name must not be empty");


### PR DESCRIPTION
This PR includes the following changes:
1. Fixed boolean command line flags to allow for explicit --argument=true/--argument=false syntax.
2. Fixed help output of command line arguments to have a consistent 80 width spacing, alphabetical order, and minimal special casing for XR.
3. Added metrics command line arguments to control whether metrics are enabled/disabled.
4. Fixed smaller errors in some calling conventions inside metrics.
5. Added application-level metrics management wrappers to avoid direct pointer access exposure, instead using a map with IDs which can be invalidated.
6. Migrated fishtornado's metrics system onto using the new, application-level metrics. This includes changes to enable FT's metrics even when imgui is disabled.