### PR TITLE
Fix some minor CLI nits

### DIFF
--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -176,63 +176,64 @@ public:
 private:
     CliOptions  mOpts;
     std::string mUsageMsg = R"(
---help                        Prints this help message and exits.
+--help              Prints this help message and exits.
 
---assets-path                 Add a path in front of the assets search path
-                              list (Can be specified multiple times).
+--assets-path       Add a path in front of the assets search path list (Can be
+                    specified multiple times).
 
---deterministic               Disable non-deterministic behaviors, like clocks
-                              and diagnostic display.
+--deterministic     Disable non-deterministic behaviors, like clocks and
+                    diagnostic display.
 
---frame-count <N>             Shutdown the application after successfully
-                              rendering N frames. Default: 0 (infinite).
+--frame-count <N>   Shutdown the application after successfully rendering N
+                    frames. Default: 0 (infinite).
 
---run-time-ms <N>             Shutdown the application after N milliseconds.
-                              Default: 0 (infinite).
+--run-time-ms <N>   Shutdown the application after N milliseconds. Default: 0
+                    (infinite).
 
---gpu <index>                 Select the gpu with the given index. To determine
-                              the set of valid indices use --list-gpus.
+--gpu <index>       Select the gpu with the given index. To determine the set
+                    of valid indices use --list-gpus.
 
---headless                    Run the sample without creating windows.
+--headless          Run the sample without creating windows.
 
---list-gpus                   Prints a list of the available GPUs on the
-                              current system with their index and exits
-                              (see --gpu).
+--list-gpus         Prints a list of the available GPUs on the current system
+                    with their index and exits (see --gpu).
 )"
 #if defined(PPX_BUILD_XR)
                             R"(
---resolution <Width>x<Height> Specify the per-eye resolution in pixels. Width
-                              and Height must be two positive integers greater
-                              or equal to 1.
+--resolution <Width>x<Height>
+                    Specify the per-eye resolution in pixels. Width and Height
+                    must be two positive integers greater or equal to 1.
 )"
 #else
                             R"(
---resolution <Width>x<Height> Specify the main window resolution in pixels.
-                              Width and Height must be two positive integers
-                              greater or equal to 1.
+--resolution <Width>x<Height>
+                    Specify the main window resolution in pixels. Width and
+                    Height must be two positive integers greater or equal to 1.
 )"
 #endif
                             R"(
---screenshot-frame-number <N> Take a screenshot of frame number N and save it
-                              in PPM format. See also `--screenshot-path`.
+--screenshot-frame-number <N>
+                    Take a screenshot of frame number N and save it in PPM
+                    format. See also `--screenshot-path`.
 
---screenshot-path             Save the screenshot to this destination. If not
-                              specified, BigWheels will create a
-                              "screenshot_frameN" file in the current working
-                              directory.
+--screenshot-path   Save the screenshot to this destination. If not specified,
+                    BigWheels will create a "screenshot_frameN" file in the
+                    current working directory.
 
---stats-frame-window <N>      Calculate frame statistics over the last N frames
-                              only. Set to 0 to use all frames since the
-                              beginning of the application.
+--stats-frame-window <N>
+                    Calculate frame statistics over the last N frames only.
+                    Default: 0 (use all frames since the beginning of the
+                    application).
 
---use-software-renderer       Use a software renderer instead of a hardware
-                              device, if available.
+--use-software-renderer
+                    Use a software renderer instead of a hardware device, if
+                    available.
 )"
 #if defined(PPX_BUILD_XR)
                             R"(
---xr-ui-res <Width>x<Height>  Specify the UI quad resolution in pixels.
-                              Width and Height must be two positive integers
-                              greater or equal to 1.
+--xr-ui-resolution <Width>x<Height>
+                    Specify the UI quad resolution in pixels. Width and Height
+                    must be two positive integers greater or equal to 1.
 )"
 #endif
         ; // mUsageMsg

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -174,50 +174,70 @@ public:
     }
 
 private:
-    CliOptions mOpts;
-#if defined(PPX_BUILD_XR)
+    CliOptions  mOpts;
     std::string mUsageMsg = R"(
 --help                        Prints this help message and exits.
 
---assets-path                 Add a path in front of the assets search path list (Can be specified multiple times).
---deterministic               Disable non-deterministic behaviors, like clocks.
---frame-count <N>             Shutdown the application after successfully rendering N frames.
+--assets-path                 Add a path in front of the assets search path
+                              list (Can be specified multiple times).
+
+--deterministic               Disable non-deterministic behaviors, like clocks
+                              and diagnostic display.
+
+--frame-count <N>             Shutdown the application after successfully
+                              rendering N frames. Default: 0 (infinite).
+
 --run-time-ms <N>             Shutdown the application after N milliseconds.
---gpu <index>                 Select the gpu with the given index. To determine the set of valid indices use --list-gpus.
---headless                    Run the sample without creating windows.
---list-gpus                   Prints a list of the available GPUs on the current system with their index and exits (see --gpu).
---resolution <Width>x<Height> Specify the per-eye resolution in pixels. Width and Height must be two positive integers greater or equal to 1.
---xr-ui-resolution <Width>x<Height> Specify the UI quad resolution in pixels. Width and Height must be two positive integers greater or equal to 1.
---screenshot-frame-number <N> Take a screenshot of frame number N and save it in PPM format.
-                              See also `--screenshot-path`.
---screenshot-path             Save the screenshot to this path. If not specified, BigWheels will create a
-                              "screenshot_frameN" file in the current working directory.
---stats-frame-window <N>      Calculate frame statistics over the last N frames only.
-                              Set to 0 to use all frames since the beginning of the application.
---use-software-renderer       Use a software renderer instead of a hardware device, if available.
-)";
-#else
-    std::string mUsageMsg = R"(
---help                        Prints this help message and exits.
+                              Default: 0 (infinite).
 
---assets-path                 Add a path in front of the assets search path list (Can be specified multiple times).
---deterministic               Disable non-deterministic behaviors, like clocks.
---frame-count <N>             Shutdown the application after successfully rendering N frames. Default: 0 (infinite).
---run-time-ms <N>             Shutdown the application after N milliseconds. Default: 0 (infinite).
---gpu <index>                 Select the gpu with the given index. To determine the set of valid indices use --list-gpus.
+--gpu <index>                 Select the gpu with the given index. To determine
+                              the set of valid indices use --list-gpus.
+
 --headless                    Run the sample without creating windows.
---list-gpus                   Prints a list of the available GPUs on the current system with their index and exits (see --gpu).
---resolution <Width>x<Height> Specify the main window resolution in pixels. Width and Height must be two positive integers greater or equal to 1.
---screenshot-frame-number <N> Take a screenshot of frame number N and save it in PPM format.
-                              See also `--screenshot-path`.
---screenshot-path             Save the screenshot to this path. If not specified, BigWheels will create a
-                              "screenshot_frameN" file in the current working directory.
---stats-frame-window <N>      Calculate frame statistics over the last N frames only.
-                              Set to 0 to use all frames since the beginning of the application.
---use-software-renderer       Use a software renderer instead of a hardware device, if available.
-)";
+
+--list-gpus                   Prints a list of the available GPUs on the
+                              current system with their index and exits
+                              (see --gpu).
+)"
+#if defined(PPX_BUILD_XR)
+                            R"(
+--resolution <Width>x<Height> Specify the per-eye resolution in pixels. Width
+                              and Height must be two positive integers greater
+                              or equal to 1.
+)"
+#else
+                            R"(
+--resolution <Width>x<Height> Specify the main window resolution in pixels.
+                              Width and Height must be two positive integers
+                              greater or equal to 1.
+)"
 #endif
+                            R"(
+--screenshot-frame-number <N> Take a screenshot of frame number N and save it
+                              in PPM format. See also `--screenshot-path`.
+
+--screenshot-path             Save the screenshot to this destination. If not
+                              specified, BigWheels will create a
+                              "screenshot_frameN" file in the current working
+                              directory.
+
+--stats-frame-window <N>      Calculate frame statistics over the last N frames
+                              only. Set to 0 to use all frames since the
+                              beginning of the application.
+
+--use-software-renderer       Use a software renderer instead of a hardware
+                              device, if available.
+)"
+#if defined(PPX_BUILD_XR)
+                            R"(
+--xr-ui-res <Width>x<Height>  Specify the UI quad resolution in pixels.
+                              Width and Height must be two positive integers
+                              greater or equal to 1.
+)"
+#endif
+        ; // mUsageMsg
 };
+
 } // namespace ppx
 
 #endif // ppx_command_line_parser_h

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -149,9 +149,9 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             mOpts.standardOptions.use_software_renderer = opt.GetValueOrDefault<bool>(true);
         }
 #if defined(PPX_BUILD_XR)
-        else if (opt.GetName() == "xr-ui-res") {
+        else if (opt.GetName() == "xr-ui-resolution") {
             if (!opt.HasValue()) {
-                return std::string("Command-line option --xr-ui-res requires a parameter");
+                return std::string("Command-line option --xr-ui-resolution requires a parameter");
             }
 
             // Resolution is passed as <Width>x<Height>.
@@ -161,10 +161,10 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             char              x;
             ss >> width >> x >> height;
             if (ss.fail() || x != 'x') {
-                return std::string("Parameter for command-line option --xr-ui-res must be in <Width>x<Height> format, got " + val + " instead");
+                return std::string("Parameter for command-line option --xr-ui-resolution must be in <Width>x<Height> format, got " + val + " instead");
             }
             if (width < 1 || height < 1) {
-                return std::string("Parameter for command-line option --xr-ui-res must be in <Width>x<Height> format where Width and Height are integers greater or equal to 1");
+                return std::string("Parameter for command-line option --xr-ui-resolution must be in <Width>x<Height> format where Width and Height are integers greater or equal to 1");
             }
 
             mOpts.standardOptions.xrUIResolution = {width, height};

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -149,9 +149,9 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             mOpts.standardOptions.use_software_renderer = opt.GetValueOrDefault<bool>(true);
         }
 #if defined(PPX_BUILD_XR)
-        else if (opt.GetName() == "xr-ui-resolution") {
+        else if (opt.GetName() == "xr-ui-res") {
             if (!opt.HasValue()) {
-                return std::string("Command-line option --xr-ui-resolution requires a parameter");
+                return std::string("Command-line option --xr-ui-res requires a parameter");
             }
 
             // Resolution is passed as <Width>x<Height>.
@@ -161,10 +161,10 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             char              x;
             ss >> width >> x >> height;
             if (ss.fail() || x != 'x') {
-                return std::string("Parameter for command-line option --xr-ui-resolution must be in <Width>x<Height> format, got " + val + " instead");
+                return std::string("Parameter for command-line option --xr-ui-res must be in <Width>x<Height> format, got " + val + " instead");
             }
             if (width < 1 || height < 1) {
-                return std::string("Parameter for command-line option --xr-ui-resolution must be in <Width>x<Height> format where Width and Height are integers greater or equal to 1");
+                return std::string("Parameter for command-line option --xr-ui-res must be in <Width>x<Height> format where Width and Height are integers greater or equal to 1");
             }
 
             mOpts.standardOptions.xrUIResolution = {width, height};

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -75,7 +75,7 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             mOpts.standardOptions.assets_paths.push_back(opt.GetValueOrDefault<std::string>(""));
         }
         else if (opt.GetName() == "deterministic") {
-            mOpts.standardOptions.deterministic = true;
+            mOpts.standardOptions.deterministic = opt.GetValueOrDefault<bool>(true);
         }
         else if (opt.GetName() == "frame-count") {
             if (!opt.HasValue()) {
@@ -93,13 +93,13 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             }
         }
         else if (opt.GetName() == "headless") {
-            mOpts.standardOptions.headless = true;
+            mOpts.standardOptions.headless = opt.GetValueOrDefault<bool>(true);
         }
         else if (opt.GetName() == "help") {
-            mOpts.standardOptions.help = true;
+            mOpts.standardOptions.help = opt.GetValueOrDefault<bool>(true);
         }
         else if (opt.GetName() == "list-gpus") {
-            mOpts.standardOptions.list_gpus = true;
+            mOpts.standardOptions.list_gpus = opt.GetValueOrDefault<bool>(true);
         }
         else if (opt.GetName() == "resolution") {
             if (!opt.HasValue()) {
@@ -146,7 +146,7 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             mOpts.standardOptions.screenshot_path = opt.GetValueOrDefault<std::string>("");
         }
         else if (opt.GetName() == "use-software-renderer") {
-            mOpts.standardOptions.use_software_renderer = true;
+            mOpts.standardOptions.use_software_renderer = opt.GetValueOrDefault<bool>(true);
         }
 #if defined(PPX_BUILD_XR)
         else if (opt.GetName() == "xr-ui-resolution") {


### PR DESCRIPTION
Includes two changes:
1. Creates a default-true behavior on flags when they're present, so they can also now be explicitly set to false. E.g.:
--argument present means true
no --argument present means "use internal default" (most likely false)
--argument=true means explicitly true
--argument=false means explicitly false

2. Cleans up the CLI help to be 80 characters wide, and unifies the strings used between XR/non-XR versions. Also alphabetizes the order of arguments. To do this, xr-ui-resolution is now xr-ui-res.