### PR TITLE
Move C++20 feature out of the header file.

### DIFF
--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -73,7 +73,7 @@ class CliOptions
 public:
     CliOptions() = default;
 
-    bool HasExtraOption(std::string_view option) const { return mAllOptions.contains(option); }
+    bool HasExtraOption(std::string_view option) const;
 
     // Returns the number of unique options and flags that were specified on the commandline,
     // not counting multiple appearances of the same flag such as: --assets-path a --assets-path b

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -37,6 +37,11 @@ bool StartsWithDoubleDash(std::string_view s)
 
 namespace ppx {
 
+bool CliOptions::HasExtraOption(std::string_view option) const
+{
+    return mAllOptions.contains(option);
+}
+
 std::pair<int, int> CliOptions::GetOptionValueOrDefault(std::string_view optionName, const std::pair<int, int>& defaultValue) const
 {
     auto it = mAllOptions.find(optionName);


### PR DESCRIPTION
[`std::unordered_map::contains`](https://en.cppreference.com/w/cpp/container/unordered_map/contains) was added in C++20.

This keeps the header file C++17 compliant.