### PR TITLE
Adding more flexible specifications for commandline parsing

### DIFF
--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -73,21 +73,21 @@ class CliOptions
 public:
     CliOptions() = default;
 
-    bool HasExtraOption(std::string_view option) const { return allOptions.contains(option); }
+    bool HasExtraOption(std::string_view option) const { return mAllOptions.contains(option); }
 
     // Returns the number of unique options and flags that were specified on the commandline,
     // not counting multiple appearances of the same flag such as: --assets-path a --assets-path b
-    size_t GetNumUniqueOptions() const { return allOptions.size(); }
+    size_t GetNumUniqueOptions() const { return mAllOptions.size(); }
 
-    // Try to parse option string into the type of the default value and return it.
+    // Tries to parse the option string into the type of the default value and return it.
     // If the value fails to be converted, return the specified default value.
     // Warning: If this is called instead of the vector overload for multiple-value flags,
     //          only the last value will be returned.
     template <typename T>
     T GetOptionValueOrDefault(std::string_view optionName, const T& defaultValue) const
     {
-        auto it = allOptions.find(optionName);
-        if (it == allOptions.cend()) {
+        auto it = mAllOptions.find(optionName);
+        if (it == mAllOptions.cend()) {
             return defaultValue;
         }
         auto valueStr = it->second.back();
@@ -99,8 +99,8 @@ public:
     template <typename T>
     std::vector<T> GetOptionValueOrDefault(std::string_view optionName, const std::vector<T>& defaultValues) const
     {
-        auto it = allOptions.find(optionName);
-        if (it == allOptions.cend()) {
+        auto it = mAllOptions.find(optionName);
+        if (it == mAllOptions.cend()) {
             return defaultValues;
         }
         std::vector<T> parsedValues;
@@ -131,7 +131,7 @@ private:
     // Adds new option if the option does not already exist
     // Otherwise, the new value is appended to the end of the vector of stored parameters for this option
     void
-    AddOption(std::string_view key, std::string_view value);
+    AddOption(std::string_view optionName, std::string_view value);
 
     template <typename T>
     T GetParsedOrDefault(std::string_view valueStr, const T& defaultValue) const
@@ -162,7 +162,7 @@ private:
 
 private:
     // All flag names (string) and parameters (vector of strings) specified on the command line
-    std::unordered_map<std::string_view, std::vector<std::string_view>> allOptions;
+    std::unordered_map<std::string_view, std::vector<std::string_view>> mAllOptions;
 
     friend class CommandLineParser;
 };

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -75,10 +75,14 @@ public:
 
     bool HasExtraOption(std::string_view option) const { return allOptions.contains(option); }
 
+    // Returns the number of unique options and flags that were specified on the commandline,
+    // not counting multiple appearances of the same flag such as: --assets-path a --assets-path b
     size_t GetNumUniqueOptions() const { return allOptions.size(); }
 
     // Try to parse option string into the type of the default value and return it.
     // If the value fails to be converted, return the specified default value.
+    // Warning: If this is called instead of the vector overload for multiple-value flags,
+    //          only the last value will be returned.
     template <typename T>
     T GetOptionValueOrDefault(std::string_view optionName, const T& defaultValue) const
     {
@@ -90,7 +94,8 @@ public:
         return GetParsedOrDefault<T>(valueStr, defaultValue);
     }
 
-    // Intended for list flags, specified on command line with multiple instances of the same flag
+    // Same as above, but intended for list flags that are specified on the command line
+    // with multiple instances of the same flag
     template <typename T>
     std::vector<T> GetOptionValueOrDefault(std::string_view optionName, const std::vector<T>& defaultValues) const
     {
@@ -106,7 +111,8 @@ public:
         return parsedValues;
     }
 
-    // Intended for resolution flags, specified on command line with <Width>x<Height>
+    // Same as above, but intended for resolution flags that are specified on command line
+    // with <Width>x<Height>
     std::pair<int, int> GetOptionValueOrDefault(std::string_view optionName, const std::pair<int, int>& defaultValue) const;
 
     // (WILL BE DEPRECATED, USE KNOBS INSTEAD)

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -21,6 +21,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
@@ -62,7 +63,7 @@ struct StandardOptions
 
 // All commandline flags are stored as key-value pairs (string, list of strings)
 // Value syntax:
-// - strings cannot contain "," or "="
+// - strings cannot contain "="
 // - boolean values stored as "0" "false" "1" "true"
 //
 // GetOptionValueOrDefault() can be used to access value of specified type.
@@ -72,85 +73,80 @@ class CliOptions
 public:
     CliOptions() = default;
 
-    bool HasExtraOption(const std::string& option) const
-    {
-        return allOptions.find(option) != allOptions.end();
-    }
+    bool HasExtraOption(std::string_view option) const { return allOptions.contains(option); }
 
-    size_t GetNumOptions() const { return allOptions.size(); }
+    size_t GetNumUniqueOptions() const { return allOptions.size(); }
 
     // Try to parse option string into the type of the default value and return it.
     // If the value fails to be converted, return the specified default value.
     template <typename T>
-    T GetOptionValueOrDefault(const std::string& optionName, const T& defaultValue) const
+    T GetOptionValueOrDefault(std::string_view optionName, const T& defaultValue) const
     {
-        if (allOptions.find(optionName) == allOptions.cend()) {
+        auto it = allOptions.find(optionName);
+        if (it == allOptions.cend()) {
             return defaultValue;
         }
-        auto valueStr = allOptions.at(optionName).back();
+        auto valueStr = it->second.back();
         return GetParsedOrDefault<T>(valueStr, defaultValue);
     }
 
-    // Intended for list flags, specified on command line with comma-separated parameters and/or multiple instances of same flag
-    template <typename T1>
-    std::vector<T1> GetOptionValueOrDefault(const std::string& optionName, const std::vector<T1>& defaultValues) const
+    // Intended for list flags, specified on command line with multiple instances of the same flag
+    template <typename T>
+    std::vector<T> GetOptionValueOrDefault(std::string_view optionName, const std::vector<T>& defaultValues) const
     {
-        if (allOptions.find(optionName) == allOptions.cend()) {
+        auto it = allOptions.find(optionName);
+        if (it == allOptions.cend()) {
             return defaultValues;
         }
-        std::vector<T1> values;
-        auto            valueList = allOptions.at(optionName);
-        T1              nullValue{};
-        for (size_t i = 0; i < valueList.size(); ++i) {
-            std::string valueStr = "";
-            values.emplace_back(GetParsedOrDefault<T1>(valueList[i], nullValue));
+        std::vector<T> parsedValues;
+        T              nullValue{};
+        for (size_t i = 0; i < it->second.size(); ++i) {
+            parsedValues.emplace_back(GetParsedOrDefault<T>(it->second.at(i), nullValue));
         }
-        return values;
+        return parsedValues;
     }
 
     // Intended for resolution flags, specified on command line with <Width>x<Height>
-    std::pair<int, int> GetOptionValueOrDefault(const std::string& optionName, const std::pair<int, int>& defaultValue) const;
+    std::pair<int, int> GetOptionValueOrDefault(std::string_view optionName, const std::pair<int, int>& defaultValue) const;
 
-    // (DEPRECATED)
+    // (WILL BE DEPRECATED, USE KNOBS INSTEAD)
     // Get the parameter value after converting it into the desired integral,
     // floating-point, or boolean type. If the value fails to be converted,
     // return the specified default value.
-    template <typename T2>
-    T2 GetExtraOptionValueOrDefault(const std::string& optionName, const T2& defaultValue) const
+    template <typename T>
+    T GetExtraOptionValueOrDefault(std::string_view optionName, const T& defaultValue) const
     {
-        static_assert(std::is_integral_v<T2> || std::is_floating_point_v<T2> || std::is_same_v<T2, std::string>, "GetExtraOptionValueOrDefault must be called with an integral, floating-point, boolean, or std::string type");
+        static_assert(std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, std::string>, "GetExtraOptionValueOrDefault must be called with an integral, floating-point, boolean, or std::string type");
 
-        return GetOptionValueOrDefault<T2>(optionName, defaultValue);
+        return GetOptionValueOrDefault<T>(optionName, defaultValue);
     }
 
 private:
-    // Add new option unless an option with this name already exists
+    // Adds new option if the option does not already exist
+    // Otherwise, the new value is appended to the end of the vector of stored parameters for this option
     void
-    AddOption(const std::string& key, const std::string& value);
+    AddOption(std::string_view key, std::string_view value);
 
-    template <typename T3>
-    T3 GetParsedOrDefault(const std::string& valueStr, const T3& defaultValue) const
+    template <typename T>
+    T GetParsedOrDefault(std::string_view valueStr, const T& defaultValue) const
     {
-        static_assert(std::is_integral_v<T3> || std::is_floating_point_v<T3> || std::is_same_v<T3, std::string>, "GetParsedOrDefault must be called with an integral, floating-point, boolean, or std::string type");
-        if constexpr (std::is_same_v<T3, std::string>) {
-            return valueStr == "" ? defaultValue : valueStr;
-        }
-        else if constexpr (std::is_same_v<T3, bool>) {
-            return GetParsedBoolOrDefault(valueStr, defaultValue);
-        }
-        return GetParsedNumberOrDefault<T3>(valueStr, defaultValue);
+        static_assert(std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, std::string>, "GetParsedOrDefault must be called with an integral, floating-point, boolean, or std::string type");
+        return Parse(valueStr, defaultValue);
     }
 
     // For boolean parameters
     //   interpreted as true: "true", 1, ""
     //   interpreted as false: "false", 0
-    bool GetParsedBoolOrDefault(const std::string& valueStr, bool defaultValue) const;
+    bool Parse(std::string_view valueStr, bool defaultValue) const;
 
-    template <typename T4>
-    T4 GetParsedNumberOrDefault(const std::string& valueStr, const T4 defaultValue) const
+    template <typename T>
+    T Parse(std::string_view valueStr, const T defaultValue) const
     {
-        std::stringstream ss{valueStr};
-        T4                valueAsNum;
+        if constexpr (std::is_same_v<T, std::string>) {
+            return static_cast<std::string>(valueStr);
+        }
+        std::stringstream ss{static_cast<std::string>(valueStr)};
+        T                 valueAsNum;
         ss >> valueAsNum;
         if (ss.fail()) {
             return defaultValue;
@@ -160,7 +156,7 @@ private:
 
 private:
     // All flag names (string) and parameters (vector of strings) specified on the command line
-    std::unordered_map<std::string, std::vector<std::string>> allOptions;
+    std::unordered_map<std::string_view, std::vector<std::string_view>> allOptions;
 
     friend class CommandLineParser;
 };
@@ -186,13 +182,11 @@ public:
     const StandardOptions&      GetStandardOptions() const { return mStandardOpts; }
     std::string                 GetUsageMsg() const { return mUsageMsg; }
     void                        AppendUsageMsg(const std::string& additionalMsg) { mUsageMsg += additionalMsg; }
-    bool                        GetPrintHelp() const { return mPrintHelp; }
 
 private:
     CliOptions      mOpts;
     StandardOptions mStandardOpts;
-    bool            mPrintHelp = false;
-    std::string     mUsageMsg  = R"(
+    std::string     mUsageMsg = R"(
 USAGE
 ==============================
 Boolean options can be turned on with:

--- a/include/ppx/string_util.h
+++ b/include/ppx/string_util.h
@@ -23,7 +23,8 @@ namespace string_util {
 void TrimLeft(std::string& s);
 void TrimRight(std::string& s);
 
-std::string TrimCopy(const std::string& s);
+std::string      TrimCopy(const std::string& s);
+std::string_view TrimBothEnds(std::string_view s, std::string_view c = " \t");
 
 } // namespace string_util
 } // namespace ppx

--- a/include/ppx/string_util.h
+++ b/include/ppx/string_util.h
@@ -16,6 +16,7 @@
 #define PPX_STRING_UTIL_H
 
 #include <string>
+#include <optional>
 
 namespace ppx {
 namespace string_util {
@@ -25,6 +26,10 @@ void TrimRight(std::string& s);
 
 std::string      TrimCopy(const std::string& s);
 std::string_view TrimBothEnds(std::string_view s, std::string_view c = " \t");
+
+// Splits s at the first instance of delimeter and returns two substrings
+// Returns std::nullopt if s does not contain the delimeter
+std::optional<std::pair<std::string_view, std::string_view>> SplitInTwo(std::string_view s, char delimiter);
 
 } // namespace string_util
 } // namespace ppx

--- a/include/ppx/string_util.h
+++ b/include/ppx/string_util.h
@@ -24,7 +24,9 @@ namespace string_util {
 void TrimLeft(std::string& s);
 void TrimRight(std::string& s);
 
-std::string      TrimCopy(const std::string& s);
+std::string TrimCopy(const std::string& s);
+
+// Trims all characters specified in c from both the left and right sides of s
 std::string_view TrimBothEnds(std::string_view s, std::string_view c = " \t");
 
 // Splits s at the first instance of delimeter and returns two substrings

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1029,7 +1029,7 @@ int Application::Run(int argc, char** argv)
         PPX_ASSERT_MSG(false, "Unable to parse command line arguments");
         return EXIT_FAILURE;
     }
-    mStandardOptions = mCommandLineParser.GetOptions().GetStandardOptions();
+    mStandardOptions = mCommandLineParser.GetStandardOptions();
 
     // Knobs need to be set up before commandline parsing.
     DispatchInitKnobs();
@@ -1038,7 +1038,7 @@ int Application::Run(int argc, char** argv)
         mCommandLineParser.AppendUsageMsg(mKnobManager.GetUsageMsg());
     }
 
-    if (mStandardOptions.help) {
+    if (mCommandLineParser.GetPrintHelp()) {
         PPX_LOG_INFO(mCommandLineParser.GetUsageMsg());
         return EXIT_SUCCESS;
     }
@@ -1676,7 +1676,7 @@ void Application::UpdateAppMetrics()
         const double     framerateSecondsDiff    = seconds - mMetrics.framerateRecordTimer;
         constexpr double FRAMERATE_RECORD_PERIOD = 1.0;
         if (framerateSecondsDiff >= FRAMERATE_RECORD_PERIOD) {
-            const double framerate = mMetrics.framerateFrameCount / framerateSecondsDiff;
+            const double        framerate     = mMetrics.framerateFrameCount / framerateSecondsDiff;
             metrics::MetricData framerateData = {metrics::MetricType::GAUGE};
             framerateData.gauge.seconds       = seconds;
             framerateData.gauge.value         = framerate;

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1038,7 +1038,7 @@ int Application::Run(int argc, char** argv)
         mCommandLineParser.AppendUsageMsg(mKnobManager.GetUsageMsg());
     }
 
-    if (mCommandLineParser.GetPrintHelp()) {
+    if (mCommandLineParser.GetOptions().GetOptionValueOrDefault("help", false)) {
         PPX_LOG_INFO(mCommandLineParser.GetUsageMsg());
         return EXIT_SUCCESS;
     }

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -37,6 +37,62 @@ bool IsOptionOrFlag(const std::string& s)
 
 namespace ppx {
 
+std::pair<int, int> CliOptions::GetOptionValueOrDefault(const std::string& optionName, const std::pair<int, int>& defaultValue) const
+{
+    if (allOptions.find(optionName) == allOptions.cend()) {
+        return defaultValue;
+    }
+    auto   valueStr = allOptions.at(optionName).back();
+    size_t xIndex   = valueStr.find("x");
+    if (xIndex == std::string::npos) {
+        // valueStr not in expected format "NxM"
+        return defaultValue;
+    }
+    std::string substringN = valueStr.substr(0, xIndex);
+    std::string substringM = valueStr.substr(xIndex + 1);
+    int         N          = GetParsedNumberOrDefault(substringN, defaultValue.first);
+    int         M          = GetParsedNumberOrDefault(substringM, defaultValue.second);
+    return std::make_pair(N, M);
+}
+
+void CliOptions::AddOption(const std::string& key, const std::string& valueStr)
+{
+    // If valueStr contains commas, split into separate elements to store
+    std::vector<std::string> elements;
+    std::string              remainingValueStr = valueStr;
+    std::string              elementSubstring;
+    size_t                   commaIndex = 0;
+    while (commaIndex != std::string::npos) {
+        commaIndex = remainingValueStr.find(",");
+        elements.push_back(remainingValueStr.substr(0, commaIndex));
+        remainingValueStr = remainingValueStr.substr(commaIndex + 1);
+    }
+
+    if (allOptions.find(key) != allOptions.cend()) {
+        allOptions[key].insert(allOptions[key].end(), elements.begin(), elements.end());
+        return;
+    }
+    allOptions.emplace(key, elements);
+}
+
+bool CliOptions::GetParsedBoolOrDefault(const std::string& valueStr, bool defaultValue) const
+{
+    if (valueStr == "") {
+        return true;
+    }
+    std::stringstream ss{valueStr};
+    bool              valueAsBool;
+    ss >> valueAsBool;
+    if (ss.fail()) {
+        ss.clear();
+        ss >> std::boolalpha >> valueAsBool;
+        if (ss.fail()) {
+            return defaultValue;
+        }
+    }
+    return valueAsBool;
+}
+
 std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc, const char* argv[])
 {
     // argc is always >= 1 and argv[0] is the name of the executable.
@@ -44,150 +100,67 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
         return std::nullopt;
     }
 
-    // Process arguments into either standalone flags or
-    // options with parameters.
-    std::vector<std::string>        args(argv + 1, argv + argc);
-    std::vector<CliOptions::Option> options;
+    // Split flag and parameters connected with '='
+    std::vector<std::string> args;
+    for (size_t i = 1; i < argc; ++i) {
+        std::string argString(argv[i]);
+        size_t      delimeterIndex = argString.find("=");
+        if (delimeterIndex == std::string::npos) {
+            args.emplace_back(argv[i]);
+            continue;
+        }
+        args.emplace_back(argString.substr(0, delimeterIndex));
+        args.emplace_back(argString.substr(delimeterIndex + 1));
+    }
+
+    // Process arguments into either standalone flags or options with parameters.
     for (size_t i = 0; i < args.size(); ++i) {
         std::string name = ppx::string_util::TrimCopy(args[i]);
         if (!IsOptionOrFlag(name)) {
             return "Invalid command-line option " + name;
         }
         name = name.substr(2);
+        if (name == "help") {
+            mPrintHelp = true;
+            return std::nullopt;
+        }
 
-        std::string parameter = (i + 1 < args.size()) ? ppx::string_util::TrimCopy(args[i + 1]) : "";
-        if (!IsOptionOrFlag(parameter)) {
+        std::string nextElem = (i + 1 < args.size()) ? ppx::string_util::TrimCopy(args[i + 1]) : "";
+        if (nextElem.size() > 0 && !IsOptionOrFlag(nextElem)) {
             // We found an option with a parameter.
-            options.emplace_back(name, parameter);
+            mOpts.AddOption(name, nextElem);
             ++i;
         }
+        else if (name.substr(0, 3) == "no-") {
+            // Option does not have a parameter, check if it has a no- prefix
+            mOpts.AddOption(name.substr(3), "0");
+        }
         else {
-            options.emplace_back(name, "");
+            // Option has no parameter, likely a boolean flag but do not assign "true"
+            // in case it is a non-boolean string flag that is missing a parameter
+            mOpts.AddOption(name, "");
         }
     }
 
-    for (const auto& opt : options) {
-        // Process standard options.
-        if (opt.GetName() == "assets-path") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --assets-path requires a parameter");
-            }
-            mOpts.standardOptions.assets_paths.push_back(opt.GetValueOrDefault<std::string>(""));
-        }
-        else if (opt.GetName() == "deterministic") {
-            mOpts.standardOptions.deterministic = opt.GetValueOrDefault<bool>(true);
-        }
-        else if (opt.GetName() == "enable-metrics") {
-            mOpts.standardOptions.enable_metrics = opt.GetValueOrDefault<bool>(true);
-        }
-        else if (opt.GetName() == "frame-count") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --frame-count requires a parameter");
-            }
-            mOpts.standardOptions.frame_count = opt.GetValueOrDefault<int>(0);
-        }
-        else if (opt.GetName() == "gpu") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --gpu requires a parameter");
-            }
-            mOpts.standardOptions.gpu_index = opt.GetValueOrDefault<int>(-1);
-            if (mOpts.standardOptions.gpu_index < 0) {
-                return std::string("Command-line option --gpu requires a positive integer as the parameter");
-            }
-        }
-        else if (opt.GetName() == "headless") {
-            mOpts.standardOptions.headless = opt.GetValueOrDefault<bool>(true);
-        }
-        else if (opt.GetName() == "help") {
-            mOpts.standardOptions.help = opt.GetValueOrDefault<bool>(true);
-        }
-        else if (opt.GetName() == "list-gpus") {
-            mOpts.standardOptions.list_gpus = opt.GetValueOrDefault<bool>(true);
-        }
-        else if (opt.GetName() == "metrics-filename") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --metrics-filename requires a parameter");
-            }
-            mOpts.standardOptions.metrics_filename = opt.GetValueOrDefault<std::string>("");
-        }
-        else if (opt.GetName() == "overwrite-metrics-file") {
-            mOpts.standardOptions.overwrite_metrics_file = opt.GetValueOrDefault<bool>(true);
-        }
-        else if (opt.GetName() == "resolution") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --resolution requires a parameter");
-            }
-
-            // Resolution is passed as <Width>x<Height>.
-            std::string       val = opt.GetValueOrDefault<std::string>("");
-            std::stringstream ss{val};
-            int               width = -1, height = -1;
-            char              x;
-            ss >> width >> x >> height;
-            if (ss.fail() || x != 'x') {
-                return std::string("Parameter for command-line option --resolution must be in <Width>x<Height> format, got " + val + " instead");
-            }
-            if (width < 1 || height < 1) {
-                return std::string("Parameter for command-line option --resolution must be in <Width>x<Height> format where Width and Height are integers greater or equal to 1");
-            }
-
-            mOpts.standardOptions.resolution = {width, height};
-        }
-        else if (opt.GetName() == "run-time-ms") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --run-time-ms requires a parameter");
-            }
-            mOpts.standardOptions.run_time_ms = opt.GetValueOrDefault<int>(0);
-        }
-        else if (opt.GetName() == "stats-frame-window") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --stats-frame-window requires a parameter");
-            }
-            mOpts.standardOptions.stats_frame_window = opt.GetValueOrDefault<uint32_t>(300);
-        }
-        else if (opt.GetName() == "screenshot-frame-number") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --screenshot-frame-number requires a parameter");
-            }
-            mOpts.standardOptions.screenshot_frame_number = opt.GetValueOrDefault<int>(-1);
-        }
-        else if (opt.GetName() == "screenshot-path") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --screenshot-path requires a parameter");
-            }
-            mOpts.standardOptions.screenshot_path = opt.GetValueOrDefault<std::string>("");
-        }
-        else if (opt.GetName() == "use-software-renderer") {
-            mOpts.standardOptions.use_software_renderer = opt.GetValueOrDefault<bool>(true);
-        }
+    // Fill out standard options.
+    mStandardOpts.assets_paths            = mOpts.GetOptionValueOrDefault("assets-path", mStandardOpts.assets_paths);
+    mStandardOpts.deterministic           = mOpts.GetOptionValueOrDefault("deterministic", mStandardOpts.deterministic);
+    mStandardOpts.enable_metrics          = mOpts.GetOptionValueOrDefault("enable-metrics", mStandardOpts.enable_metrics);
+    mStandardOpts.frame_count             = mOpts.GetOptionValueOrDefault("frame-count", mStandardOpts.frame_count);
+    mStandardOpts.gpu_index               = mOpts.GetOptionValueOrDefault("gpu", mStandardOpts.gpu_index);
+    mStandardOpts.headless                = mOpts.GetOptionValueOrDefault("headless", mStandardOpts.headless);
+    mStandardOpts.list_gpus               = mOpts.GetOptionValueOrDefault("list-gpus", mStandardOpts.list_gpus);
+    mStandardOpts.metrics_filename        = mOpts.GetOptionValueOrDefault("metrics-filename", mStandardOpts.metrics_filename);
+    mStandardOpts.overwrite_metrics_file  = mOpts.GetOptionValueOrDefault("overwrite-metrics-file", mStandardOpts.overwrite_metrics_file);
+    mStandardOpts.resolution              = mOpts.GetOptionValueOrDefault("resolution", mStandardOpts.resolution);
+    mStandardOpts.run_time_ms             = mOpts.GetOptionValueOrDefault("run-time-ms", mStandardOpts.run_time_ms);
+    mStandardOpts.stats_frame_window      = mOpts.GetOptionValueOrDefault("stats-frame-window", mStandardOpts.stats_frame_window);
+    mStandardOpts.screenshot_frame_number = mOpts.GetOptionValueOrDefault("screenshot-frame-number", mStandardOpts.screenshot_frame_number);
+    mStandardOpts.screenshot_path         = mOpts.GetOptionValueOrDefault("screenshot-path", mStandardOpts.screenshot_path);
+    mStandardOpts.use_software_renderer   = mOpts.GetOptionValueOrDefault("use-software-renderer", mStandardOpts.use_software_renderer);
 #if defined(PPX_BUILD_XR)
-        else if (opt.GetName() == "xr-ui-resolution") {
-            if (!opt.HasValue()) {
-                return std::string("Command-line option --xr-ui-resolution requires a parameter");
-            }
-
-            // Resolution is passed as <Width>x<Height>.
-            std::string       val = opt.GetValueOrDefault<std::string>("");
-            std::stringstream ss{val};
-            int               width = -1, height = -1;
-            char              x;
-            ss >> width >> x >> height;
-            if (ss.fail() || x != 'x') {
-                return std::string("Parameter for command-line option --xr-ui-resolution must be in <Width>x<Height> format, got " + val + " instead");
-            }
-            if (width < 1 || height < 1) {
-                return std::string("Parameter for command-line option --xr-ui-resolution must be in <Width>x<Height> format where Width and Height are integers greater or equal to 1");
-            }
-
-            mOpts.standardOptions.xrUIResolution = {width, height};
-        }
+    mStandardOpts.xrUIResolution = mOpts.GetOptionValueOrDefault("xr-ui-resolution", mStandardOpts.xrUIResolution);
 #endif
-        else {
-            // Non-standard option.
-            mOpts.AddExtraOption(opt);
-        }
-    }
-
     return std::nullopt;
 }
 

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -39,8 +39,8 @@ namespace ppx {
 
 std::pair<int, int> CliOptions::GetOptionValueOrDefault(std::string_view optionName, const std::pair<int, int>& defaultValue) const
 {
-    auto it = allOptions.find(optionName);
-    if (it == allOptions.cend()) {
+    auto it = mAllOptions.find(optionName);
+    if (it == mAllOptions.cend()) {
         return defaultValue;
     }
     auto valueStr = it->second.back();
@@ -54,12 +54,12 @@ std::pair<int, int> CliOptions::GetOptionValueOrDefault(std::string_view optionN
     return std::make_pair(N, M);
 }
 
-void CliOptions::AddOption(std::string_view key, std::string_view valueStr)
+void CliOptions::AddOption(std::string_view optionName, std::string_view valueStr)
 {
-    auto it = allOptions.find(key);
-    if (it == allOptions.cend()) {
+    auto it = mAllOptions.find(optionName);
+    if (it == mAllOptions.cend()) {
         std::vector<std::string_view> v{valueStr};
-        allOptions.emplace(key, v);
+        mAllOptions.emplace(optionName, v);
         return;
     }
     it->second.push_back(valueStr);
@@ -77,6 +77,7 @@ bool CliOptions::Parse(std::string_view valueStr, bool defaultValue) const
         ss.clear();
         ss >> std::boolalpha >> valueAsBool;
         if (ss.fail()) {
+            PPX_LOG_ERROR("could not be parsed as bool: " << valueStr);
             return defaultValue;
         }
     }

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -70,7 +70,7 @@ bool CliOptions::Parse(std::string_view valueStr, bool defaultValue) const
     if (valueStr == "") {
         return true;
     }
-    std::stringstream ss{static_cast<std::string>(valueStr)};
+    std::stringstream ss{std::string(valueStr)};
     bool              valueAsBool;
     ss >> valueAsBool;
     if (ss.fail()) {
@@ -85,7 +85,7 @@ bool CliOptions::Parse(std::string_view valueStr, bool defaultValue) const
 
 std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc, const char* argv[])
 {
-    // argc is always >= 1 and argv[0] is the name of the executable.
+    // argc should be >= 1 and argv[0] the name of the executable.
     if (argc < 2) {
         return std::nullopt;
     }
@@ -99,8 +99,11 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
             args.emplace_back(argString);
             continue;
         }
-        if (res->second.find('=') != std::string_view::npos) {
-            return "Unexpected number of '=' symbols in following string: \"" + static_cast<std::string>(argString) + "\"";
+        if (res->first.empty() || res->second.empty()) {
+            return "Malformed flag with '=': \"" + std::string(argString) + "\"";
+        }
+        else if (res->second.find('=') != std::string_view::npos) {
+            return "Unexpected number of '=' symbols in the following string: \"" + std::string(argString) + "\"";
         }
         args.emplace_back(res->first);
         args.emplace_back(res->second);
@@ -110,7 +113,7 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
     for (size_t i = 0; i < args.size(); ++i) {
         std::string_view name = ppx::string_util::TrimBothEnds(args[i]);
         if (!StartsWithDoubleDash(name)) {
-            return "Invalid command-line option: \"" + static_cast<std::string>(name) + "\"";
+            return "Invalid command-line option: \"" + std::string(name) + "\"";
         }
         name = name.substr(2);
 

--- a/src/ppx/string_util.cpp
+++ b/src/ppx/string_util.cpp
@@ -56,7 +56,7 @@ std::string_view TrimBothEnds(std::string_view s, std::string_view c)
 
 std::optional<std::pair<std::string_view, std::string_view>> SplitInTwo(std::string_view s, char delimiter)
 {
-    if (s.size() == 0 || delimiter == '\0') {
+    if (s.size() == 0) {
         return std::nullopt;
     }
     size_t delimeterIndex = s.find(delimiter);

--- a/src/ppx/string_util.cpp
+++ b/src/ppx/string_util.cpp
@@ -48,10 +48,24 @@ std::string_view TrimBothEnds(std::string_view s, std::string_view c)
     if (s.size() == 0) {
         return s;
     }
-    const auto strBegin = s.find_first_not_of(c);
-    const auto strEnd   = s.find_last_not_of(c);
-    const auto strRange = strEnd - strBegin + 1;
+    auto strBegin = s.find_first_not_of(c);
+    auto strEnd   = s.find_last_not_of(c);
+    auto strRange = strEnd - strBegin + 1;
     return s.substr(strBegin, strRange);
+}
+
+std::optional<std::pair<std::string_view, std::string_view>> SplitInTwo(std::string_view s, char delimiter)
+{
+    if (s.size() == 0 || delimiter == '\0') {
+        return std::nullopt;
+    }
+    size_t delimeterIndex = s.find(delimiter);
+    if (delimeterIndex == std::string_view::npos) {
+        return std::nullopt;
+    }
+    std::string_view firstSubstring  = s.substr(0, delimeterIndex);
+    std::string_view secondSubstring = s.substr(delimeterIndex + 1);
+    return std::make_pair(firstSubstring, secondSubstring);
 }
 
 } // namespace string_util

--- a/src/ppx/string_util.cpp
+++ b/src/ppx/string_util.cpp
@@ -43,5 +43,16 @@ std::string TrimCopy(const std::string& s)
     return sc;
 }
 
+std::string_view TrimBothEnds(std::string_view s, std::string_view c)
+{
+    if (s.size() == 0) {
+        return s;
+    }
+    const auto strBegin = s.find_first_not_of(c);
+    const auto strEnd   = s.find_last_not_of(c);
+    const auto strRange = strEnd - strBegin + 1;
+    return s.substr(strBegin, strRange);
+}
+
 } // namespace string_util
 } // namespace ppx

--- a/src/test/command_line_parser_test.cpp
+++ b/src/test/command_line_parser_test.cpp
@@ -27,8 +27,8 @@ TEST(CommandLineParserTest, ZeroArguments)
     CommandLineParser parser;
     StandardOptions   defaultOptions;
     EXPECT_FALSE(parser.Parse(0, nullptr));
-    EXPECT_EQ(parser.GetOptions().GetStandardOptions(), defaultOptions);
-    EXPECT_EQ(parser.GetOptions().GetNumExtraOptions(), 0);
+    EXPECT_EQ(parser.GetStandardOptions(), defaultOptions);
+    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 0);
 }
 
 TEST(CommandLineParserTest, FirstArgumentIgnored)
@@ -36,19 +36,18 @@ TEST(CommandLineParserTest, FirstArgumentIgnored)
     CommandLineParser parser;
     StandardOptions   defaultOptions;
     const char*       args[] = {"/path/to/executable"};
-    EXPECT_FALSE(parser.Parse(1, args));
-    EXPECT_EQ(parser.GetOptions().GetStandardOptions(), defaultOptions);
-    EXPECT_EQ(parser.GetOptions().GetNumExtraOptions(), 0);
+    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
+    EXPECT_EQ(parser.GetStandardOptions(), defaultOptions);
+    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 0);
 }
 
 TEST(CommandLineParserTest, StandardOptionsSuccessfullyParsed)
 {
     CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--help", "--list-gpus", "--gpu", "5", "--resolution", "1920x1080", "--frame-count", "11", "--use-software-renderer", "--screenshot-frame-number", "321", "--screenshot-path", "/path/to/screenshot/dir/filename"};
-    EXPECT_FALSE(parser.Parse(14, args));
+    const char*       args[] = {"/path/to/executable", "--list-gpus", "--gpu", "5", "--resolution", "1920x1080", "--frame-count", "11", "--use-software-renderer", "--screenshot-frame-number", "321", "--screenshot-path", "/path/to/screenshot/dir/filename"};
+    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
 
     StandardOptions wantOptions;
-    wantOptions.help                    = true;
     wantOptions.list_gpus               = true;
     wantOptions.gpu_index               = 5;
     wantOptions.resolution              = {1920, 1080};
@@ -57,8 +56,58 @@ TEST(CommandLineParserTest, StandardOptionsSuccessfullyParsed)
     wantOptions.screenshot_frame_number = 321;
     wantOptions.screenshot_path         = "/path/to/screenshot/dir/filename";
 
-    EXPECT_EQ(parser.GetOptions().GetStandardOptions(), wantOptions);
-    EXPECT_EQ(parser.GetOptions().GetNumExtraOptions(), 0);
+    EXPECT_EQ(parser.GetStandardOptions(), wantOptions);
+    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 7);
+}
+
+TEST(CommandLineParserTest, MixedEqualSignsAllowed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--list-gpus", "--gpu=5", "--resolution=1920x1080", "--frame-count", "11", "--use-software-renderer", "--screenshot-frame-number=321", "--screenshot-path=/path/to/screenshot/dir/filename"};
+    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
+
+    StandardOptions wantOptions;
+    wantOptions.list_gpus               = true;
+    wantOptions.gpu_index               = 5;
+    wantOptions.resolution              = {1920, 1080};
+    wantOptions.frame_count             = 11;
+    wantOptions.use_software_renderer   = true;
+    wantOptions.screenshot_frame_number = 321;
+    wantOptions.screenshot_path         = "/path/to/screenshot/dir/filename";
+
+    EXPECT_EQ(parser.GetStandardOptions(), wantOptions);
+    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 7);
+}
+
+TEST(CommandLineParserTest, BooleansSuccessfullyParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--list-gpus", "--deterministic", "1", "--enable-metrics", "true", "--no-use-software-renderer", "--headless", "0", "--overwrite_metrics_file", "false"};
+    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
+
+    StandardOptions wantOptions;
+    wantOptions.list_gpus              = true;
+    wantOptions.deterministic          = true;
+    wantOptions.enable_metrics         = true;
+    wantOptions.use_software_renderer  = false;
+    wantOptions.headless               = false;
+    wantOptions.overwrite_metrics_file = false;
+
+    EXPECT_EQ(parser.GetStandardOptions(), wantOptions);
+    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 6);
+}
+
+TEST(CommandLineParserTest, LastValueIsTaken)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--gpu", "1", "--gpu", "2", "--gpu", "3"};
+    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
+
+    StandardOptions wantOptions;
+    wantOptions.gpu_index = 3;
+
+    EXPECT_EQ(parser.GetStandardOptions(), wantOptions);
+    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 1);
 }
 
 TEST(CommandLineParserTest, ExtraOptionsSuccessfullyParsed)
@@ -66,11 +115,11 @@ TEST(CommandLineParserTest, ExtraOptionsSuccessfullyParsed)
     CommandLineParser parser;
     StandardOptions   defaultOptions;
     const char*       args[] = {"/path/to/executable", "--extra-option-bool", "true", "--extra-option-int", "123", "--extra-option-no-param", "--extra-option-str", "option string value"};
-    EXPECT_FALSE(parser.Parse(8, args));
+    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
 
     auto opts = parser.GetOptions();
-    EXPECT_EQ(opts.GetStandardOptions(), defaultOptions);
-    EXPECT_EQ(opts.GetNumExtraOptions(), 4);
+    EXPECT_EQ(parser.GetStandardOptions(), defaultOptions);
+    EXPECT_EQ(opts.GetNumOptions(), 4);
     EXPECT_EQ(opts.GetExtraOptionValueOrDefault("extra-option-bool", false), true);
     EXPECT_EQ(opts.GetExtraOptionValueOrDefault("extra-option-int", 0), 123);
     EXPECT_EQ(opts.GetExtraOptionValueOrDefault<std::string>("extra-option-str", ""), "option string value");
@@ -78,48 +127,21 @@ TEST(CommandLineParserTest, ExtraOptionsSuccessfullyParsed)
     EXPECT_TRUE(opts.HasExtraOption("extra-option-no-param"));
 }
 
-TEST(CommandLineParserTest, StandardOptionsParsingErrorMissingParameter)
-{
-    CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--gpu"};
-    auto              error  = parser.Parse(2, args);
-    EXPECT_TRUE(error.has_value());
-
-    EXPECT_THAT(error->errorMsg, HasSubstr("requires a parameter"));
-}
-
-TEST(CommandLineParserTest, StandardOptionsParsingErrorInvalidParameterNegativeInteger)
-{
-    CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--gpu", "-5"};
-    auto              error  = parser.Parse(3, args);
-    EXPECT_TRUE(error.has_value());
-
-    EXPECT_THAT(error->errorMsg, HasSubstr("requires a positive integer"));
-}
-
-TEST(CommandLineParserTest, StandardOptionsParsingErrorInvalidParameterResolution)
-{
-    CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--resolution", "1920-1080"};
-    auto              error  = parser.Parse(3, args);
-    EXPECT_TRUE(error.has_value());
-
-    EXPECT_THAT(error->errorMsg, HasSubstr("must be in <Width>x<Height> format"));
-}
-
 TEST(CommandLineParserTest, StandardOptionsParsingMultipleAssets)
 {
     CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--assets-path", "some-path", "--assets-path", "some-other-path"};
+    const char*       args[] = {"/path/to/executable", "--assets-path", "some-path", "--assets-path", "some-other-path,some-other-path-2,some-other-path-3", "--assets-path", "last-path"};
 
     EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
     auto opts = parser.GetOptions();
 
-    const auto& paths = parser.GetOptions().GetStandardOptions().assets_paths;
-    EXPECT_EQ(paths.size(), 2);
+    const auto& paths = parser.GetStandardOptions().assets_paths;
+    EXPECT_EQ(paths.size(), 5);
     EXPECT_EQ(paths[0], "some-path");
     EXPECT_EQ(paths[1], "some-other-path");
+    EXPECT_EQ(paths[2], "some-other-path-2");
+    EXPECT_EQ(paths[3], "some-other-path-3");
+    EXPECT_EQ(paths[4], "last-path");
 }
 
 } // namespace

--- a/src/test/command_line_parser_test.cpp
+++ b/src/test/command_line_parser_test.cpp
@@ -26,9 +26,11 @@ TEST(CommandLineParserTest, ZeroArguments)
 {
     CommandLineParser parser;
     StandardOptions   defaultOptions;
-    EXPECT_FALSE(parser.Parse(0, nullptr));
+    if (auto error = parser.Parse(0, nullptr)) {
+        FAIL() << error->errorMsg;
+    }
     EXPECT_EQ(parser.GetStandardOptions(), defaultOptions);
-    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 0);
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 0);
 }
 
 TEST(CommandLineParserTest, FirstArgumentIgnored)
@@ -36,78 +38,233 @@ TEST(CommandLineParserTest, FirstArgumentIgnored)
     CommandLineParser parser;
     StandardOptions   defaultOptions;
     const char*       args[] = {"/path/to/executable"};
-    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
     EXPECT_EQ(parser.GetStandardOptions(), defaultOptions);
-    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 0);
-}
-
-TEST(CommandLineParserTest, StandardOptionsSuccessfullyParsed)
-{
-    CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--list-gpus", "--gpu", "5", "--resolution", "1920x1080", "--frame-count", "11", "--use-software-renderer", "--screenshot-frame-number", "321", "--screenshot-path", "/path/to/screenshot/dir/filename"};
-    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
-
-    StandardOptions wantOptions;
-    wantOptions.list_gpus               = true;
-    wantOptions.gpu_index               = 5;
-    wantOptions.resolution              = {1920, 1080};
-    wantOptions.frame_count             = 11;
-    wantOptions.use_software_renderer   = true;
-    wantOptions.screenshot_frame_number = 321;
-    wantOptions.screenshot_path         = "/path/to/screenshot/dir/filename";
-
-    EXPECT_EQ(parser.GetStandardOptions(), wantOptions);
-    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 7);
-}
-
-TEST(CommandLineParserTest, MixedEqualSignsAllowed)
-{
-    CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--list-gpus", "--gpu=5", "--resolution=1920x1080", "--frame-count", "11", "--use-software-renderer", "--screenshot-frame-number=321", "--screenshot-path=/path/to/screenshot/dir/filename"};
-    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
-
-    StandardOptions wantOptions;
-    wantOptions.list_gpus               = true;
-    wantOptions.gpu_index               = 5;
-    wantOptions.resolution              = {1920, 1080};
-    wantOptions.frame_count             = 11;
-    wantOptions.use_software_renderer   = true;
-    wantOptions.screenshot_frame_number = 321;
-    wantOptions.screenshot_path         = "/path/to/screenshot/dir/filename";
-
-    EXPECT_EQ(parser.GetStandardOptions(), wantOptions);
-    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 7);
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 0);
 }
 
 TEST(CommandLineParserTest, BooleansSuccessfullyParsed)
 {
     CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--list-gpus", "--deterministic", "1", "--enable-metrics", "true", "--no-use-software-renderer", "--headless", "0", "--overwrite_metrics_file", "false"};
-    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
+    const char*       args[] = {"/path/to/executable", "--a", "--b", "1", "--c", "true", "--no-d", "--e", "0", "--f", "false"};
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
+    CliOptions gotOptions = parser.GetOptions();
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 6);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<bool>("a", false), true);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<bool>("b", false), true);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<bool>("c", false), true);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<bool>("d", true), false);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<bool>("e", true), false);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<bool>("f", true), false);
+}
 
-    StandardOptions wantOptions;
-    wantOptions.list_gpus              = true;
-    wantOptions.deterministic          = true;
-    wantOptions.enable_metrics         = true;
-    wantOptions.use_software_renderer  = false;
-    wantOptions.headless               = false;
-    wantOptions.overwrite_metrics_file = false;
+TEST(CommandLineParserTest, StringsSuccessfullyParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--a", "filename with spaces", "--b", "filenameWithoutSpaces", "--c", "filename,with/.punctuation,", "--d", "", "--e"};
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
+    CliOptions gotOptions = parser.GetOptions();
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 5);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<std::string>("a", ""), "filename with spaces");
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<std::string>("b", ""), "filenameWithoutSpaces");
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<std::string>("c", ""), "filename,with/.punctuation,");
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<std::string>("d", "foo"), "");
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<std::string>("e", "foo"), "");
+}
 
-    EXPECT_EQ(parser.GetStandardOptions(), wantOptions);
-    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 6);
+TEST(CommandLineParserTest, IntegersSuccessfullyParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--a", "0", "--b", "-5", "--c", "300", "--d", "0", "--e", "1000"};
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
+    CliOptions gotOptions = parser.GetOptions();
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 5);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("a", -1), 0);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("b", -1), -5);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("c", -1), 300);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("d", -1), 0);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("e", -1), 1000);
+}
+
+TEST(CommandLineParserTest, FloatsSuccessfullyParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--a", "1.0", "--b", "-6.5", "--c", "300"};
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
+    CliOptions gotOptions = parser.GetOptions();
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 3);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<float>("a", 0.0f), 1.0f);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<float>("b", 0.0f), -6.5f);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<float>("c", 0.0f), 300.0f);
+}
+
+TEST(CommandLineParserTest, StringListSuccesfullyParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--a", "some-path", "--a", "some-other-path", "--a", "last-path"};
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
+    CliOptions gotOptions = parser.GetOptions();
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 1);
+    auto paths = gotOptions.GetOptionValueOrDefault<std::string>("a", {"a-path"});
+    EXPECT_EQ(paths.size(), 3);
+    if (paths.size() == 3) {
+        EXPECT_EQ(paths[0], "some-path");
+        EXPECT_EQ(paths[1], "some-other-path");
+        EXPECT_EQ(paths[2], "last-path");
+    }
+}
+
+TEST(CommandLineParserTest, ResolutionSuccesfullyParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--a", "1000x2000"};
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
+    CliOptions gotOptions = parser.GetOptions();
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 1);
+    auto res = gotOptions.GetOptionValueOrDefault("a", std::make_pair(0, 0));
+    EXPECT_EQ(res.first, 1000);
+    EXPECT_EQ(res.second, 2000);
+}
+
+TEST(CommandLineParserTest, ResolutionSuccessfullyParsedButDefaulted)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--a", "1000X2000"};
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
+    CliOptions gotOptions = parser.GetOptions();
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 1);
+    auto res = gotOptions.GetOptionValueOrDefault("a", std::make_pair(0, 0));
+    EXPECT_EQ(res.first, 0);
+    EXPECT_EQ(res.second, 0);
+}
+
+TEST(CommandLineParserTest, EqualSignsSuccessfullyParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--a", "--b=5", "--c", "--d", "11"};
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
+    CliOptions gotOptions = parser.GetOptions();
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 4);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<bool>("a", false), true);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("b", 0), 5);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<bool>("c", false), true);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("d", 0), 11);
+}
+
+TEST(CommandLineParserTest, EqualSignsFailedParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--a", "--b=5=8", "--c", "--d", "11"};
+    auto              error  = parser.Parse(sizeof(args) / sizeof(args[0]), args);
+    EXPECT_TRUE(error);
+    EXPECT_THAT(error->errorMsg, HasSubstr("Unexpected number of '=' symbols in following string"));
+}
+
+TEST(CommandLineParserTest, LeadingParameterFailedParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "10", "--a", "--b", "5", "--c", "--d", "11"};
+    auto              error  = parser.Parse(sizeof(args) / sizeof(args[0]), args);
+    EXPECT_TRUE(error);
+    EXPECT_THAT(error->errorMsg, HasSubstr("Invalid command-line option"));
+}
+
+TEST(CommandLineParserTest, AdjacentParameterFailedParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--a", "--b", "5", "8", "--c", "--d", "11"};
+    auto              error  = parser.Parse(sizeof(args) / sizeof(args[0]), args);
+    EXPECT_TRUE(error);
+    EXPECT_THAT(error->errorMsg, HasSubstr("Invalid command-line option"));
 }
 
 TEST(CommandLineParserTest, LastValueIsTaken)
 {
     CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--gpu", "1", "--gpu", "2", "--gpu", "3"};
-    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
+    const char*       args[] = {"/path/to/executable", "--a", "1", "--b", "1", "--a", "2", "--a", "3"};
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
+    CliOptions gotOptions = parser.GetOptions();
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 2);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("a", 0), 3);
+    EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("b", 0), 1);
+}
 
-    StandardOptions wantOptions;
-    wantOptions.gpu_index = 3;
-
-    EXPECT_EQ(parser.GetStandardOptions(), wantOptions);
-    EXPECT_EQ(parser.GetOptions().GetNumOptions(), 1);
+TEST(CommandLineParserTest, StandardOptionsSuccessfullyParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {
+        "/path/to/executable",
+        "--list-gpus",
+        "--deterministic",
+        "1",
+        "--enable-metrics",
+        "true",
+        "--no-use-software-renderer",
+        "--headless",
+        "0",
+        "--overwrite_metrics_file",
+        "false",
+        "--metrics-filename",
+        "filename with spaces",
+        "--screenshot-path",
+        "filenameWithoutSpaces",
+        "--frame-count",
+        "0",
+        "--gpu",
+        "5",
+        "--run-time-ms",
+        "300",
+        "--screenshot-frame-number",
+        "0",
+        "--stats-frame-window",
+        "1000",
+        "--assets-path",
+        "foo1",
+        "--assets-path",
+        "foo2",
+        "--resolution",
+        "100x200"};
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
+    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 15);
+    StandardOptions gotStandardOptions = parser.GetStandardOptions();
+    EXPECT_EQ(gotStandardOptions.list_gpus, true);
+    EXPECT_EQ(gotStandardOptions.deterministic, true);
+    EXPECT_EQ(gotStandardOptions.enable_metrics, true);
+    EXPECT_EQ(gotStandardOptions.use_software_renderer, false);
+    EXPECT_EQ(gotStandardOptions.headless, false);
+    EXPECT_EQ(gotStandardOptions.overwrite_metrics_file, false);
+    EXPECT_EQ(gotStandardOptions.metrics_filename, "filename with spaces");
+    EXPECT_EQ(gotStandardOptions.screenshot_path, "filenameWithoutSpaces");
+    EXPECT_EQ(gotStandardOptions.frame_count, 0);
+    EXPECT_EQ(gotStandardOptions.gpu_index, 5);
+    EXPECT_EQ(gotStandardOptions.run_time_ms, 300);
+    EXPECT_EQ(gotStandardOptions.screenshot_frame_number, 0);
+    EXPECT_EQ(gotStandardOptions.stats_frame_window, 1000);
+    std::vector<std::string> assetsPaths{"foo1", "foo2"};
+    EXPECT_EQ(gotStandardOptions.assets_paths, assetsPaths);
+    EXPECT_EQ(gotStandardOptions.resolution, std::make_pair(100, 200));
 }
 
 TEST(CommandLineParserTest, ExtraOptionsSuccessfullyParsed)
@@ -115,33 +272,17 @@ TEST(CommandLineParserTest, ExtraOptionsSuccessfullyParsed)
     CommandLineParser parser;
     StandardOptions   defaultOptions;
     const char*       args[] = {"/path/to/executable", "--extra-option-bool", "true", "--extra-option-int", "123", "--extra-option-no-param", "--extra-option-str", "option string value"};
-    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
-
+    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+        FAIL() << error->errorMsg;
+    }
     auto opts = parser.GetOptions();
     EXPECT_EQ(parser.GetStandardOptions(), defaultOptions);
-    EXPECT_EQ(opts.GetNumOptions(), 4);
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 4);
     EXPECT_EQ(opts.GetExtraOptionValueOrDefault("extra-option-bool", false), true);
     EXPECT_EQ(opts.GetExtraOptionValueOrDefault("extra-option-int", 0), 123);
     EXPECT_EQ(opts.GetExtraOptionValueOrDefault<std::string>("extra-option-str", ""), "option string value");
     EXPECT_EQ(opts.GetExtraOptionValueOrDefault<std::string>("extra-option-no-param", ""), "");
     EXPECT_TRUE(opts.HasExtraOption("extra-option-no-param"));
-}
-
-TEST(CommandLineParserTest, StandardOptionsParsingMultipleAssets)
-{
-    CommandLineParser parser;
-    const char*       args[] = {"/path/to/executable", "--assets-path", "some-path", "--assets-path", "some-other-path,some-other-path-2,some-other-path-3", "--assets-path", "last-path"};
-
-    EXPECT_FALSE(parser.Parse(sizeof(args) / sizeof(args[0]), args));
-    auto opts = parser.GetOptions();
-
-    const auto& paths = parser.GetStandardOptions().assets_paths;
-    EXPECT_EQ(paths.size(), 5);
-    EXPECT_EQ(paths[0], "some-path");
-    EXPECT_EQ(paths[1], "some-other-path");
-    EXPECT_EQ(paths[2], "some-other-path-2");
-    EXPECT_EQ(paths[3], "some-other-path-3");
-    EXPECT_EQ(paths[4], "last-path");
 }
 
 } // namespace

--- a/src/test/command_line_parser_test.cpp
+++ b/src/test/command_line_parser_test.cpp
@@ -169,13 +169,22 @@ TEST(CommandLineParserTest, EqualSignsSuccessfullyParsed)
     EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("d", 0), 11);
 }
 
-TEST(CommandLineParserTest, EqualSignsFailedParsed)
+TEST(CommandLineParserTest, EqualSignsMultipleFailedParsed)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "--b=5=8", "--c", "--d", "11"};
     auto              error  = parser.Parse(sizeof(args) / sizeof(args[0]), args);
     EXPECT_TRUE(error);
-    EXPECT_THAT(error->errorMsg, HasSubstr("Unexpected number of '=' symbols in following string"));
+    EXPECT_THAT(error->errorMsg, HasSubstr("Unexpected number of '=' symbols in the following string"));
+}
+
+TEST(CommandLineParserTest, EqualSignsMalformedFailedParsed)
+{
+    CommandLineParser parser;
+    const char*       args[] = {"/path/to/executable", "--a", "--b=", "--c", "--d", "11"};
+    auto              error  = parser.Parse(sizeof(args) / sizeof(args[0]), args);
+    EXPECT_TRUE(error);
+    EXPECT_THAT(error->errorMsg, HasSubstr("Malformed flag with '='"));
 }
 
 TEST(CommandLineParserTest, LeadingParameterFailedParsed)

--- a/src/test/string_util_test.cpp
+++ b/src/test/string_util_test.cpp
@@ -53,3 +53,51 @@ TEST(StringUtilTest, TrimCopyLeftAndRightSpaces)
     EXPECT_EQ(trimmed, "Some spaces");
     EXPECT_EQ(toTrim, "  Some spaces  ");
 }
+
+TEST(StringUtilTest, TrimBothEndsNothingToTrim)
+{
+    std::string_view toTrim  = "No spaces";
+    std::string_view trimmed = TrimBothEnds(toTrim);
+    EXPECT_EQ(trimmed, "No spaces");
+    EXPECT_EQ(toTrim, "No spaces");
+}
+
+TEST(StringUtilTest, TrimBothEndsLeftAndRightSpaces)
+{
+    std::string_view toTrim  = "  Some spaces  ";
+    std::string_view trimmed = TrimBothEnds(toTrim);
+    EXPECT_EQ(trimmed, "Some spaces");
+    EXPECT_EQ(toTrim, "  Some spaces  ");
+}
+
+TEST(StringUtilTest, SplitInTwoEmptyString)
+{
+    std::string_view toSplit = "";
+    auto             res     = SplitInTwo(toSplit, ',');
+    EXPECT_EQ(res, std::nullopt);
+}
+
+TEST(StringUtilTest, SplitInTwoNullDelimiter)
+{
+    std::string_view toSplit = "Apple,Banana";
+    auto             res     = SplitInTwo(toSplit, '\0');
+    EXPECT_EQ(res, std::nullopt);
+}
+
+TEST(StringUtilTest, SplitInTwoOneDelimiter)
+{
+    std::string_view toSplit = "Apple,Banana";
+    auto             res     = SplitInTwo(toSplit, ',');
+    EXPECT_NE(res, std::nullopt);
+    EXPECT_EQ(res->first, "Apple");
+    EXPECT_EQ(res->second, "Banana");
+}
+
+TEST(StringUtilTest, SplitInTwoMultipleDelimiter)
+{
+    std::string_view toSplit = "Apple,Banana,Orange";
+    auto             res     = SplitInTwo(toSplit, ',');
+    EXPECT_NE(res, std::nullopt);
+    EXPECT_EQ(res->first, "Apple");
+    EXPECT_EQ(res->second, "Banana,Orange");
+}

--- a/src/test/string_util_test.cpp
+++ b/src/test/string_util_test.cpp
@@ -77,13 +77,6 @@ TEST(StringUtilTest, SplitInTwoEmptyString)
     EXPECT_EQ(res, std::nullopt);
 }
 
-TEST(StringUtilTest, SplitInTwoNullDelimiter)
-{
-    std::string_view toSplit = "Apple,Banana";
-    auto             res     = SplitInTwo(toSplit, '\0');
-    EXPECT_EQ(res, std::nullopt);
-}
-
 TEST(StringUtilTest, SplitInTwoOneDelimiter)
 {
     std::string_view toSplit = "Apple,Banana";


### PR DESCRIPTION
* Changed CliOptions implementation to remove extra options. All options are stored as key (string) and value (list of strings) pairs in an unordered map.
* Some validation has been removed at the parsing stage (e.g. `--gpu -3` will parse without error, but run into a different error later)
* Added some `string_util` helpers for parsing

Expanded commandline flags syntax to allow:
* Resolution flags : `--flag-name NxM`
* no- prefix for boolean flags : `--no-flag-name`
* Other boolean values accepted
* = between flag and value : `--flag-name=parameter`