### PR TITLE
Fix build for clang 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ else()
         -Wno-deprecated-copy \
         -Wno-deprecated-enum-enum-conversion \
         -Wno-pointer-bool-conversion \
+        -Wno-format-security \
     ")
 
     if (NOT PPX_BUILD_XR)


### PR DESCRIPTION
was getting errors like

```
/include/ppx/knob.h:361:21: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
        ImGui::Text(flagText.c_str());
```

on ubnutu 22.04

this fixes it and lets me build