### PR TITLE
Add virtual to passthrough related methods.

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -444,7 +444,7 @@ public:
     bool RecordMetricData(metrics::MetricID id, const metrics::MetricData& data);
 
 #if defined(PPX_BUILD_XR)
-    XrComponent& GetXrComponent()
+    virtual XrComponent& GetXrComponent()
     {
         return mXrComponent;
     }

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -154,9 +154,9 @@ public:
     bool IsSessionRunning() const { return mIsSessionRunning; }
     bool ShouldRender() const { return mShouldRender; }
 
-    void BeginPassthrough();
-    void EndPassthrough();
-    void TogglePassthrough();
+    virtual void BeginPassthrough();
+    virtual void EndPassthrough();
+    virtual void TogglePassthrough();
 
 private:
     const XrEventDataBaseHeader* TryReadNextEvent();

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -92,6 +92,8 @@ struct XrComponentCreateInfo
 class XrComponent
 {
 public:
+    virtual ~XrComponent() = default;
+
     void InitializeBeforeGrfxDeviceInit(const XrComponentCreateInfo& createInfo);
     void InitializeAfterGrfxDeviceInit(const grfx::InstancePtr pGrfxInstance);
     void Destroy();


### PR DESCRIPTION
Useful for mocking during unit tests, for making sure that passthrough was changed by the code under test.