### PR TITLE
Rename push constants functions

### DIFF
--- a/include/ppx/grfx/dx12/dx12_command.h
+++ b/include/ppx/grfx/dx12/dx12_command.h
@@ -82,7 +82,7 @@ public:
         uint32_t                          setCount,
         const grfx::DescriptorSet* const* ppSets) override;
 
-    virtual void SetGraphicsPushConstants(
+    virtual void PushGraphicsConstants(
         const grfx::PipelineInterface* pInterface,
         uint32_t                       count,
         const void*                    pValues,
@@ -95,7 +95,7 @@ public:
         uint32_t                          setCount,
         const grfx::DescriptorSet* const* ppSets) override;
 
-    virtual void SetComputePushConstants(
+    virtual void PushComputeConstants(
         const grfx::PipelineInterface* pInterface,
         uint32_t                       count,
         const void*                    pValues,

--- a/include/ppx/grfx/grfx_command.h
+++ b/include/ppx/grfx/grfx_command.h
@@ -311,7 +311,7 @@ public:
     //     with a different compiler or source language. The contents pointed to
     //     by pValues must respect the packing rules in effect.
     //
-    virtual void SetGraphicsPushConstants(
+    virtual void PushGraphicsConstants(
         const grfx::PipelineInterface* pInterface,
         uint32_t                       count,
         const void*                    pValues,
@@ -364,7 +364,7 @@ public:
         const grfx::DescriptorSet* const* ppSets) = 0;
 
     // See comments at SetGraphicsPushConstants for explanation about count, pValues and dstOffset.
-    virtual void SetComputePushConstants(
+    virtual void PushComputeConstants(
         const grfx::PipelineInterface* pInterface,
         uint32_t                       count,
         const void*                    pValues,

--- a/include/ppx/grfx/vk/vk_command.h
+++ b/include/ppx/grfx/vk/vk_command.h
@@ -82,7 +82,7 @@ public:
         uint32_t                          setCount,
         const grfx::DescriptorSet* const* ppSets) override;
 
-    virtual void SetGraphicsPushConstants(
+    virtual void PushGraphicsConstants(
         const grfx::PipelineInterface* pInterface,
         uint32_t                       count,
         const void*                    pValues,
@@ -95,7 +95,7 @@ public:
         uint32_t                          setCount,
         const grfx::DescriptorSet* const* ppSets) override;
 
-    virtual void SetComputePushConstants(
+    virtual void PushComputeConstants(
         const grfx::PipelineInterface* pInterface,
         uint32_t                       count,
         const void*                    pValues,
@@ -181,7 +181,7 @@ private:
         uint32_t                          setCount,
         const grfx::DescriptorSet* const* ppSets);
 
-    void SetPushConstants(
+    void PushConstants(
         const grfx::PipelineInterface* pInterface,
         uint32_t                       count,
         const void*                    pValues,

--- a/projects/24_push_constants/PushConstants.cpp
+++ b/projects/24_push_constants/PushConstants.cpp
@@ -306,10 +306,10 @@ void PushConstantsApp::Render()
                 float4x4 M   = T * R;
                 float4x4 mat = P * V * M;
                 // Set MVP push constants
-                frame.cmd->SetGraphicsPushConstants(mPipelineInterface, 16, &mat);
+                frame.cmd->PushGraphicsConstants(mPipelineInterface, 16, &mat);
                 // Set texture index push constant at dstOffset=16
                 uint32_t textureIndex = 0;
-                frame.cmd->SetGraphicsPushConstants(mPipelineInterface, 1, &textureIndex, 16);
+                frame.cmd->PushGraphicsConstants(mPipelineInterface, 1, &textureIndex, 16);
             }
             frame.cmd->Draw(36, 1, 0, 0);
 
@@ -321,10 +321,10 @@ void PushConstantsApp::Render()
                 float4x4 M   = T * R;
                 float4x4 mat = P * V * M;
                 // Set MVP push constants
-                frame.cmd->SetGraphicsPushConstants(mPipelineInterface, 16, &mat);
+                frame.cmd->PushGraphicsConstants(mPipelineInterface, 16, &mat);
                 // Set texture index push constant at offset=16
                 uint32_t textureIndex = 1;
-                frame.cmd->SetGraphicsPushConstants(mPipelineInterface, 1, &textureIndex, 16);
+                frame.cmd->PushGraphicsConstants(mPipelineInterface, 1, &textureIndex, 16);
             }
             frame.cmd->Draw(36, 1, 0, 0);
 
@@ -336,10 +336,10 @@ void PushConstantsApp::Render()
                 float4x4 M   = T * R;
                 float4x4 mat = P * V * M;
                 // Set MVP push constants
-                frame.cmd->SetGraphicsPushConstants(mPipelineInterface, 16, &mat);
+                frame.cmd->PushGraphicsConstants(mPipelineInterface, 16, &mat);
                 // Set texture index push constant at offset=16
                 uint32_t textureIndex = 2;
-                frame.cmd->SetGraphicsPushConstants(mPipelineInterface, 1, &textureIndex, 16);
+                frame.cmd->PushGraphicsConstants(mPipelineInterface, 1, &textureIndex, 16);
             }
             frame.cmd->Draw(36, 1, 0, 0);
 

--- a/projects/26_push_descriptors/PushDescriptors.cpp
+++ b/projects/26_push_descriptors/PushDescriptors.cpp
@@ -17,12 +17,6 @@
 #include "ppx/graphics_util.h"
 using namespace ppx;
 
-#if defined(USE_VK)
-const grfx::Api kApi = grfx::API_VK_1_1;
-#else
-#error "This application requires Vulkan"
-#endif
-
 const uint32_t kUniformBufferStride = 256;
 
 struct DrawParams
@@ -34,7 +28,7 @@ void PushDescriptorsApp::Config(ppx::ApplicationSettings& settings)
 {
     settings.appName                    = "26_push_descriptors";
     settings.enableImGui                = true;
-    settings.grfx.api                   = kApi;
+    settings.grfx.api                   = grfx::API_VK_1_1;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
     settings.grfx.enableDebug           = false;
 }

--- a/src/ppx/grfx/dx12/dx12_command.cpp
+++ b/src/ppx/grfx/dx12/dx12_command.cpp
@@ -592,7 +592,7 @@ void CommandBuffer::BindGraphicsDescriptorSets(
     }
 }
 
-void CommandBuffer::SetGraphicsPushConstants(
+void CommandBuffer::PushGraphicsConstants(
     const grfx::PipelineInterface* pInterface,
     uint32_t                       count,
     const void*                    pValues,
@@ -643,7 +643,7 @@ void CommandBuffer::BindComputeDescriptorSets(
     }
 }
 
-void CommandBuffer::SetComputePushConstants(
+void CommandBuffer::PushComputeConstants(
     const grfx::PipelineInterface* pInterface,
     uint32_t                       count,
     const void*                    pValues,

--- a/src/ppx/grfx/vk/vk_command.cpp
+++ b/src/ppx/grfx/vk/vk_command.cpp
@@ -517,7 +517,7 @@ void CommandBuffer::BindGraphicsDescriptorSets(
     BindDescriptorSets(VK_PIPELINE_BIND_POINT_GRAPHICS, pInterface, setCount, ppSets);
 }
 
-void CommandBuffer::SetPushConstants(
+void CommandBuffer::PushConstants(
     const grfx::PipelineInterface* pInterface,
     uint32_t                       count,
     const void*                    pValues,
@@ -540,7 +540,7 @@ void CommandBuffer::SetPushConstants(
         pValues);
 }
 
-void CommandBuffer::SetGraphicsPushConstants(
+void CommandBuffer::PushGraphicsConstants(
     const grfx::PipelineInterface* pInterface,
     uint32_t                       count,
     const void*                    pValues,
@@ -553,7 +553,7 @@ void CommandBuffer::SetGraphicsPushConstants(
         PPX_ASSERT_MSG(false, "push constants shader visibility flags in pInterface does not have any graphics stages");
     }
 
-    SetPushConstants(pInterface, count, pValues, dstOffset);
+    PushConstants(pInterface, count, pValues, dstOffset);
 }
 
 void CommandBuffer::BindGraphicsPipeline(const grfx::GraphicsPipeline* pPipeline)
@@ -574,7 +574,7 @@ void CommandBuffer::BindComputeDescriptorSets(
     BindDescriptorSets(VK_PIPELINE_BIND_POINT_COMPUTE, pInterface, setCount, ppSets);
 }
 
-void CommandBuffer::SetComputePushConstants(
+void CommandBuffer::PushComputeConstants(
     const grfx::PipelineInterface* pInterface,
     uint32_t                       count,
     const void*                    pValues,
@@ -587,7 +587,7 @@ void CommandBuffer::SetComputePushConstants(
         PPX_ASSERT_MSG(false, "push constants shader visibility flags in pInterface does not have compute stage");
     }
 
-    SetPushConstants(pInterface, count, pValues, dstOffset);
+    PushConstants(pInterface, count, pValues, dstOffset);
 }
 
 void CommandBuffer::BindComputePipeline(const grfx::ComputePipeline* pPipeline)


### PR DESCRIPTION
This change list renames the Set*PushConstants to Push*Constants to match their push descriptor counterparts, which are all named Push*. This change list also contains a change for PushDescriptors.cpp that was accidentally left out of pr#237.

- Renamed SetGraphicsPushConstants to PushGraphicsConstants
- Renamed SetComputePushConstants to PushComputeConstants
- Removed API check for sample 26 since it's a Vulkan only sample.