### PR TITLE
Add CLI flags for controlling metrics enable/disable, filename, etc.

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -235,6 +235,7 @@ struct ApplicationSettings
     bool        allowThirdPartyAssets = false;
     // Set to true to opt-in for metrics.
     bool enableMetrics = false;
+    std::string reportPath    = "";
 
     struct
     {

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -234,7 +234,8 @@ struct ApplicationSettings
     bool        enableImGui           = false;
     bool        allowThirdPartyAssets = false;
     // Set to true to opt-in for metrics.
-    bool enableMetrics = false;
+    bool        enableMetrics        = false;
+    bool        overwriteMetricsFile = false;
     std::string reportPath    = "";
 
     struct

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -236,7 +236,7 @@ struct ApplicationSettings
     // Set to true to opt-in for metrics.
     bool        enableMetrics        = false;
     bool        overwriteMetricsFile = false;
-    std::string reportPath    = "";
+    std::string reportPath           = "";
 
     struct
     {

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -32,12 +32,13 @@ namespace ppx {
 struct StandardOptions
 {
     // Flags
-    bool deterministic         = false;
-    bool enable_metrics        = false;
-    bool headless              = false;
-    bool help                  = false;
-    bool list_gpus             = false;
-    bool use_software_renderer = false;
+    bool deterministic          = false;
+    bool enable_metrics         = false;
+    bool headless               = false;
+    bool help                   = false;
+    bool list_gpus              = false;
+    bool overwrite_metrics_file = false;
+    bool use_software_renderer  = false;
 
     // Options
     std::vector<std::string> assets_paths            = {};
@@ -187,7 +188,7 @@ private:
                     diagnostic display.
 
 --enable-metrics    Enable metrics report output. See also:
-                    `--metrics-filename`.
+                    `--metrics-filename` and `--overwrite-metrics-file`.
 
 --frame-count <N>   Shutdown the application after successfully rendering N
                     frames. Default: 0 (infinite).
@@ -208,7 +209,14 @@ private:
                     symbols in the filename (not the path) will be replaced
                     with the current timestamp. If the filename does not end in
                     .json, it will be appended. Default: "report_@". See also:
-                    `--enable-metrics`.
+                    `--enable-metrics` and `--overwrite-metrics-file`.
+
+--overwrite-metrics-file
+                    Only applies if metrics are enabled with
+                    `--enable-metrics`. If an existing file at the path set
+                    with `--metrics-filename` is found, it will be overwritten.
+                    Default: false. See also: `--enable-metrics` and
+                    `--metrics-filename`.
 )"
 #if defined(PPX_BUILD_XR)
                             R"(

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -33,6 +33,7 @@ struct StandardOptions
 {
     // Flags
     bool deterministic         = false;
+    bool enable_metrics        = false;
     bool headless              = false;
     bool help                  = false;
     bool list_gpus             = false;
@@ -40,10 +41,11 @@ struct StandardOptions
 
     // Options
     std::vector<std::string> assets_paths            = {};
-    int                      gpu_index               = -1;
     int                      frame_count             = 0;
-    int                      run_time_ms             = 0;
+    int                      gpu_index               = -1;
+    std::string              metrics_filename        = "";
     std::pair<int, int>      resolution              = {-1, -1};
+    int                      run_time_ms             = 0;
     int                      screenshot_frame_number = -1;
     std::string              screenshot_path         = "";
     uint32_t                 stats_frame_window      = 300;
@@ -184,6 +186,9 @@ private:
 --deterministic     Disable non-deterministic behaviors, like clocks and
                     diagnostic display.
 
+--enable-metrics    Enable metrics report output. See also:
+                    `--metrics-filename`.
+
 --frame-count <N>   Shutdown the application after successfully rendering N
                     frames. Default: 0 (infinite).
 
@@ -197,6 +202,13 @@ private:
 
 --list-gpus         Prints a list of the available GPUs on the current system
                     with their index and exits (see --gpu).
+
+--metrics-filename  If metrics are enabled, save the metrics report to the
+                    provided filename (including path). If used, any "@"
+                    symbols in the filename (not the path) will be replaced
+                    with the current timestamp. If the filename does not end in
+                    .json, it will be appended. Default: "report_@". See also:
+                    `--enable-metrics`.
 )"
 #if defined(PPX_BUILD_XR)
                             R"(

--- a/include/ppx/metrics.h
+++ b/include/ppx/metrics.h
@@ -29,7 +29,7 @@ namespace ppx {
 namespace metrics {
 
 #define METRICS_NO_COPY(TYPE__)     \
-    TYPE__(TYPE__&)       = delete; \
+    TYPE__(TYPE__&&)      = delete; \
     TYPE__(const TYPE__&) = delete; \
     TYPE__& operator=(const TYPE__&) = delete;
 
@@ -180,7 +180,7 @@ public:
     // to the caller, and its expiration cannot be known directly. Instead, we may want to use either
     // strong/weak pointers or functional access to help prevent unexpected use-after-free situations.
     template <typename T>
-    T* AddMetric(MetricMetadata metadata)
+    T* AddMetric(const MetricMetadata& metadata)
     {
         PPX_ASSERT_MSG(!metadata.name.empty(), "The metric name must not be empty");
         PPX_ASSERT_MSG(!HasMetric(metadata.name), "Metrics must have unique names (duplicate name detected)");

--- a/include/ppx/metrics.h
+++ b/include/ppx/metrics.h
@@ -218,7 +218,7 @@ public:
     Run* AddRun(const std::string& name);
 
     // Exports all the runs and metrics information into a report to disk.
-    void ExportToDisk(const std::string& baseReportName) const;
+    void ExportToDisk(const std::string& reportPath) const;
 
 private:
     METRICS_NO_COPY(Manager)
@@ -232,20 +232,20 @@ private:
     {
     public:
         static constexpr const char* kFileExtension = ".json";
+        static constexpr const char* kDefaultReportPath = "report_@";
 
     public:
         // Copy constructor for content.
-        Report(const nlohmann::json& content, const std::string& baseReportName);
+        Report(const nlohmann::json& content, const std::string& reportPath);
         // Move constructor for content.
-        Report(nlohmann::json&& content, const std::string& baseReportName);
+        Report(nlohmann::json&& content, const std::string& reportPath);
 
         void WriteToDisk(bool overwriteExisting = false) const;
 
     private:
-        void SetReportName(const std::string& baseReportName);
+        void SetReportPath(const std::string& reportPath);
 
         nlohmann::json        mContent;
-        std::string           mReportName;
         std::filesystem::path mFilePath;
     };
 

--- a/include/ppx/metrics.h
+++ b/include/ppx/metrics.h
@@ -218,7 +218,7 @@ public:
     Run* AddRun(const std::string& name);
 
     // Exports all the runs and metrics information into a report to disk.
-    void ExportToDisk(const std::string& reportPath) const;
+    void ExportToDisk(const std::string& reportPath, bool overwriteExisting = false) const;
 
 private:
     METRICS_NO_COPY(Manager)
@@ -240,7 +240,7 @@ private:
         // Move constructor for content.
         Report(nlohmann::json&& content, const std::string& reportPath);
 
-        void WriteToDisk(bool overwriteExisting = false) const;
+        void WriteToDisk(bool overwriteExisting) const;
 
     private:
         void SetReportPath(const std::string& reportPath);

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -694,7 +694,7 @@ void Application::SaveMetricsReportToDisk()
     }
 
     // Export the report from the metrics manager to the disk.
-    mMetrics.manager.ExportToDisk(mSettings.reportPath);
+    mMetrics.manager.ExportToDisk(mSettings.reportPath, mSettings.overwriteMetricsFile);
 }
 
 void Application::DispatchShutdown()
@@ -1075,6 +1075,7 @@ int Application::Run(int argc, char** argv)
         mSettings.enableMetrics = true;
         // An empty reportPath will be replaced with the default.
         mSettings.reportPath = mStandardOptions.metrics_filename;
+        mSettings.overwriteMetricsFile = mStandardOptions.overwrite_metrics_file;
     }
 
     // Initialize the platform

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1074,7 +1074,7 @@ int Application::Run(int argc, char** argv)
     if (mStandardOptions.enable_metrics) {
         mSettings.enableMetrics = true;
         // An empty reportPath will be replaced with the default.
-        mSettings.reportPath = mStandardOptions.metrics_filename;
+        mSettings.reportPath           = mStandardOptions.metrics_filename;
         mSettings.overwriteMetricsFile = mStandardOptions.overwrite_metrics_file;
     }
 

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -694,7 +694,7 @@ void Application::SaveMetricsReportToDisk()
     }
 
     // Export the report from the metrics manager to the disk.
-    mMetrics.manager.ExportToDisk("report");
+    mMetrics.manager.ExportToDisk(mSettings.reportPath);
 }
 
 void Application::DispatchShutdown()
@@ -1068,7 +1068,13 @@ int Application::Run(int argc, char** argv)
     // ImGUI is not non-deterministic, but the visible informations (stats, timers) are.
     if ((mSettings.headless || mStandardOptions.deterministic) && mSettings.enableImGui) {
         mSettings.enableImGui = false;
-        PPX_LOG_WARN("Headless mode: disabling ImGui");
+        PPX_LOG_WARN("Headless or deterministic mode: disabling ImGui");
+    }
+
+    if (mStandardOptions.enable_metrics) {
+        mSettings.enableMetrics = true;
+        // An empty reportPath will be replaced with the default.
+        mSettings.reportPath = mStandardOptions.metrics_filename;
     }
 
     // Initialize the platform

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -110,6 +110,9 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             }
             mOpts.standardOptions.metrics_filename = opt.GetValueOrDefault<std::string>("");
         }
+        else if (opt.GetName() == "overwrite-metrics-file") {
+            mOpts.standardOptions.overwrite_metrics_file = opt.GetValueOrDefault<bool>(true);
+        }
         else if (opt.GetName() == "resolution") {
             if (!opt.HasValue()) {
                 return std::string("Command-line option --resolution requires a parameter");

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -77,6 +77,9 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
         else if (opt.GetName() == "deterministic") {
             mOpts.standardOptions.deterministic = opt.GetValueOrDefault<bool>(true);
         }
+        else if (opt.GetName() == "enable-metrics") {
+            mOpts.standardOptions.enable_metrics = opt.GetValueOrDefault<bool>(true);
+        }
         else if (opt.GetName() == "frame-count") {
             if (!opt.HasValue()) {
                 return std::string("Command-line option --frame-count requires a parameter");
@@ -100,6 +103,12 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
         }
         else if (opt.GetName() == "list-gpus") {
             mOpts.standardOptions.list_gpus = opt.GetValueOrDefault<bool>(true);
+        }
+        else if (opt.GetName() == "metrics-filename") {
+            if (!opt.HasValue()) {
+                return std::string("Command-line option --metrics-filename requires a parameter");
+            }
+            mOpts.standardOptions.metrics_filename = opt.GetValueOrDefault<std::string>("");
         }
         else if (opt.GetName() == "resolution") {
             if (!opt.HasValue()) {

--- a/src/ppx/metrics.cpp
+++ b/src/ppx/metrics.cpp
@@ -226,7 +226,7 @@ Run* Manager::AddRun(const std::string& name)
     return pRun;
 }
 
-void Manager::ExportToDisk(const std::string& reportPath) const
+void Manager::ExportToDisk(const std::string& reportPath, bool overwriteExisting) const
 {
     nlohmann::json content;
     for (const auto& [name, pRun] : mRuns) {
@@ -237,7 +237,7 @@ void Manager::ExportToDisk(const std::string& reportPath) const
     // Since the json library relies on strings-as-pointers rather than self-allocated objects,
     // the lifecycle of the report is tied to the lifecycle of the runs and metrics owned by
     // the manager. But this is opaque.
-    Report(std::move(content), reportPath).WriteToDisk();
+    Report(std::move(content), reportPath).WriteToDisk(overwriteExisting);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This set of changes introduces the following metrics command-line arguments:
1. enable-metrics, to enable/disable the metrics globally.
2. metrics-filename, which allows a user to set a destination path and filename for the metrics report.
3. overwrite-metrics-file, which allows a user to overwrite any existing metrics file, as set by metrics-filename.

It also includes some minor cleanup in the METRICS_NO_COPY macro.