### PR TITLE
Bug fixes, helper functions and better logging for string_util and knobs

### DIFF
--- a/include/ppx/knob.h
+++ b/include/ppx/knob.h
@@ -19,6 +19,7 @@
 #include "ppx/config.h"
 #include "ppx/imgui_impl.h"
 #include "ppx/log.h"
+#include "ppx/string_util.h"
 
 #include <iostream>
 #include <memory>
@@ -70,7 +71,8 @@ protected:
 
 private:
     // Only called from KnobManager
-    virtual void Draw() = 0;
+    virtual void        Draw()        = 0;
+    virtual std::string ValueString() = 0;
 
     // Updates knob value from commandline flag
     virtual void UpdateFromFlags(const CliOptions& opts) = 0;
@@ -104,7 +106,8 @@ public:
     void SetValue(bool newValue);
 
 private:
-    void Draw() override;
+    void        Draw() override;
+    std::string ValueString() override;
 
     // Expected commandline flag format:
     // --flag_name <true|false>
@@ -176,11 +179,16 @@ private:
         }
     }
 
+    std::string ValueString() override
+    {
+        return ppx::string_util::ToString(mValue);
+    }
+
     // Expected commandline flag format:
     // --flag_name <int>
     void UpdateFromFlags(const CliOptions& opts) override
     {
-        SetDefaultAndValue(opts.GetExtraOptionValueOrDefault(mFlagName, mValue));
+        SetDefaultAndValue(opts.GetOptionValueOrDefault(mFlagName, mValue));
     }
 
     bool IsValidValue(T val)
@@ -297,11 +305,16 @@ private:
         ImGui::EndCombo();
     }
 
+    std::string ValueString() override
+    {
+        return mChoices[mIndex];
+    }
+
     // Expected commandline flag format:
     // --flag_name <str>
     void UpdateFromFlags(const CliOptions& opts) override
     {
-        SetDefaultAndIndex(opts.GetExtraOptionValueOrDefault(mFlagName, GetValue()));
+        SetDefaultAndIndex(opts.GetOptionValueOrDefault(mFlagName, GetValue()));
     }
 
     bool IsValidIndex(size_t index)
@@ -370,16 +383,20 @@ public:
 private:
     void Draw() override
     {
-        std::stringstream ss;
-        ss << mFlagName << ": " << mValue;
-        std::string flagText = ss.str();
+        std::string flagText = mFlagName + ": " + ValueString();
         ImGui::Text("%s", flagText.c_str());
     }
+
+    std::string ValueString() override
+    {
+        return ppx::string_util::ToString(mValue);
+    }
+
     void ResetToDefault() override {} // KnobFlag is always the "default" value
 
     void UpdateFromFlags(const CliOptions& opts) override
     {
-        SetValue(opts.GetExtraOptionValueOrDefault(mFlagName, mValue));
+        SetValue(opts.GetOptionValueOrDefault(mFlagName, mValue));
     }
 
     bool IsValidValue(T val)

--- a/include/ppx/string_util.h
+++ b/include/ppx/string_util.h
@@ -59,7 +59,7 @@ std::string ToString(std::vector<T> values)
 {
     std::stringstream ss;
     for (const auto& value : values) {
-        ss << value << ", ";
+        ss << ToString<T>(value) << ", ";
     }
     std::string valueStr = ss.str();
     return valueStr.substr(0, valueStr.length() - 2);
@@ -70,7 +70,7 @@ template <typename T>
 std::string ToString(std::pair<T, T> values)
 {
     std::stringstream ss;
-    ss << values.first << ", " << values.second;
+    ss << ToString<T>(values.first) << ", " << ToString<T>(values.second);
     return ss.str();
 }
 

--- a/include/ppx/string_util.h
+++ b/include/ppx/string_util.h
@@ -15,8 +15,10 @@
 #ifndef PPX_STRING_UTIL_H
 #define PPX_STRING_UTIL_H
 
-#include <string>
 #include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace ppx {
 namespace string_util {
@@ -38,6 +40,39 @@ std::optional<std::pair<std::string_view, std::string_view>> SplitInTwo(std::str
 // middle of a word if possible.
 // Leading and trailing whitespace is trimmed from each line.
 std::string WrapText(const std::string& s, size_t width, size_t indent = 0);
+
+// Provides string representation of value for printing or display
+template <typename T>
+std::string ToString(T value)
+{
+    std::stringstream ss;
+    if constexpr (std::is_same_v<T, bool>) {
+        ss << std::boolalpha;
+    }
+    ss << value;
+    return ss.str();
+}
+
+// Same as above, for vectors
+template <typename T>
+std::string ToString(std::vector<T> values)
+{
+    std::stringstream ss;
+    for (const auto& value : values) {
+        ss << value << ", ";
+    }
+    std::string valueStr = ss.str();
+    return valueStr.substr(0, valueStr.length() - 2);
+}
+
+// Same as above, for pairs
+template <typename T>
+std::string ToString(std::pair<T, T> values)
+{
+    std::stringstream ss;
+    ss << values.first << ", " << values.second;
+    return ss.str();
+}
 
 } // namespace string_util
 } // namespace ppx

--- a/src/ppx/knob.cpp
+++ b/src/ppx/knob.cpp
@@ -60,9 +60,14 @@ void KnobCheckbox::Draw()
     RaiseUpdatedFlag();
 }
 
+std::string KnobCheckbox::ValueString()
+{
+    return ppx::string_util::ToString(mValue);
+}
+
 void KnobCheckbox::UpdateFromFlags(const CliOptions& opts)
 {
-    SetDefaultAndValue(opts.GetExtraOptionValueOrDefault(mFlagName, mValue));
+    SetDefaultAndValue(opts.GetOptionValueOrDefault(mFlagName, mValue));
 }
 
 void KnobCheckbox::SetValue(bool newValue)
@@ -121,7 +126,7 @@ void KnobManager::DrawAllKnobs(bool inExistingWindow)
 
 std::string KnobManager::GetUsageMsg()
 {
-    std::string usageMsg = "\nApplication-Specific Flags:\n";
+    std::string usageMsg = "\nFlags:\n";
     for (const auto& knobPtr : mKnobs) {
         std::string knobMsg = "--" + knobPtr->mFlagName;
         if (knobPtr->mFlagParameters != "") {
@@ -140,6 +145,7 @@ void KnobManager::UpdateFromFlags(const CliOptions& opts)
 {
     for (auto& knobPtr : mKnobs) {
         knobPtr->UpdateFromFlags(opts);
+        PPX_LOG_INFO("KNOB: " << knobPtr->mFlagName << " : (" << knobPtr->ValueString() << ")");
     }
 }
 

--- a/src/ppx/string_util.cpp
+++ b/src/ppx/string_util.cpp
@@ -80,9 +80,19 @@ std::string WrapText(const std::string& s, size_t width, size_t indent)
     std::string wrappedText = "";
     while (remainingString != "") {
         // Section off the next line from the remaining string, format it, and append it to wrappedText
-        size_t lineLength = remainingString.find_last_of(" \t", textWidth);
-        if (lineLength == std::string::npos) {
-            lineLength = std::min(textWidth, remainingString.length());
+        size_t lineLength = remainingString.length();
+        if (lineLength > textWidth) {
+            // Break the line at textWidth
+            lineLength = textWidth;
+            // If the character after the line break is not empty, the line break will interrupt a word
+            // so try to insert the line break at the last empty space on this line
+            if (!std::isspace(remainingString[textWidth])) {
+                lineLength = remainingString.find_last_of(" \t", textWidth);
+                // In case there is no empty space on this entire line, go back to breaking the word at textWidth
+                if (lineLength == std::string::npos) {
+                    lineLength = textWidth;
+                }
+            }
         }
         std::string newLine = remainingString.substr(0, lineLength);
         TrimRight(newLine);

--- a/src/test/knob_test.cpp
+++ b/src/test/knob_test.cpp
@@ -51,26 +51,31 @@ protected:
     {
         ppx::Log::Initialize(ppx::LOG_MODE_CONSOLE, nullptr);
 
-        k1 = km.CreateKnob<ppx::KnobCheckbox>("flag_name1", true);
-        k2 = km.CreateKnob<ppx::KnobCheckbox>("flag_name2", true);
-        k3 = km.CreateKnob<ppx::KnobSlider<int>>("flag_name3", 5, 0, 10);
-        k4 = km.CreateKnob<ppx::KnobDropdown<std::string>>("flag_name4", 1, choices4);
-        k5 = km.CreateKnob<ppx::KnobFlag<bool>>("flag_name5", true);
-        k6 = km.CreateKnob<ppx::KnobFlag<float>>("flag_name6", 6.6f, 0.0f, 10.0f);
-        k7 = km.CreateKnob<ppx::KnobFlag<int>>("flag_name7", 8, 0, INT_MAX);
-        k8 = km.CreateKnob<ppx::KnobSlider<float>>("flag_name8", 5.0f, 0.0f, 10.0f);
+        k1  = km.CreateKnob<ppx::KnobCheckbox>("flag_name1", true);
+        k2  = km.CreateKnob<ppx::KnobCheckbox>("flag_name2", true);
+        k3  = km.CreateKnob<ppx::KnobSlider<int>>("flag_name3", 5, 0, 10);
+        k4  = km.CreateKnob<ppx::KnobDropdown<std::string>>("flag_name4", 1, choices4);
+        k5  = km.CreateKnob<ppx::KnobFlag<bool>>("flag_name5", true);
+        k6  = km.CreateKnob<ppx::KnobFlag<float>>("flag_name6", 6.6f, 0.0f, 10.0f);
+        k7  = km.CreateKnob<ppx::KnobFlag<int>>("flag_name7", 8, 0, INT_MAX);
+        k8  = km.CreateKnob<ppx::KnobSlider<float>>("flag_name8", 5.0f, 0.0f, 10.0f);
+        k9  = km.CreateKnob<ppx::KnobFlag<std::pair<int, int>>>("flag_name9", std::make_pair(1, 2));
+        k10 = km.CreateKnob<ppx::KnobFlag<std::vector<std::string>>>("flag_name10", defaultValues10);
     }
 
 protected:
-    std::shared_ptr<ppx::KnobCheckbox>              k1;
-    std::shared_ptr<ppx::KnobCheckbox>              k2;
-    std::shared_ptr<ppx::KnobSlider<int>>           k3;
-    std::vector<std::string>                        choices4 = {"c1", "c2", "c3 and more"};
-    std::shared_ptr<ppx::KnobDropdown<std::string>> k4;
-    std::shared_ptr<ppx::KnobFlag<bool>>            k5;
-    std::shared_ptr<ppx::KnobFlag<float>>           k6;
-    std::shared_ptr<ppx::KnobFlag<int>>             k7;
-    std::shared_ptr<ppx::KnobSlider<float>>         k8;
+    std::shared_ptr<ppx::KnobCheckbox>                       k1;
+    std::shared_ptr<ppx::KnobCheckbox>                       k2;
+    std::shared_ptr<ppx::KnobSlider<int>>                    k3;
+    std::vector<std::string>                                 choices4 = {"c1", "c2", "c3 and more"};
+    std::shared_ptr<ppx::KnobDropdown<std::string>>          k4;
+    std::shared_ptr<ppx::KnobFlag<bool>>                     k5;
+    std::shared_ptr<ppx::KnobFlag<float>>                    k6;
+    std::shared_ptr<ppx::KnobFlag<int>>                      k7;
+    std::shared_ptr<ppx::KnobSlider<float>>                  k8;
+    std::shared_ptr<ppx::KnobFlag<std::pair<int, int>>>      k9;
+    std::vector<std::string>                                 defaultValues10 = {"a", "b", "c", "d and more"};
+    std::shared_ptr<ppx::KnobFlag<std::vector<std::string>>> k10;
 };
 
 namespace ppx {
@@ -427,6 +432,31 @@ TEST_F(KnobTestFixture, KnobFlag_CreateFloatWithRange)
     EXPECT_EQ(k.GetValue(), 1.5f);
 }
 
+TEST_F(KnobTestFixture, KnobFlag_CreatePairInts)
+{
+    KnobFlag<std::pair<int, int>> k = KnobFlag<std::pair<int, int>>("flag_name1", std::make_pair(1, 2));
+    EXPECT_EQ(k.GetValue().first, 1);
+    EXPECT_EQ(k.GetValue().second, 2);
+}
+
+TEST_F(KnobTestFixture, KnobFlag_CreateListStrings)
+{
+    KnobFlag<std::vector<std::string>> k = KnobFlag<std::vector<std::string>>("flag_name1", {"hi1", "hi2", "hi3"});
+    EXPECT_EQ(k.GetValue().size(), 3);
+    EXPECT_EQ(k.GetValue().at(0), "hi1");
+    EXPECT_EQ(k.GetValue().at(1), "hi2");
+    EXPECT_EQ(k.GetValue().at(2), "hi3");
+}
+
+TEST_F(KnobTestFixture, KnobFlag_CreateListInts)
+{
+    KnobFlag<std::vector<int>> k = KnobFlag<std::vector<int>>("flag_name1", {1, 2, 3});
+    EXPECT_EQ(k.GetValue().size(), 3);
+    EXPECT_EQ(k.GetValue().at(0), 1);
+    EXPECT_EQ(k.GetValue().at(1), 2);
+    EXPECT_EQ(k.GetValue().at(2), 3);
+}
+
 // -------------------------------------------------------------------------------------------------
 // KnobManager
 // -------------------------------------------------------------------------------------------------
@@ -497,6 +527,33 @@ TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagFloatWithRange)
     EXPECT_EQ(knobPtr->GetValue(), 1.5f);
 }
 
+TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagPairInts)
+{
+    std::shared_ptr<KnobFlag<std::pair<int, int>>> knobPtr(km.CreateKnob<KnobFlag<std::pair<int, int>>>("flag_name1", std::make_pair(1, 2)));
+    EXPECT_EQ(knobPtr->GetValue().first, 1);
+    EXPECT_EQ(knobPtr->GetValue().second, 2);
+}
+
+TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagListStrings)
+{
+    std::vector<std::string>                            stringList = {"hi1", "hi2", "hi3"};
+    std::shared_ptr<KnobFlag<std::vector<std::string>>> knobPtr(km.CreateKnob<KnobFlag<std::vector<std::string>>>("flag_name1", stringList));
+    EXPECT_EQ(knobPtr->GetValue().size(), 3);
+    EXPECT_EQ(knobPtr->GetValue().at(0), "hi1");
+    EXPECT_EQ(knobPtr->GetValue().at(1), "hi2");
+    EXPECT_EQ(knobPtr->GetValue().at(2), "hi3");
+}
+
+TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagListInts)
+{
+    std::vector<int>                            intList = {1, 2, 3};
+    std::shared_ptr<KnobFlag<std::vector<int>>> knobPtr(km.CreateKnob<KnobFlag<std::vector<int>>>("flag_name1", intList));
+    EXPECT_EQ(knobPtr->GetValue().size(), 3);
+    EXPECT_EQ(knobPtr->GetValue().at(0), 1);
+    EXPECT_EQ(knobPtr->GetValue().at(1), 2);
+    EXPECT_EQ(knobPtr->GetValue().at(2), 3);
+}
+
 #if defined(PERFORM_DEATH_TESTS)
 TEST_F(KnobManagerTestFixture, KnobManager_CreateUniqueName)
 {
@@ -512,7 +569,7 @@ TEST_F(KnobManagerTestFixture, KnobManager_CreateUniqueName)
 TEST_F(KnobManagerWithKnobsTestFixture, KnobManager_GetBasicUsageMsg)
 {
     std::string usageMsg = R"(
-Application-Specific Flags:
+Flags:
 --flag_name1 <true|false>
 --flag_name2 <true|false>
 --flag_name3 <0~10>
@@ -521,6 +578,8 @@ Application-Specific Flags:
 --flag_name6
 --flag_name7
 --flag_name8 <0.0~10.0>
+--flag_name9
+--flag_name10
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);
 }
@@ -537,9 +596,11 @@ TEST_F(KnobManagerWithKnobsTestFixture, KnobManager_GetCustomizedUsageMsg)
     k6->SetFlagDescription("description6");
     k7->SetFlagParameters("<0~INT_MAX>");
     k8->SetFlagParameters("<0.000~10.000>");
+    k9->SetFlagDescription("description9");
+    k10->SetFlagParameters("<string>");
 
     std::string usageMsg = R"(
-Application-Specific Flags:
+Flags:
 --flag_name1 <bool>
                     description1
 
@@ -556,6 +617,10 @@ Application-Specific Flags:
 
 --flag_name7 <0~INT_MAX>
 --flag_name8 <0.000~10.000>
+--flag_name9
+                    description9
+
+--flag_name10 <string>
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);
 }

--- a/src/test/string_util_test.cpp
+++ b/src/test/string_util_test.cpp
@@ -18,35 +18,35 @@
 
 using namespace ppx::string_util;
 
-TEST(StringUtilTest, TrimLeftNothingToTrim)
+TEST(StringUtilTest, TrimLeft_NothingToTrim)
 {
     std::string toTrim = "No left space  ";
     TrimLeft(toTrim);
     EXPECT_EQ(toTrim, "No left space  ");
 }
 
-TEST(StringUtilTest, TrimLeftSpaces)
+TEST(StringUtilTest, TrimLeft_Spaces)
 {
     std::string toTrim = "  Some left spaces  ";
     TrimLeft(toTrim);
     EXPECT_EQ(toTrim, "Some left spaces  ");
 }
 
-TEST(StringUtilTest, TrimRightNothingToTrim)
+TEST(StringUtilTest, TrimRight_NothingToTrim)
 {
     std::string toTrim = "    No right space";
     TrimRight(toTrim);
     EXPECT_EQ(toTrim, "    No right space");
 }
 
-TEST(StringUtilTest, TrimRightSpaces)
+TEST(StringUtilTest, TrimRight_Spaces)
 {
     std::string toTrim = "  Some right spaces  ";
     TrimRight(toTrim);
     EXPECT_EQ(toTrim, "  Some right spaces");
 }
 
-TEST(StringUtilTest, TrimCopyLeftAndRightSpaces)
+TEST(StringUtilTest, TrimCopy_LeftAndRightSpaces)
 {
     std::string toTrim  = "  Some spaces  ";
     std::string trimmed = TrimCopy(toTrim);
@@ -54,7 +54,7 @@ TEST(StringUtilTest, TrimCopyLeftAndRightSpaces)
     EXPECT_EQ(toTrim, "  Some spaces  ");
 }
 
-TEST(StringUtilTest, TrimBothEndsNothingToTrim)
+TEST(StringUtilTest, TrimBothEnds_NothingToTrim)
 {
     std::string_view toTrim  = "No spaces";
     std::string_view trimmed = TrimBothEnds(toTrim);
@@ -62,7 +62,7 @@ TEST(StringUtilTest, TrimBothEndsNothingToTrim)
     EXPECT_EQ(toTrim, "No spaces");
 }
 
-TEST(StringUtilTest, TrimBothEndsLeftAndRightSpaces)
+TEST(StringUtilTest, TrimBothEnds_LeftAndRightSpaces)
 {
     std::string_view toTrim  = "  Some spaces  ";
     std::string_view trimmed = TrimBothEnds(toTrim);
@@ -70,14 +70,14 @@ TEST(StringUtilTest, TrimBothEndsLeftAndRightSpaces)
     EXPECT_EQ(toTrim, "  Some spaces  ");
 }
 
-TEST(StringUtilTest, SplitInTwoEmptyString)
+TEST(StringUtilTest, SplitInTwo_EmptyString)
 {
     std::string_view toSplit = "";
     auto             res     = SplitInTwo(toSplit, ',');
     EXPECT_EQ(res, std::nullopt);
 }
 
-TEST(StringUtilTest, SplitInTwoOneDelimiter)
+TEST(StringUtilTest, SplitInTwo_OneDelimiter)
 {
     std::string_view toSplit = "Apple,Banana";
     auto             res     = SplitInTwo(toSplit, ',');
@@ -86,7 +86,7 @@ TEST(StringUtilTest, SplitInTwoOneDelimiter)
     EXPECT_EQ(res->second, "Banana");
 }
 
-TEST(StringUtilTest, SplitInTwoMultipleDelimiter)
+TEST(StringUtilTest, SplitInTwo_MultipleDelimiter)
 {
     std::string_view toSplit = "Apple,Banana,Orange";
     auto             res     = SplitInTwo(toSplit, ',');
@@ -95,7 +95,7 @@ TEST(StringUtilTest, SplitInTwoMultipleDelimiter)
     EXPECT_EQ(res->second, "Banana,Orange");
 }
 
-TEST(StringUtilTest, WrapTextEmptyString)
+TEST(StringUtilTest, WrapText_EmptyString)
 {
     std::string toWrap  = "";
     std::string wrapped = WrapText(toWrap, 10);
@@ -103,14 +103,14 @@ TEST(StringUtilTest, WrapTextEmptyString)
     EXPECT_EQ(toWrap, "");
 }
 
-TEST(StringUtilTest, WrapTextIndentLargerThanWidth)
+TEST(StringUtilTest, WrapText_IndentLargerThanWidth)
 {
     std::string toWrap  = "Some text.";
     std::string wrapped = WrapText(toWrap, 5, 8);
     EXPECT_EQ(wrapped, toWrap);
 }
 
-TEST(StringUtilTest, WrapTextNoIndent)
+TEST(StringUtilTest, WrapText_NoIndent)
 {
     std::string toWrap   = "The quick brown fox jumps over the lazy dog.";
     std::string wantWrap = R"(The quick
@@ -123,7 +123,7 @@ dog.
     EXPECT_EQ(wrapped, wantWrap);
 }
 
-TEST(StringUtilTest, WrapTextWithIndent)
+TEST(StringUtilTest, WrapText_WithIndent)
 {
     std::string toWrap   = "The quick brown fox jumps over the lazy dog.";
     std::string wantWrap = R"(   The quick
@@ -136,7 +136,7 @@ TEST(StringUtilTest, WrapTextWithIndent)
     EXPECT_EQ(wrapped, wantWrap);
 }
 
-TEST(StringUtilTest, WrapTextLeadingTrailingSpaces)
+TEST(StringUtilTest, WrapText_LeadingTrailingSpaces)
 {
     std::string toWrap   = "    The quick brown fox jumps over the lazy dog.    ";
     std::string wantWrap = R"(The quick
@@ -149,7 +149,7 @@ dog.
     EXPECT_EQ(wrapped, wantWrap);
 }
 
-TEST(StringUtilTest, WrapTextWithTabs)
+TEST(StringUtilTest, WrapText_WithTabs)
 {
     std::string toWrap   = "\t\tThe quick brown \tfox jumps over \tthe lazy dog.\t";
     std::string wantWrap = "The quick\nbrown \tfox\njumps over\nthe lazy\ndog.\n";
@@ -157,7 +157,7 @@ TEST(StringUtilTest, WrapTextWithTabs)
     EXPECT_EQ(wrapped, wantWrap);
 }
 
-TEST(StringUtilTest, WrapTextMixedTabsAndSpaces)
+TEST(StringUtilTest, WrapText_MixedTabsAndSpaces)
 {
     std::string toWrap   = "    \t\tThe quick brown \tfox       jumps over \tthe lazy dog. \t  ";
     std::string wantWrap = "The quick\nbrown \tfox\njumps over\nthe lazy\ndog.\n";
@@ -165,7 +165,7 @@ TEST(StringUtilTest, WrapTextMixedTabsAndSpaces)
     EXPECT_EQ(wrapped, wantWrap);
 }
 
-TEST(StringUtilTest, WrapTextLongWord)
+TEST(StringUtilTest, WrapText_LongWord)
 {
     std::string toWrap   = "The quick brown fox jumps over the extremely-long-word-here lazy dog.";
     std::string wantWrap = R"(The quick
@@ -181,7 +181,7 @@ dog.
     EXPECT_EQ(wrapped, wantWrap);
 }
 
-TEST(StringUtilTest, WrapTextLongTextWithIndent)
+TEST(StringUtilTest, WrapText_LongTextWithIndent)
 {
     std::string toWrap   = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
 Cras dapibus finibus nibh, id volutpat odio porta eget. Curabitur lacus urna, \
@@ -205,4 +205,73 @@ blandit neque sed nisl pretium, quis volutpat dui pharetra.";
 )";
     std::string wrapped  = WrapText(toWrap, 80, 20);
     EXPECT_EQ(wrapped, wantWrap);
+}
+
+TEST(StringUtilTest, ToString_Bool)
+{
+    bool        b          = false;
+    std::string wantString = "false";
+    std::string gotString  = ToString(b);
+    EXPECT_EQ(gotString, wantString);
+
+    b          = true;
+    wantString = "true";
+    gotString  = ToString(b);
+    EXPECT_EQ(gotString, wantString);
+}
+
+TEST(StringUtilTest, ToString_Int)
+{
+    int         i          = 4;
+    std::string wantString = "4";
+    std::string gotString  = ToString(i);
+    EXPECT_EQ(gotString, wantString);
+
+    i          = -10;
+    wantString = "-10";
+    gotString  = ToString(i);
+    EXPECT_EQ(gotString, wantString);
+}
+
+TEST(StringUtilTest, ToString_Float)
+{
+    float       f          = 4.5f;
+    std::string wantString = "4.5";
+    std::string gotString  = ToString(f);
+    EXPECT_EQ(gotString, wantString);
+
+    f          = -3.1415f;
+    wantString = "-3.1415";
+    gotString  = ToString(f);
+    EXPECT_EQ(gotString, wantString);
+
+    // Trims trailing zeros
+    f          = 80.000f;
+    wantString = "80";
+    gotString  = ToString(f);
+    EXPECT_EQ(gotString, wantString);
+}
+
+TEST(StringUtilTest, ToString_PairInt)
+{
+    std::pair<int, int> pi         = std::make_pair(10, 20);
+    std::string         wantString = "10, 20";
+    std::string         gotString  = ToString(pi);
+    EXPECT_EQ(gotString, wantString);
+}
+
+TEST(StringUtilTest, ToString_VectorString)
+{
+    std::vector<std::string> vs         = {"hello", "world", "!"};
+    std::string              wantString = "hello, world, !";
+    std::string              gotString  = ToString(vs);
+    EXPECT_EQ(gotString, wantString);
+}
+
+TEST(StringUtilTest, ToString_VectorBool)
+{
+    std::vector<bool> vb         = {true, false, true, true, false};
+    std::string       wantString = "true, false, true, true, false";
+    std::string       gotString  = ToString(vb);
+    EXPECT_EQ(gotString, wantString);
 }

--- a/src/test/string_util_test.cpp
+++ b/src/test/string_util_test.cpp
@@ -180,3 +180,29 @@ dog.
     std::string wrapped  = WrapText(toWrap, 10, 0);
     EXPECT_EQ(wrapped, wantWrap);
 }
+
+TEST(StringUtilTest, WrapTextLongTextWithIndent)
+{
+    std::string toWrap   = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. \
+Cras dapibus finibus nibh, id volutpat odio porta eget. Curabitur lacus urna, \
+placerat tempus consequat id, vulputate eget urna. Suspendisse et massa eget erat \
+pretium convallis elementum quis nunc. Suspendisse lacinia justo tellus, a fermentum \
+metus cursus sed. Phasellus rhoncus ante nec augue rhoncus, id interdum nunc condimentum. \
+Pellentesque vel urna ac tellus euismod finibus quis ac magna. Cras sit amet sapien id \
+neque lobortis aliquam. Vivamus porttitor neque eu eros mollis imperdiet. Vivamus \
+blandit neque sed nisl pretium, quis volutpat dui pharetra.";
+    std::string wantWrap = R"(                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    Cras dapibus finibus nibh, id volutpat odio porta eget.
+                    Curabitur lacus urna, placerat tempus consequat id,
+                    vulputate eget urna. Suspendisse et massa eget erat pretium
+                    convallis elementum quis nunc. Suspendisse lacinia justo
+                    tellus, a fermentum metus cursus sed. Phasellus rhoncus ante
+                    nec augue rhoncus, id interdum nunc condimentum.
+                    Pellentesque vel urna ac tellus euismod finibus quis ac
+                    magna. Cras sit amet sapien id neque lobortis aliquam.
+                    Vivamus porttitor neque eu eros mollis imperdiet. Vivamus
+                    blandit neque sed nisl pretium, quis volutpat dui pharetra.
+)";
+    std::string wrapped  = WrapText(toWrap, 80, 20);
+    EXPECT_EQ(wrapped, wantWrap);
+}

--- a/src/test/string_util_test.cpp
+++ b/src/test/string_util_test.cpp
@@ -207,48 +207,59 @@ blandit neque sed nisl pretium, quis volutpat dui pharetra.";
     EXPECT_EQ(wrapped, wantWrap);
 }
 
-TEST(StringUtilTest, ToString_Bool)
+TEST(StringUtilTest, ToString_BoolTrue)
+{
+    bool        b          = true;
+    std::string wantString = "true";
+    std::string gotString  = ToString(b);
+    EXPECT_EQ(gotString, wantString);
+}
+
+TEST(StringUtilTest, ToString_BoolFalse)
 {
     bool        b          = false;
     std::string wantString = "false";
     std::string gotString  = ToString(b);
     EXPECT_EQ(gotString, wantString);
-
-    b          = true;
-    wantString = "true";
-    gotString  = ToString(b);
-    EXPECT_EQ(gotString, wantString);
 }
 
-TEST(StringUtilTest, ToString_Int)
+TEST(StringUtilTest, ToString_IntPositive)
 {
     int         i          = 4;
     std::string wantString = "4";
     std::string gotString  = ToString(i);
     EXPECT_EQ(gotString, wantString);
+}
 
-    i          = -10;
-    wantString = "-10";
-    gotString  = ToString(i);
+TEST(StringUtilTest, ToString_IntNegative)
+{
+    int         i          = -10;
+    std::string wantString = "-10";
+    std::string gotString  = ToString(i);
     EXPECT_EQ(gotString, wantString);
 }
 
-TEST(StringUtilTest, ToString_Float)
+TEST(StringUtilTest, ToString_FloatPositive)
 {
     float       f          = 4.5f;
     std::string wantString = "4.5";
     std::string gotString  = ToString(f);
     EXPECT_EQ(gotString, wantString);
+}
 
-    f          = -3.1415f;
-    wantString = "-3.1415";
-    gotString  = ToString(f);
+TEST(StringUtilTest, ToString_FloatNegative)
+{
+    float       f          = -3.1415f;
+    std::string wantString = "-3.1415";
+    std::string gotString  = ToString(f);
     EXPECT_EQ(gotString, wantString);
+}
 
-    // Trims trailing zeros
-    f          = 80.000f;
-    wantString = "80";
-    gotString  = ToString(f);
+TEST(StringUtilTest, ToString_FloatNoTrailingZeroes)
+{
+    float       f          = 80.8000f;
+    std::string wantString = "80.8";
+    std::string gotString  = ToString(f);
     EXPECT_EQ(gotString, wantString);
 }
 


### PR DESCRIPTION
Preparing knobs and utilities for implementing `StandardOptions` as knobs

To support vector knobs
* `GetExtraOptionValueOrDefault` in knob code replaced with `GetOptionValueOrDefault`
* Adding some unit test cases for complex knobs

Logging fixes/changes
* Changing `Application-Specific Flags` title into `Flags`
* Fix bug for `string_util::WrapText()` which would line break too early, added unit test case to catch this
* Added `Knob::ValueString()` and logging for initial knob values inside `UpdateFromFlags`, for easier debugging 
* Added `string_util::ToString()` util for drawing values of knobs
