### PR TITLE
Shutdown logging in the LogInitialized test

### DIFF
--- a/src/test/log_console_test.cpp
+++ b/src/test/log_console_test.cpp
@@ -21,6 +21,24 @@
 
 namespace ppx {
 
+class LogStaticTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Some other unrelated tests might have run before the logging tests and
+        // already initialized logging. Since we share global state and run all
+        // tests in a single process, we need to shut down any existing logging.
+        // If the logging was not initialized this operation is a no-op.
+        Log::Shutdown();
+    }
+
+    void TearDown() override
+    {
+        Log::Shutdown();
+    }
+};
+
 class LogTest : public ::testing::Test
 {
 protected:
@@ -44,7 +62,7 @@ protected:
     std::stringstream mOut;
 };
 
-TEST(LogStaticTest, LogInitialized)
+TEST_F(LogStaticTest, LogInitialized)
 {
     std::stringstream out;
 
@@ -58,7 +76,7 @@ TEST(LogStaticTest, LogInitialized)
     Log::Shutdown();
 }
 
-TEST(LogStaticTest, LogShutdown)
+TEST_F(LogStaticTest, LogShutdown)
 {
     std::stringstream out;
     Log::Initialize(LOG_MODE_CONSOLE, nullptr, &out);


### PR DESCRIPTION
The `LogInitialized` does not use the `LogTest` class, so the fix in
https://github.com/google/bigwheels/pull/243 did not apply there. This
applies the same fix for `LogInitialized`.
