### PR TITLE
Fix logging tests

### DIFF
--- a/src/test/log_console_test.cpp
+++ b/src/test/log_console_test.cpp
@@ -26,7 +26,12 @@ class LogTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        Log::Initialize(LOG_MODE_CONSOLE, nullptr, &mOut);
+        bool initialized = Log::Initialize(LOG_MODE_CONSOLE, nullptr, &mOut);
+        if (!initialized) {
+            // Shut down the existing logging to capture the log output in the stream.
+            Log::Shutdown();
+            Log::Initialize(LOG_MODE_CONSOLE, nullptr, &mOut);
+        }
         mOut.str(std::string());
         mOut.clear();
     }


### PR DESCRIPTION
Depending on the order of tests, logging tests can execute after other tests that log output. In those cases the tests can't capture and test the logging output. This adds a check and shuts down existing logging to be able to properly capture and test logging output.