### PR TITLE
Change StandardOptions into knobs

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -29,6 +29,7 @@
 #include <deque>
 #include <filesystem>
 #include <cinttypes>
+#include <vector>
 
 // clang-format off
 #if !defined(PPX_ANDROID)
@@ -221,6 +222,39 @@ struct KeyState
 };
 
 // -------------------------------------------------------------------------------------------------
+// StandardOptions
+// -------------------------------------------------------------------------------------------------
+struct StandardOptions
+{
+    // Flags
+    std::shared_ptr<KnobFlag<bool>> pListGpus;
+    std::shared_ptr<KnobFlag<bool>> pUseSoftwareRenderer;
+#if not defined(PPX_LINUX_HEADLESS)
+    std::shared_ptr<KnobFlag<bool>> pHeadless;
+#endif
+    std::shared_ptr<KnobFlag<bool>> pDeterministic;
+    std::shared_ptr<KnobFlag<bool>> pEnableMetrics;
+    std::shared_ptr<KnobFlag<bool>> pOverwriteMetricsFile;
+
+    // Options
+    std::shared_ptr<KnobFlag<int>>      pGpuIndex;
+    std::shared_ptr<KnobFlag<uint64_t>> pFrameCount;
+    std::shared_ptr<KnobFlag<int>>      pRunTimeMs;
+    std::shared_ptr<KnobFlag<int>>      pStatsFrameWindow;
+    std::shared_ptr<KnobFlag<int>>      pScreenshotFrameNumber;
+
+    std::shared_ptr<KnobFlag<std::string>> pScreenshotPath;
+    std::shared_ptr<KnobFlag<std::string>> pMetricsFilename;
+
+    std::shared_ptr<KnobFlag<std::pair<int, int>>> pResolution;
+#if defined(PPX_BUILD_XR)
+    std::shared_ptr<KnobFlag<std::pair<int, int>>> pXrUiResolution;
+#endif
+
+    std::shared_ptr<KnobFlag<std::vector<std::string>>> pAssetsPaths;
+};
+
+// -------------------------------------------------------------------------------------------------
 // Application
 // -------------------------------------------------------------------------------------------------
 
@@ -233,10 +267,6 @@ struct ApplicationSettings
     bool        headless              = false;
     bool        enableImGui           = false;
     bool        allowThirdPartyAssets = false;
-    // Set to true to opt-in for metrics.
-    bool        enableMetrics        = false;
-    bool        overwriteMetricsFile = false;
-    std::string reportPath           = "";
 
     struct
     {
@@ -359,10 +389,10 @@ public:
     void Quit();
 
     std::vector<const char*> GetCommandLineArgs() const;
-    const StandardOptions    GetStandardOptions() const;
     const CliOptions&        GetExtraOptions() const;
 
     const ApplicationSettings* GetSettings() const { return &mSettings; }
+    const StandardOptions&     GetStandardOptions() const { return mStandardOpts; }
     uint32_t                   GetWindowWidth() const { return mSettings.window.width; }
     uint32_t                   GetWindowHeight() const { return mSettings.window.height; }
     bool                       IsWindowIconified() const;
@@ -486,6 +516,9 @@ private:
     // Saves the metrics data to a file on disk.
     void SaveMetricsReportToDisk();
 
+    // Initializes standard knobs
+    void InitStandardKnobs();
+
 private:
     friend struct WindowEvents;
     //
@@ -506,8 +539,7 @@ private:
 
 private:
     CommandLineParser               mCommandLineParser;
-    StandardOptions                 mStandardOptions;
-    uint64_t                        mMaxFrames;
+    StandardOptions                 mStandardOpts;
     float                           mRunTimeSeconds;
     ApplicationSettings             mSettings = {};
     std::string                     mDecoratedApiName;
@@ -537,10 +569,10 @@ private:
     // Metrics
     struct
     {
-        metrics::Manager        manager;
-        metrics::MetricID       cpuFrameTimeId = metrics::kInvalidMetricID;
-        metrics::MetricID       framerateId    = metrics::kInvalidMetricID;
-        metrics::MetricID       frameCountId   = metrics::kInvalidMetricID;
+        metrics::Manager  manager;
+        metrics::MetricID cpuFrameTimeId = metrics::kInvalidMetricID;
+        metrics::MetricID framerateId    = metrics::kInvalidMetricID;
+        metrics::MetricID frameCountId   = metrics::kInvalidMetricID;
 
         double   framerateRecordTimer   = 0.0;
         uint64_t framerateFrameCount    = 0;

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -27,35 +27,6 @@
 #include <vector>
 
 namespace ppx {
-// -------------------------------------------------------------------------------------------------
-// StandardOptions
-// -------------------------------------------------------------------------------------------------
-struct StandardOptions
-{
-    // Flags
-    bool deterministic          = false;
-    bool enable_metrics         = false;
-    bool headless               = false;
-    bool list_gpus              = false;
-    bool overwrite_metrics_file = false;
-    bool use_software_renderer  = false;
-
-    // Options
-    std::vector<std::string> assets_paths            = {};
-    int                      frame_count             = 0;
-    int                      gpu_index               = -1;
-    std::string              metrics_filename        = "";
-    std::pair<int, int>      resolution              = {-1, -1};
-    int                      run_time_ms             = 0;
-    int                      screenshot_frame_number = -1;
-    std::string              screenshot_path         = "";
-    uint32_t                 stats_frame_window      = 300;
-#if defined(PPX_BUILD_XR)
-    std::pair<int, int> xrUIResolution = {-1, -1};
-#endif
-
-    bool operator==(const StandardOptions&) const = default;
-};
 
 // -------------------------------------------------------------------------------------------------
 // CliOptions
@@ -184,100 +155,25 @@ public:
     // succeeded. Otherwise, return true if an error occurred,
     // and write the error to `out_error`.
     std::optional<ParsingError> Parse(int argc, const char* argv[]);
-    const CliOptions&           GetOptions() const { return mOpts; }
-    const StandardOptions&      GetStandardOptions() const { return mStandardOpts; }
-    std::string                 GetUsageMsg() const { return mUsageMsg; }
-    void                        AppendUsageMsg(const std::string& additionalMsg) { mUsageMsg += additionalMsg; }
+
+    const CliOptions& GetOptions() const { return mOpts; }
+    std::string       GetUsageMsg() const { return mUsageMsg; }
+    void              AppendUsageMsg(const std::string& additionalMsg) { mUsageMsg += additionalMsg; }
 
 private:
-    CliOptions      mOpts;
-    StandardOptions mStandardOpts;
-    std::string     mUsageMsg = R"(
+    CliOptions mOpts;
+
+    std::string mUsageMsg = R"(
 USAGE
 ==============================
 Boolean options can be turned on with:
   --flag-name true, --flag-name 1, --flag-name
 And turned off with:
   --flag-name false, --flag-name 0, --no-flag-name
+
+--help : Prints this help message and exits.
 ==============================
---help              Prints this help message and exits.
-
---assets-path       Add a path in front of the assets search path list (Can be
-                    specified multiple times).
-
---deterministic     Disable non-deterministic behaviors, like clocks and
-                    diagnostic display.
-
---enable-metrics    Enable metrics report output. See also:
-                    `--metrics-filename` and `--overwrite-metrics-file`.
-
---frame-count <N>   Shutdown the application after successfully rendering N
-                    frames. Default: 0 (infinite).
-
---run-time-ms <N>   Shutdown the application after N milliseconds. Default: 0
-                    (infinite).
-
---gpu <index>       Select the gpu with the given index. To determine the set
-                    of valid indices use --list-gpus.
-
---headless          Run the sample without creating windows.
-
---list-gpus         Prints a list of the available GPUs on the current system
-                    with their index and exits (see --gpu).
-
---metrics-filename  If metrics are enabled, save the metrics report to the
-                    provided filename (including path). If used, any "@"
-                    symbols in the filename (not the path) will be replaced
-                    with the current timestamp. If the filename does not end in
-                    .json, it will be appended. Default: "report_@". See also:
-                    `--enable-metrics` and `--overwrite-metrics-file`.
-
---overwrite-metrics-file
-                    Only applies if metrics are enabled with
-                    `--enable-metrics`. If an existing file at the path set
-                    with `--metrics-filename` is found, it will be overwritten.
-                    Default: false. See also: `--enable-metrics` and
-                    `--metrics-filename`.
-)"
-#if defined(PPX_BUILD_XR)
-                            R"(
---resolution <Width>x<Height>
-                    Specify the per-eye resolution in pixels. Width and Height
-                    must be two positive integers greater or equal to 1.
-)"
-#else
-                            R"(
---resolution <Width>x<Height>
-                    Specify the main window resolution in pixels. Width and
-                    Height must be two positive integers greater or equal to 1.
-)"
-#endif
-                            R"(
---screenshot-frame-number <N>
-                    Take a screenshot of frame number N and save it in PPM
-                    format. See also `--screenshot-path`.
-
---screenshot-path   Save the screenshot to this destination. If not specified,
-                    BigWheels will create a "screenshot_frameN" file in the
-                    current working directory.
-
---stats-frame-window <N>
-                    Calculate frame statistics over the last N frames only.
-                    Default: 0 (use all frames since the beginning of the
-                    application).
-
---use-software-renderer
-                    Use a software renderer instead of a hardware device, if
-                    available.
-)"
-#if defined(PPX_BUILD_XR)
-                            R"(
---xr-ui-resolution <Width>x<Height>
-                    Specify the UI quad resolution in pixels. Width and Height
-                    must be two positive integers greater or equal to 1.
-)"
-#endif
-        ; // mUsageMsg
+)";
 };
 
 } // namespace ppx

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -137,25 +137,6 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
         }
     }
 
-    // Fill out standard options.
-    mStandardOpts.assets_paths            = mOpts.GetOptionValueOrDefault<std::string>("assets-path", mStandardOpts.assets_paths);
-    mStandardOpts.deterministic           = mOpts.GetOptionValueOrDefault<bool>("deterministic", mStandardOpts.deterministic);
-    mStandardOpts.enable_metrics          = mOpts.GetOptionValueOrDefault<bool>("enable-metrics", mStandardOpts.enable_metrics);
-    mStandardOpts.frame_count             = mOpts.GetOptionValueOrDefault<int>("frame-count", mStandardOpts.frame_count);
-    mStandardOpts.gpu_index               = mOpts.GetOptionValueOrDefault<int>("gpu", mStandardOpts.gpu_index);
-    mStandardOpts.headless                = mOpts.GetOptionValueOrDefault<bool>("headless", mStandardOpts.headless);
-    mStandardOpts.list_gpus               = mOpts.GetOptionValueOrDefault<bool>("list-gpus", mStandardOpts.list_gpus);
-    mStandardOpts.metrics_filename        = mOpts.GetOptionValueOrDefault<std::string>("metrics-filename", mStandardOpts.metrics_filename);
-    mStandardOpts.overwrite_metrics_file  = mOpts.GetOptionValueOrDefault<bool>("overwrite-metrics-file", mStandardOpts.overwrite_metrics_file);
-    mStandardOpts.resolution              = mOpts.GetOptionValueOrDefault("resolution", mStandardOpts.resolution);
-    mStandardOpts.run_time_ms             = mOpts.GetOptionValueOrDefault<int>("run-time-ms", mStandardOpts.run_time_ms);
-    mStandardOpts.stats_frame_window      = mOpts.GetOptionValueOrDefault<int>("stats-frame-window", mStandardOpts.stats_frame_window);
-    mStandardOpts.screenshot_frame_number = mOpts.GetOptionValueOrDefault<int>("screenshot-frame-number", mStandardOpts.screenshot_frame_number);
-    mStandardOpts.screenshot_path         = mOpts.GetOptionValueOrDefault<std::string>("screenshot-path", mStandardOpts.screenshot_path);
-    mStandardOpts.use_software_renderer   = mOpts.GetOptionValueOrDefault<bool>("use-software-renderer", mStandardOpts.use_software_renderer);
-#if defined(PPX_BUILD_XR)
-    mStandardOpts.xrUIResolution = mOpts.GetOptionValueOrDefault("xr-ui-resolution", mStandardOpts.xrUIResolution);
-#endif
     return std::nullopt;
 }
 

--- a/src/test/command_line_parser_test.cpp
+++ b/src/test/command_line_parser_test.cpp
@@ -25,23 +25,19 @@ using ::testing::HasSubstr;
 TEST(CommandLineParserTest, ZeroArguments)
 {
     CommandLineParser parser;
-    StandardOptions   defaultOptions;
     if (auto error = parser.Parse(0, nullptr)) {
         FAIL() << error->errorMsg;
     }
-    EXPECT_EQ(parser.GetStandardOptions(), defaultOptions);
     EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 0);
 }
 
 TEST(CommandLineParserTest, FirstArgumentIgnored)
 {
     CommandLineParser parser;
-    StandardOptions   defaultOptions;
     const char*       args[] = {"/path/to/executable"};
     if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
         FAIL() << error->errorMsg;
     }
-    EXPECT_EQ(parser.GetStandardOptions(), defaultOptions);
     EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 0);
 }
 
@@ -218,74 +214,14 @@ TEST(CommandLineParserTest, LastValueIsTaken)
     EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("b", 0), 1);
 }
 
-TEST(CommandLineParserTest, StandardOptionsSuccessfullyParsed)
-{
-    CommandLineParser parser;
-    const char*       args[] = {
-        "/path/to/executable",
-        "--list-gpus",
-        "--deterministic",
-        "1",
-        "--enable-metrics",
-        "true",
-        "--no-use-software-renderer",
-        "--headless",
-        "0",
-        "--overwrite_metrics_file",
-        "false",
-        "--metrics-filename",
-        "filename with spaces",
-        "--screenshot-path",
-        "filenameWithoutSpaces",
-        "--frame-count",
-        "0",
-        "--gpu",
-        "5",
-        "--run-time-ms",
-        "300",
-        "--screenshot-frame-number",
-        "0",
-        "--stats-frame-window",
-        "1000",
-        "--assets-path",
-        "foo1",
-        "--assets-path",
-        "foo2",
-        "--resolution",
-        "100x200"};
-    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
-        FAIL() << error->errorMsg;
-    }
-    EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 15);
-    StandardOptions gotStandardOptions = parser.GetStandardOptions();
-    EXPECT_EQ(gotStandardOptions.list_gpus, true);
-    EXPECT_EQ(gotStandardOptions.deterministic, true);
-    EXPECT_EQ(gotStandardOptions.enable_metrics, true);
-    EXPECT_EQ(gotStandardOptions.use_software_renderer, false);
-    EXPECT_EQ(gotStandardOptions.headless, false);
-    EXPECT_EQ(gotStandardOptions.overwrite_metrics_file, false);
-    EXPECT_EQ(gotStandardOptions.metrics_filename, "filename with spaces");
-    EXPECT_EQ(gotStandardOptions.screenshot_path, "filenameWithoutSpaces");
-    EXPECT_EQ(gotStandardOptions.frame_count, 0);
-    EXPECT_EQ(gotStandardOptions.gpu_index, 5);
-    EXPECT_EQ(gotStandardOptions.run_time_ms, 300);
-    EXPECT_EQ(gotStandardOptions.screenshot_frame_number, 0);
-    EXPECT_EQ(gotStandardOptions.stats_frame_window, 1000);
-    std::vector<std::string> assetsPaths{"foo1", "foo2"};
-    EXPECT_EQ(gotStandardOptions.assets_paths, assetsPaths);
-    EXPECT_EQ(gotStandardOptions.resolution, std::make_pair(100, 200));
-}
-
 TEST(CommandLineParserTest, ExtraOptionsSuccessfullyParsed)
 {
     CommandLineParser parser;
-    StandardOptions   defaultOptions;
     const char*       args[] = {"/path/to/executable", "--extra-option-bool", "true", "--extra-option-int", "123", "--extra-option-no-param", "--extra-option-str", "option string value"};
     if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
         FAIL() << error->errorMsg;
     }
     auto opts = parser.GetOptions();
-    EXPECT_EQ(parser.GetStandardOptions(), defaultOptions);
     EXPECT_EQ(opts.GetNumUniqueOptions(), 4);
     EXPECT_EQ(opts.GetExtraOptionValueOrDefault("extra-option-bool", false), true);
     EXPECT_EQ(opts.GetExtraOptionValueOrDefault("extra-option-int", 0), 123);


### PR DESCRIPTION
* Changing `StandardOptions` struct to hold knobs
* Standard options flag usage message is now generated
* Reducing some Application variables that are the same as `StandardOptions` (`mMaxFrames`, all metrics-related ones inside `ApplicationSettings`)
* Simplifying some of the `Application::Run` logic since knob ranges and validators will cover those checks
* Adding some test cases for complex knobs
* Added `ToString()` util for drawing values of complex knobs
* Fixing broken `--assets-path` flag which would not register when used multiple times
* Fixing bug with `WrapText()` which would break the line too early