### PR TITLE
Fixes view offset sizes in D3D12

### DIFF
--- a/include/ppx/grfx/grfx_buffer.h
+++ b/include/ppx/grfx/grfx_buffer.h
@@ -65,11 +65,12 @@ struct IndexBufferView
     const grfx::Buffer* pBuffer   = nullptr;
     grfx::IndexType     indexType = grfx::INDEX_TYPE_UINT16;
     uint64_t            offset    = 0;
+    uint64_t            size      = PPX_WHOLE_SIZE; // [D3D12 - REQUIRED] Size in bytes of view
 
     IndexBufferView() {}
 
-    IndexBufferView(const grfx::Buffer* pBuffer_, grfx::IndexType indexType_, uint64_t offset_ = 0)
-        : pBuffer(pBuffer_), indexType(indexType_), offset(offset_) {}
+    IndexBufferView(const grfx::Buffer* pBuffer_, grfx::IndexType indexType_, uint64_t offset_ = 0, uint64_t size_ = PPX_WHOLE_SIZE)
+        : pBuffer(pBuffer_), indexType(indexType_), offset(offset_), size(size_) {}
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -79,50 +80,13 @@ struct VertexBufferView
     const grfx::Buffer* pBuffer = nullptr;
     uint32_t            stride  = 0; // [D3D12 - REQUIRED] Stride in bytes of vertex entry
     uint64_t            offset  = 0;
+    uint64_t            size    = PPX_WHOLE_SIZE; // [D3D12 - REQUIRED] Size in bytes of view
 
     VertexBufferView() {}
 
-    VertexBufferView(const grfx::Buffer* pBuffer_, uint32_t stride_, uint64_t offset_ = 0)
-        : pBuffer(pBuffer_), stride(stride_), offset(offset_) {}
+    VertexBufferView(const grfx::Buffer* pBuffer_, uint32_t stride_, uint64_t offset_ = 0, uint64_t size_ = 0)
+        : pBuffer(pBuffer_), stride(stride_), offset(offset_), size(size_) {}
 };
-
-//// -------------------------------------------------------------------------------------------------
-//
-//struct IndexBufferCreateInfo
-//{
-//    grfx::IndexType indexType  = grfx::INDEX_TYPE_UINT16;
-//    uint32_t        indexCount = 0;
-//};
-//
-//class IndexBuffer
-//{
-//public:
-//    IndexBuffer() {}
-//    virtual ~IndexBuffer() {}
-//
-//private:
-//    grfx::BufferPtr       mBuffer;
-//    grfx::IndexBufferView mView = {};
-//};
-//
-//// -------------------------------------------------------------------------------------------------
-//
-//struct VertexBufferCreateInfo
-//{
-//    grfx::VertexBinding binding     = {};
-//    uint32_t            vertexCount = 0;
-//};
-//
-//class VertexBuffer
-//{
-//public:
-//    VertexBuffer() {}
-//    virtual ~VertexBuffer() {}
-//
-//private:
-//    grfx::BufferPtr mBuffer;
-//    grfx::VertexBufferView = {};
-//};
 
 } // namespace grfx
 } // namespace ppx

--- a/src/ppx/grfx/dx12/dx12_command.cpp
+++ b/src/ppx/grfx/dx12/dx12_command.cpp
@@ -533,9 +533,12 @@ void CommandBuffer::BindComputePipeline(const grfx::ComputePipeline* pPipeline)
 
 void CommandBuffer::BindIndexBuffer(const grfx::IndexBufferView* pView)
 {
+    D3D12_GPU_VIRTUAL_ADDRESS baseAddress = ToApi(pView->pBuffer)->GetDxResource()->GetGPUVirtualAddress();
+    UINT                      sizeInBytes = static_cast<UINT>((pView->size == PPX_WHOLE_SIZE) ? pView->pBuffer->GetSize() : pView->size);
+
     D3D12_INDEX_BUFFER_VIEW view = {};
-    view.BufferLocation          = ToApi(pView->pBuffer)->GetDxResource()->GetGPUVirtualAddress();
-    view.SizeInBytes             = static_cast<UINT>(pView->pBuffer->GetSize());
+    view.BufferLocation          = baseAddress + static_cast<D3D12_GPU_VIRTUAL_ADDRESS>(pView->offset);
+    view.SizeInBytes             = static_cast<UINT>(pView->size);
     view.Format                  = ToD3D12IndexFormat(pView->indexType);
     PPX_ASSERT_MSG(view.Format != DXGI_FORMAT_UNKNOWN, "unknown index  format");
 
@@ -548,8 +551,11 @@ void CommandBuffer::BindVertexBuffers(
 {
     D3D12_VERTEX_BUFFER_VIEW views[PPX_MAX_RENDER_TARGETS] = {};
     for (uint32_t i = 0; i < viewCount; ++i) {
-        views[i].BufferLocation = ToApi(pViews[i].pBuffer)->GetDxResource()->GetGPUVirtualAddress();
-        views[i].SizeInBytes    = static_cast<UINT>(pViews[i].pBuffer->GetSize());
+        D3D12_GPU_VIRTUAL_ADDRESS baseAddress = ToApi(pViews[i].pBuffer)->GetDxResource()->GetGPUVirtualAddress();
+        UINT                      sizeInBytes = static_cast<UINT>((pViews[i].size == PPX_WHOLE_SIZE) ? pViews[i].pBuffer->GetSize() : pViews[i].size);
+
+        views[i].BufferLocation = baseAddress + static_cast<D3D12_GPU_VIRTUAL_ADDRESS>(pViews[i].offset);
+        views[i].SizeInBytes    = sizeInBytes;
         views[i].StrideInBytes  = static_cast<UINT>(pViews[i].stride);
     }
 

--- a/src/ppx/grfx/dx12/dx12_descriptor.cpp
+++ b/src/ppx/grfx/dx12/dx12_descriptor.cpp
@@ -359,11 +359,12 @@ Result DescriptorSet::UpdateDescriptors(uint32_t writeCount, const grfx::WriteDe
             } break;
 
             case grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER: {
-                uint64_t sizeInBytes = (srcWrite.bufferRange == PPX_WHOLE_SIZE) ? srcWrite.pBuffer->GetSize() : srcWrite.bufferRange;
+                D3D12_GPU_VIRTUAL_ADDRESS baseAddress = ToApi(srcWrite.pBuffer)->GetDxResource()->GetGPUVirtualAddress();
+                UINT                      sizeInBytes = static_cast<UINT>((srcWrite.bufferRange == PPX_WHOLE_SIZE) ? srcWrite.pBuffer->GetSize() : srcWrite.bufferRange);
 
                 D3D12_CONSTANT_BUFFER_VIEW_DESC desc = {};
-                desc.BufferLocation                  = ToApi(srcWrite.pBuffer)->GetDxResource()->GetGPUVirtualAddress();
-                desc.SizeInBytes                     = static_cast<UINT>(sizeInBytes);
+                desc.BufferLocation                  = baseAddress + static_cast<D3D12_GPU_VIRTUAL_ADDRESS>(srcWrite.bufferOffset);
+                desc.SizeInBytes                     = sizeInBytes;
 
                 SIZE_T                      ptr    = heapOffset.descriptorHandle.ptr + static_cast<SIZE_T>(handleIncSizeCBVSRVUAV * srcWrite.arrayIndex);
                 D3D12_CPU_DESCRIPTOR_HANDLE handle = D3D12_CPU_DESCRIPTOR_HANDLE{ptr};


### PR DESCRIPTION
D3D12 views for buffer objects requires a size to be specified. This is analogous to Vulkan's range for storage and uniform buffers. Previous to this commit, the D3D12 views always assumed the size of the buffer for index and buffer views. Constant buffer view offset and size were already handled. correctly. This change corrects handling of both offsets and sizes for index and vertex buffer views.

- Added size member variable to IndexBufferView and VertexBufferView.
- Fixed missing offset in index and vertex buffer views for D3D12.
- Fixed missing size in index and vertex buffer view for D3D12.
- Removed unused code.