### PR TITLE
Update Android build to use multi-project setup

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: "ubuntu-20.04"
     strategy:
       fail-fast: true
-      matrix:
-        task: ["assembleMobileBasicMaterial", "assembleMobileCube", "assembleMobileFishtornado", "assembleMobileGbuffer", "assembleMobileTriangle" ]
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -35,6 +33,6 @@ jobs:
           mkdir "${HOME}/vulkan-sdk"
           tar -xf vulkansdk-linux-x86_64-1.3.216.0.tar.gz -C "${HOME}/vulkan-sdk"
           echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.3.216.0/x86_64" >> $GITHUB_ENV
-      - name: Build the sample for Android
+      - name: Build all projects
         run: |
-          ./gradlew ${{ matrix.task }}
+          ./gradlew buildRelease

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ local.properties
 /.cxx
 /.gradle
 /.idea
+
+projects/**/assets

--- a/build.gradle
+++ b/build.gradle
@@ -77,8 +77,7 @@ subprojects {
                     }
                     else {
                         arguments '-DPPX_ANDROID=TRUE',
-                                  '-DPPX_BUILD_TESTS=FALSE',
-                                  '-DBUILD_TESTS=FALSE' // Required for OpenXR
+                                  '-DPPX_BUILD_TESTS=FALSE'
                     }
                     if (project.name.contains("_xr")) {
                         cppFlags '-std=c++20',

--- a/build.gradle
+++ b/build.gradle
@@ -1,159 +1,114 @@
-plugins {
-    id 'com.android.application' version '7.3.1'
-    id 'com.android.library' version '7.3.1' apply false
+ext {
+    assetsPath = '../../assets'
+    thirdPartyAssetsPath = '../../third_party/assets'
 }
 
-android {
-    namespace 'com.google.bigwheels'
-    compileSdk 32
+subprojects {
+    repositories {
+        mavenCentral()
+        google()
+    }
 
-    defaultConfig {
-        applicationId "com.google.bigwheels"
-        minSdk 29
-        targetSdk 32
-        versionCode 1
-        versionName "1.0"
+    apply plugin: "com.android.application"
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    dependencies {
+        implementation 'androidx.appcompat:appcompat:1.5.1'
+        implementation 'com.google.android.material:material:1.7.0'
+        testImplementation 'junit:junit:4.13.2'
+        androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+        androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    }
+
+    buildDir = "../../build/android/${project.name}"
+
+    android {
+        namespace 'com.google.bigwheels'
+        compileSdkVersion 32
+
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+        }
+        buildFeatures {
+            prefab true
+        }
         externalNativeBuild {
             cmake {
-                arguments '-DPPX_ANDROID=TRUE',
-                          '-DPPX_BUILD_TESTS=FALSE',
-                          '-DBUILD_TESTS=FALSE' // Required for OpenXR
-                cppFlags '-std=c++20'
-                if (project.hasProperty('DXC_PATH')) {
-                  arguments "-DDXC_PATH=$DXC_PATH"
-                }
+                path file('../../CMakeLists.txt')
+                version '3.22.1+'
+                buildStagingDirectory "../../.cxx/${project.name}"
             }
         }
-        multiDexEnabled true
-    }
 
-    buildTypes {
-        release {
-            minifyEnabled false
-        }
-        debug {
-          applicationIdSuffix '.debug'
-          debuggable true
-        }
-    }
-    def defineFlavor = { sample_name ->
-      return {
-        dimension 'project'
-        // Package names cannot start with a number, adding prefixing.
-        applicationIdSuffix ".project_" + sample_name
-        manifestPlaceholders = [
-            sampleLibraryName : "vk_" + sample_name,
-            appLabel : "vk_" + sample_name
-        ]
-        it.buildConfigField "String", "sample_library_name", '"vk_' + sample_name + '"'
-        externalNativeBuild {
-            cmake {
-                targets "vk_" + sample_name
+        buildTypes {
+            release {
+                minifyEnabled false
+            }
+            debug {
+              applicationIdSuffix '.debug'
+              debuggable true
             }
         }
-      }
-    }
 
-    flavorDimensions 'device', 'project'
-    productFlavors {
-        triangle      defineFlavor('01_triangle')
-        cube          defineFlavor('04_cube')
-        cubexr        defineFlavor('04_cube_xr')
-        basicmaterial defineFlavor('15_basic_material')
-        gbuffer       defineFlavor('16_gbuffer')
-        fishtornado   defineFlavor('fishtornado')
-        fishtornadoxr defineFlavor('fishtornado_xr')
+        defaultConfig {
+            applicationId "com.google.bigwheels.project_${project.name}"
+            minSdk 29
+            targetSdk 32
+            versionCode 1
+            versionName "1.0"
 
-        mobile {
-            dimension 'device'
+            manifestPlaceholders = [
+                sampleLibraryName : "vk_${project.name}",
+                appLabel : "vk_${project.name}"
+            ]
+
+            ndk.abiFilters = ['arm64-v8a']
+
+            testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
             externalNativeBuild {
                 cmake {
-                    arguments '-DPPX_BUILD_XR=FALSE',
-                              '-DBUILD_LOADER=FALSE'
+                    if (project.name.contains("_xr")) {
+                        arguments '-DPPX_ANDROID=TRUE',
+                                  '-DPPX_BUILD_TESTS=FALSE',
+                                  '-DBUILD_TESTS=FALSE', // Required for OpenXR
+                                  '-DPPX_BUILD_XR=TRUE',
+                                  '-DBUILD_LOADER=TRUE',
+                                  '-DBUILD_ALL_EXTENSIONS=TRUE'
+                    }
+                    else {
+                        arguments '-DPPX_ANDROID=TRUE',
+                                  '-DPPX_BUILD_TESTS=FALSE',
+                                  '-DBUILD_TESTS=FALSE' // Required for OpenXR
+                    }
+                    if (project.name.contains("_xr")) {
+                        cppFlags '-std=c++20',
+                                 '-DXR_USE_PLATFORM_ANDROID'
+                    }
+                    else {
+                        cppFlags '-std=c++20'
+                    }
+                   
+                    if (project.hasProperty('DXC_PATH')) {
+                      arguments "-DDXC_PATH=$DXC_PATH"
+                    }
+                    targets "vk_${project.name}"
+                }
+            }
+            multiDexEnabled true
+            it.buildConfigField "String", "sample_library_name", '"vk_' + project.name + '"'
+            sourceSets.main {
+                java.srcDirs = [ '../../src/android' ]
+                assets.srcDirs = ['assets']
+                if (project.name.contains("_xr")) {
+                    manifest.srcFile '../../src/android/AndroidManifest.XR.xml'
+                } else {
+                    manifest.srcFile '../../src/android/AndroidManifest.xml'
                 }
             }
         }
-        xr {
-            dimension 'device'
-            applicationIdSuffix '.xr'
-            versionNameSuffix '-xr'
-            externalNativeBuild {
-                cmake {
-                    arguments '-DPPX_BUILD_XR=TRUE',
-                              '-DBUILD_LOADER=TRUE',
-                              '-DBUILD_ALL_EXTENSIONS=TRUE'
-                    cppFlags '-DXR_USE_PLATFORM_ANDROID'
-                }
-            }
-        }
     }
 
-    variantFilter { variant ->
-        def deviceFlavors = variant.flavors.findAll { it.dimension == 'device' }
-        def projectFlavors = variant.flavors.findAll { it.dimension == 'project'}
-        def device = deviceFlavors[0].name
-        def project = projectFlavors[0].name
-
-        def xrProjects = ['cubexr', 'fishtornadoxr']
-
-        if (device == 'mobile' && xrProjects.contains(project)) {
-            // Ignore XR projects for mobile devices.
-            setIgnore(true)
-        }
-        if ((device == 'xr') && !xrProjects.contains(project)) {
-            // Ignore non-XR projects for XR devices.
-            setIgnore(true)
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-    buildFeatures {
-        prefab true
-    }
-    externalNativeBuild {
-        cmake {
-            path file('CMakeLists.txt')
-            version '3.22.1+'
-        }
-    }
-    sourceSets {
-        main {
-            manifest.srcFile 'src/android/AndroidManifest.xml'
-            java.srcDirs = [ 'src/android' ]
-            assets {
-                srcDirs 'assets', "third_party/assets"
-            }
-        }
-        xr {
-            manifest.srcFile 'src/android/AndroidManifest.XR.xml'
-        }
-    }
-
-    splits {
-        // Configures multiple APKs based on ABI.
-        abi {
-          enable true
-          // Resets the list of ABIs for Gradle to create APKs for to none.
-          reset()
-
-          // Specifies a list of ABIs for Gradle to create APKs for.
-          include "arm64-v8a"
-
-          // Do not generate a universal APK that includes all ABIs.
-          universalApk false
-        }
-    }
-}
-
-dependencies {
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    // Each sample project must define copyTask for copying assets
+    // that are used in the project.
+    preBuild.dependsOn ":" + project.name + ":copyTask"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ subprojects {
                     else {
                         cppFlags '-std=c++20'
                     }
-                   
+
                     if (project.hasProperty('DXC_PATH')) {
                       arguments "-DDXC_PATH=$DXC_PATH"
                     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 ext {
-    assetsPath = '../../assets'
-    thirdPartyAssetsPath = '../../third_party/assets'
+    assetsPath = "${rootProject.projectDir}/assets"
+    thirdPartyAssetsPath = "${rootProject.projectDir}/third_party/assets"
 }
 
 subprojects {
@@ -19,11 +19,11 @@ subprojects {
         androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
     }
 
-    buildDir = "../../build/android/${project.name}"
+    buildDir = "${rootProject.buildDir}/android/${project.name}"
 
     android {
         namespace 'com.google.bigwheels'
-        compileSdkVersion 32
+        compileSdk 32
 
         compileOptions {
             sourceCompatibility JavaVersion.VERSION_1_8
@@ -34,9 +34,9 @@ subprojects {
         }
         externalNativeBuild {
             cmake {
-                path file('../../CMakeLists.txt')
+                path file("${rootProject.projectDir}/CMakeLists.txt")
                 version '3.22.1+'
-                buildStagingDirectory "../../.cxx/${project.name}"
+                buildStagingDirectory "${rootProject.projectDir}/.cxx/${project.name}"
             }
         }
 
@@ -97,12 +97,12 @@ subprojects {
             multiDexEnabled true
             it.buildConfigField "String", "sample_library_name", '"vk_' + project.name + '"'
             sourceSets.main {
-                java.srcDirs = [ '../../src/android' ]
-                assets.srcDirs = ['assets']
+                java.srcDirs = [ "${rootProject.projectDir}/src/android" ]
+                assets.srcDirs = [ "assets" ]
                 if (project.name.contains("_xr")) {
-                    manifest.srcFile '../../src/android/AndroidManifest.XR.xml'
+                    manifest.srcFile "${rootProject.projectDir}/src/android/AndroidManifest.XR.xml"
                 } else {
-                    manifest.srcFile '../../src/android/AndroidManifest.xml'
+                    manifest.srcFile "${rootProject.projectDir}/src/android/AndroidManifest.xml"
                 }
             }
         }

--- a/docs/building_and_running.md
+++ b/docs/building_and_running.md
@@ -93,7 +93,7 @@ Some common commands:
 ./gradlew 01_triangle:assembleDebug
 
 # Build & install the debug application through ADB:
-./gradlew 01_triangle:install -PDXC_PATH=some/path/to/dxc
+./gradlew 01_triangle:installDebug -PDXC_PATH=some/path/to/dxc
 ```
 
 To generate APKs for all available samples:

--- a/docs/building_and_running.md
+++ b/docs/building_and_running.md
@@ -44,7 +44,9 @@ Built binaries are written to `build\bin`.
 Use Android Studio to open the BigWheels folder and build it.
 A custom DXC_PATH can be set through the env of a `.properties` file.
 
-You can select the sample and target device by navigating to `Build -> Select Build Variant` within Android Studio.
+You can select the sample in the "Select Run/Debug Configuring" drop-down
+within the top toolbar. You can also select the target device using the
+top toolbar.
 
 ## Android (on Linux)
 
@@ -69,57 +71,46 @@ Make sure the Android SDK path is in your env
 export ANDROID_HOME=/path/to/android/sdk
 ```
 
-Multiple targets are available, This example will assume the `triangle`
-target is built. Below the target naming scheme will be explained.
-
-To use Vulkan's SDK DXC version:
+You can list available projects with:
 
 ```bash
-./gradlew buildMobileTriangleDebug
+./gradlew projects
 ```
 
-To provide the DXC path:
+You can use command line tools to build, package and install projects.
+The example below will assume the `01_triangle` target is built.
+
+Some common commands:
 
 ```bash
-./gradlew buildMobileTriangleDebug -PDXC_PATH=some/path/to/dxc
+# Build using Vulkan's SDK DXC version:
+./gradlew 01_triangle:build
+
+# Building with a custom DXC path:
+./gradlew 01_triangle:build -PDXC_PATH=some/path/to/dxc
+
+# Assemble a debug APK without installing:
+./gradlew 01_triangle:assembleDebug
+
+# Build & install the debug application through ADB:
+./gradlew 01_triangle:install -PDXC_PATH=some/path/to/dxc
 ```
 
-To build & install the application through ADB
+To generate APKs for all available samples:
 
+```bash
+./gradlew assemble
 ```
-./gradlew installMobileTriangleDebug -PDXC_PATH=some/path/to/dxc
-```
 
-The target names are composed using this pattern:
-<buildType><device><sampleName>[xr]<flavor>
+The generated APKs can be found in the
+`build/android/<project_name>/outputs/apk/<flavour>` directory.
 
-buildType:
-  - assemble: build and package the APK without installing
-  - build: only build the artefacts
-  - install: build and package the APK and install with ADB.
+### Adding a new Android sample
 
-device:
-  - Mobile : an Android phone
-  - Xr : an XR device
-
-sampleName:
-  - Triangle    : 01_triangle
-  - Cube        : 04_cube
-  ...
-
-The `xr` suffix can be added on some samples (see projects/ directory)
-
-flavor:
-  - Debug
-  - Release
-
-Example:
-
-To build Fishtornado, XR:
-
-```
-./gradlew buildXrFishtornadoxrDebug
-```
+To add a new Android project to the list of available projects,
+create a `build.gradle` file in the project directory and define
+a `copyTask` that specifies all assets used in the project.
+You can follow any existing samples for an example.
 
 ## OpenXR
 OpenXR support can be enabled by adding `-DPPX_BUILD_XR=1` flag.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.parallel=true

--- a/projects/01_triangle/build.gradle
+++ b/projects/01_triangle/build.gradle
@@ -1,0 +1,7 @@
+task copyTask {
+    copy {
+        from rootProject.ext.assetsPath + '/basic/shaders/spv'
+        into 'assets/basic/shaders/spv'
+        include '*.spv'
+    }
+}

--- a/projects/04_cube/build.gradle
+++ b/projects/04_cube/build.gradle
@@ -1,0 +1,7 @@
+task copyTask {
+    copy {
+        from rootProject.ext.assetsPath + '/basic/shaders/spv'
+        into 'assets/basic/shaders/spv'
+        include '*.spv'
+    }
+}

--- a/projects/04_cube_xr/build.gradle
+++ b/projects/04_cube_xr/build.gradle
@@ -1,0 +1,11 @@
+task copyTask {
+    copy {
+        from rootProject.ext.assetsPath + '/basic/shaders/spv'
+        into 'assets/basic/shaders/spv'
+        include '*.spv'
+    }
+    copy {
+        from rootProject.ext.assetsPath + '/fishtornado'
+        into 'assets/fishtornado'
+    }
+}

--- a/projects/04_cube_xr/build.gradle
+++ b/projects/04_cube_xr/build.gradle
@@ -4,8 +4,4 @@ task copyTask {
         into 'assets/basic/shaders/spv'
         include '*.spv'
     }
-    copy {
-        from rootProject.ext.assetsPath + '/fishtornado'
-        into 'assets/fishtornado'
-    }
 }

--- a/projects/08_basic_geometry/build.gradle
+++ b/projects/08_basic_geometry/build.gradle
@@ -1,0 +1,7 @@
+task copyTask {
+    copy {
+        from rootProject.ext.assetsPath + '/basic/shaders/spv'
+        into 'assets/basic/shaders/spv'
+        include '*.spv'
+    }
+}

--- a/projects/15_basic_material/build.gradle
+++ b/projects/15_basic_material/build.gradle
@@ -1,0 +1,23 @@
+task copyTask {
+    copy {
+        from rootProject.ext.assetsPath + '/basic/models'
+        into 'assets/basic/models'
+    }
+    copy {
+        from rootProject.ext.assetsPath + '/basic/shaders/spv'
+        into 'assets/basic/shaders/spv'
+        include '*.spv'
+    }
+    copy {
+        from rootProject.ext.assetsPath + '/common/textures'
+        into 'assets/common/textures'
+    }
+    copy {
+        from rootProject.ext.assetsPath + '/materials/shaders'
+        into 'assets/materials/shaders'
+    }
+    copy {
+        from rootProject.ext.thirdPartyAssetsPath + '/poly_haven'
+        into 'assets/poly_haven'
+    }
+}

--- a/projects/16_gbuffer/build.gradle
+++ b/projects/16_gbuffer/build.gradle
@@ -1,0 +1,16 @@
+task copyTask {
+    copy {
+        from rootProject.ext.assetsPath + '/basic/shaders/spv'
+        into 'assets/basic/shaders/spv'
+        include '*.spv'
+    }
+    copy {
+        from rootProject.ext.assetsPath + '/gbuffer/shaders/spv'
+        into 'assets/gbuffer/shaders/spv'
+        include '*.spv'
+    }
+    copy {
+        from rootProject.ext.assetsPath + '/materials/textures'
+        into 'assets/materials/textures'
+    }
+}

--- a/projects/fishtornado/build.gradle
+++ b/projects/fishtornado/build.gradle
@@ -1,0 +1,11 @@
+task copyTask {
+    copy {
+        from rootProject.ext.assetsPath + '/basic/shaders/spv'
+        into 'assets/basic/shaders/spv'
+        include '*.spv'
+    }
+    copy {
+        from rootProject.ext.assetsPath + '/fishtornado'
+        into 'assets/fishtornado'
+    }
+}

--- a/projects/fishtornado_xr/build.gradle
+++ b/projects/fishtornado_xr/build.gradle
@@ -1,0 +1,11 @@
+task copyTask {
+    copy {
+        from rootProject.ext.assetsPath + '/basic/shaders/spv'
+        into 'assets/basic/shaders/spv'
+        include '*.spv'
+    }
+    copy {
+        from rootProject.ext.assetsPath + '/fishtornado'
+        into 'assets/fishtornado'
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,9 @@ pluginManagement {
         google()
         mavenCentral()
     }
+    plugins {
+        id 'com.android.application' version '7.3.1' apply false
+    }
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,5 +12,19 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "bigwheels"
-include ':app'
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.3.0'
+    }
+}
+
+file('projects').eachDir { sub ->
+    if (file("projects/$sub.name/build.gradle").exists()) {
+        include ":$sub.name"
+        project(":$sub.name").projectDir = new File("projects/$sub.name")
+    }
+}


### PR DESCRIPTION
Use multi-project build setup instead of build flavours for samples. The root project `build.gradle` specifies how to build, and each subproject just creates a copyTask to copy assets that are used by the project.

Updates/benefits:
- In Android Studio, easier way to find and switch samples and no gradle sync when switching build flavours
- In CLI more straightforward way to discover projects and no need to remember syntax on how to build.
- Specifies assets per project, resulting in smaller APKs. Third party assets are only used in a few projects, and those are very large (> 300 MB). No need to add them to projects that don't use them.
- Instead of split APKS use abi filters to only build for arm64-v8a
- Build all samples in the github CI
- Modifies the default location of build and .cxx folders. The default would be in projects/<subproject> but
I don't like polluting it there, so modifying to a centralized location, so it's easier to manage/delete.

One drawback of the new setup is specifying assets that are used inside the project, so if the project is updated we have to remember to update the build.gradle file, and there is also no automated way to test right now.