### PR TITLE
Change metrics to write to the external storage.

### DIFF
--- a/include/ppx/fs.h
+++ b/include/ppx/fs.h
@@ -140,7 +140,7 @@ bool path_exists(const std::filesystem::path& path);
 std::filesystem::path GetInternalDataPath();
 
 // Returns a path to the application's external data directory (can be used for output).
-std::filesystem::path GetInternalDataPath();
+std::filesystem::path GetExternalDataPath();
 #endif
 
 } // namespace ppx::fs

--- a/include/ppx/fs.h
+++ b/include/ppx/fs.h
@@ -138,6 +138,9 @@ bool path_exists(const std::filesystem::path& path);
 // Returns a path to the application's internal data directory (can be used for output).
 // NOTE: The internal data path on Android is extremely limited in terms of filesize!
 std::filesystem::path GetInternalDataPath();
+
+// Returns a path to the application's external data directory (can be used for output).
+std::filesystem::path GetInternalDataPath();
 #endif
 
 } // namespace ppx::fs

--- a/src/ppx/fs.cpp
+++ b/src/ppx/fs.cpp
@@ -183,6 +183,11 @@ std::filesystem::path GetInternalDataPath()
 {
     return std::filesystem::path(gAndroidContext->activity->internalDataPath);
 }
+
+std::filesystem::path GetExternalDataPath()
+{
+    return std::filesystem::path(gAndroidContext->activity->externalDataPath);
+}
 #endif
 
 } // namespace ppx::fs

--- a/src/ppx/metrics.cpp
+++ b/src/ppx/metrics.cpp
@@ -351,7 +351,7 @@ void Report::SetReportPath(const std::string& reportPath)
         path += kFileExtension;
     }
 #if defined(PPX_ANDROID)
-    mFilePath = ppx::fs::GetInternalDataPath();
+    mFilePath = ppx::fs::GetExternalDataPath();
 #endif
     mFilePath /= path;
     mContent["filename"]     = mFilePath.filename().string();


### PR DESCRIPTION
External storage is easy to read and write to over `adb` commands, and doesn't require the APK to be built in `debug` configurations to utilize the metrics.