### PR TITLE
Add --config-json-path to accept flags specified in a JSON file.

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -252,7 +252,7 @@ struct StandardOptions
 #endif
 
     std::shared_ptr<KnobFlag<std::vector<std::string>>> pAssetsPaths;
-    std::shared_ptr<KnobFlag<std::vector<std::string>>> pConfigJsonPath;
+    std::shared_ptr<KnobFlag<std::vector<std::string>>> pConfigJsonPaths;
 };
 
 // -------------------------------------------------------------------------------------------------

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -252,6 +252,7 @@ struct StandardOptions
 #endif
 
     std::shared_ptr<KnobFlag<std::vector<std::string>>> pAssetsPaths;
+    std::shared_ptr<KnobFlag<std::vector<std::string>>> pConfigJsonPath;
 };
 
 // -------------------------------------------------------------------------------------------------

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -46,7 +46,7 @@ class CliOptions
 public:
     CliOptions() = default;
 
-    bool HasExtraOption(std::string_view option) const { return mAllOptions.contains(option); }
+    bool HasExtraOption(const std::string& option) const { return mAllOptions.contains(option); }
 
     // Returns the number of unique options and flags that were specified on the commandline,
     // not counting multiple appearances of the same flag such as: --assets-path a --assets-path b
@@ -57,7 +57,7 @@ public:
     // Warning: If this is called instead of the vector overload for multiple-value flags,
     //          only the last value will be returned.
     template <typename T>
-    T GetOptionValueOrDefault(std::string_view optionName, const T& defaultValue) const
+    T GetOptionValueOrDefault(const std::string& optionName, const T& defaultValue) const
     {
         auto it = mAllOptions.find(optionName);
         if (it == mAllOptions.cend()) {
@@ -70,7 +70,7 @@ public:
     // Same as above, but intended for list flags that are specified on the command line
     // with multiple instances of the same flag
     template <typename T>
-    std::vector<T> GetOptionValueOrDefault(std::string_view optionName, const std::vector<T>& defaultValues) const
+    std::vector<T> GetOptionValueOrDefault(const std::string& optionName, const std::vector<T>& defaultValues) const
     {
         auto it = mAllOptions.find(optionName);
         if (it == mAllOptions.cend()) {
@@ -86,14 +86,14 @@ public:
 
     // Same as above, but intended for resolution flags that are specified on command line
     // with <Width>x<Height>
-    std::pair<int, int> GetOptionValueOrDefault(std::string_view optionName, const std::pair<int, int>& defaultValue) const;
+    std::pair<int, int> GetOptionValueOrDefault(const std::string& optionName, const std::pair<int, int>& defaultValue) const;
 
     // (WILL BE DEPRECATED, USE KNOBS INSTEAD)
     // Get the parameter value after converting it into the desired integral,
     // floating-point, or boolean type. If the value fails to be converted,
     // return the specified default value.
     template <typename T>
-    T GetExtraOptionValueOrDefault(std::string_view optionName, const T& defaultValue) const
+    T GetExtraOptionValueOrDefault(const std::string& optionName, const T& defaultValue) const
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, std::string>, "GetExtraOptionValueOrDefault must be called with an integral, floating-point, boolean, or std::string type");
 
@@ -103,7 +103,7 @@ public:
 private:
     // Adds new option if the option does not already exist
     // Otherwise, the new value is appended to the end of the vector of stored parameters for this option
-    void AddOption(std::string_view optionName, std::string_view valueStr);
+    void AddOption(std::string_view optionName, std::string_view value);
 
     // Same as above, but appends an array of values at the same key
     void AddOption(std::string_view optionName, const std::vector<std::string>& valueArray);
@@ -136,18 +136,8 @@ private:
     }
 
 private:
-    struct string_hash
-    {
-        using hash_type      = std::hash<std::string_view>;
-        using is_transparent = void;
-
-        size_t operator()(const char* str) const { return hash_type{}(str); }
-        size_t operator()(std::string_view str) const { return hash_type{}(str); }
-        size_t operator()(std::string const& str) const { return hash_type{}(str); }
-    };
-
     // All flag names (string) and parameters (vector of strings) specified on the command line
-    std::unordered_map<std::string, std::vector<std::string>, string_hash, std::equal_to<>> mAllOptions;
+    std::unordered_map<std::string, std::vector<std::string>> mAllOptions;
 
     friend class CommandLineParser;
 };

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -124,9 +124,9 @@ private:
     T Parse(std::string_view valueStr, const T defaultValue) const
     {
         if constexpr (std::is_same_v<T, std::string>) {
-            return static_cast<std::string>(valueStr);
+            return std::string(valueStr);
         }
-        std::stringstream ss{static_cast<std::string>(valueStr)};
+        std::stringstream ss((std::string(valueStr)));
         T                 valueAsNum;
         ss >> valueAsNum;
         if (ss.fail()) {
@@ -163,9 +163,11 @@ public:
     // Adds all options specified within jsonConfig to mOpts.
     std::optional<ParsingError> AddJsonOptions(const nlohmann::json& jsonConfig);
 
+    std::string       GetJsonConfigFlagName() const { return mJsonConfigFlagName; }
     const CliOptions& GetOptions() const { return mOpts; }
     std::string       GetUsageMsg() const { return mUsageMsg; }
-    void              AppendUsageMsg(const std::string& additionalMsg) { mUsageMsg += additionalMsg; }
+
+    void AppendUsageMsg(const std::string& additionalMsg) { mUsageMsg += additionalMsg; }
 
 private:
     // Adds an option to mOpts and handles the special --no-flag-name case.
@@ -173,7 +175,8 @@ private:
     std::optional<ParsingError> AddOption(std::string_view optionName, std::string_view valueStr);
 
     CliOptions  mOpts;
-    std::string mUsageMsg = R"(
+    std::string mJsonConfigFlagName = "config-json-path";
+    std::string mUsageMsg           = R"(
 USAGE
 ==============================
 Boolean options can be turned on with:

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -108,6 +108,9 @@ private:
     // Same as above, but appends an array of values at the same key
     void AddOption(std::string_view optionName, const std::vector<std::string>& valueArray);
 
+    // For all options existing in newOptions, current entries in mAllOptions will be replaced by them
+    void OverwriteOptions(const CliOptions& newOptions);
+
     template <typename T>
     T GetParsedOrDefault(std::string_view valueStr, const T& defaultValue) const
     {
@@ -160,8 +163,12 @@ public:
     // and write the error to `out_error`.
     std::optional<ParsingError> Parse(int argc, const char* argv[]);
 
-    // Adds all options specified within jsonConfig to mOpts.
-    std::optional<ParsingError> AddJsonOptions(const nlohmann::json& jsonConfig);
+    // Parses all options specified within jsonConfig and adds them to cliOptions.
+    std::optional<ParsingError> ParseJson(CliOptions& cliOptions, const nlohmann::json& jsonConfig);
+
+    // Parses an option, handles the special --no-flag-name case, then adds the option to cliOptions
+    // Expects option names without the "--" prefix.
+    std::optional<ParsingError> ParseOption(CliOptions& cliOptions, std::string_view optionName, std::string_view valueStr);
 
     std::string       GetJsonConfigFlagName() const { return mJsonConfigFlagName; }
     const CliOptions& GetOptions() const { return mOpts; }
@@ -170,10 +177,6 @@ public:
     void AppendUsageMsg(const std::string& additionalMsg) { mUsageMsg += additionalMsg; }
 
 private:
-    // Adds an option to mOpts and handles the special --no-flag-name case.
-    // Expects option names without the "--" prefix.
-    std::optional<ParsingError> AddOption(std::string_view optionName, std::string_view valueStr);
-
     CliOptions  mOpts;
     std::string mJsonConfigFlagName = "config-json-path";
     std::string mUsageMsg           = R"(

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -806,11 +806,16 @@ void Application::SaveMetricsReportToDisk()
 void Application::InitStandardKnobs()
 {
     // Flag names in alphabetical order
-    std::vector<std::string> defaultAssetsPaths = {};
+    std::vector<std::string> defaultEmptyList = {};
     mStandardOpts.pAssetsPaths =
-        mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>("assets-path", defaultAssetsPaths);
+        mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>("assets-path", defaultEmptyList);
     mStandardOpts.pAssetsPaths->SetFlagDescription(
         "Add a path in front of the assets search path list.");
+    mStandardOpts.pAssetsPaths->SetFlagParameters("<path>");
+
+    mStandardOpts.pConfigJsonPath = mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>("config-json-path", defaultEmptyList);
+    mStandardOpts.pAssetsPaths->SetFlagDescription(
+        "Additional commandline flags specified in a JSON file.");
     mStandardOpts.pAssetsPaths->SetFlagParameters("<path>");
 
     mStandardOpts.pDeterministic =

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -813,13 +813,13 @@ void Application::InitStandardKnobs()
         "Add a path in front of the assets search path list.");
     mStandardOpts.pAssetsPaths->SetFlagParameters("<path>");
 
-    mStandardOpts.pConfigJsonPath = mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>(mCommandLineParser.GetJsonConfigFlagName(), defaultEmptyList);
-    mStandardOpts.pConfigJsonPath->SetFlagDescription(
+    mStandardOpts.pConfigJsonPaths = mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>(mCommandLineParser.GetJsonConfigFlagName(), defaultEmptyList);
+    mStandardOpts.pConfigJsonPaths->SetFlagDescription(
         "Additional commandline flags specified in a JSON file. Values specified in JSON files are "
         "always lower priority than those specified on the command line. Between different files, the "
         "later ones take priority. For lists, the JSON values will come earlier in the array than the "
         "command-line values");
-    mStandardOpts.pConfigJsonPath->SetFlagParameters("<path>");
+    mStandardOpts.pConfigJsonPaths->SetFlagParameters("<path>");
 
     mStandardOpts.pDeterministic =
         mKnobManager.CreateKnob<KnobFlag<bool>>("deterministic", false);

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -672,8 +672,8 @@ void Application::DispatchConfig()
 
     auto assetPaths = mStandardOpts.pAssetsPaths->GetValue();
     if (!assetPaths.empty()) {
-        // Insert at front, in reverse order, so we respect the command line ordering for priority.
-        for (auto it = assetPaths.rbegin(); it < assetPaths.rend(); it++) {
+        // Asset directories specified later have higher priority
+        for (auto it = assetPaths.begin(); it < assetPaths.end(); it++) {
             AddAssetDir(*it, /* insert_at_front= */ true);
         }
     }

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -813,10 +813,13 @@ void Application::InitStandardKnobs()
         "Add a path in front of the assets search path list.");
     mStandardOpts.pAssetsPaths->SetFlagParameters("<path>");
 
-    mStandardOpts.pConfigJsonPath = mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>("config-json-path", defaultEmptyList);
-    mStandardOpts.pAssetsPaths->SetFlagDescription(
-        "Additional commandline flags specified in a JSON file.");
-    mStandardOpts.pAssetsPaths->SetFlagParameters("<path>");
+    mStandardOpts.pConfigJsonPath = mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>(mCommandLineParser.GetJsonConfigFlagName(), defaultEmptyList);
+    mStandardOpts.pConfigJsonPath->SetFlagDescription(
+        "Additional commandline flags specified in a JSON file. Values specified in JSON files are "
+        "always lower priority than those specified on the command line. Between different files, the "
+        "later ones take priority. For lists, the JSON values will come earlier in the array than the "
+        "command-line values");
+    mStandardOpts.pConfigJsonPath->SetFlagParameters("<path>");
 
     mStandardOpts.pDeterministic =
         mKnobManager.CreateKnob<KnobFlag<bool>>("deterministic", false);

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -672,8 +672,8 @@ void Application::DispatchConfig()
 
     auto assetPaths = mStandardOpts.pAssetsPaths->GetValue();
     if (!assetPaths.empty()) {
-        // Asset directories specified later have higher priority
-        for (auto it = assetPaths.begin(); it < assetPaths.end(); it++) {
+        // Insert at front, in reverse order, so we respect the command line ordering for priority.
+        for (auto it = assetPaths.rbegin(); it < assetPaths.rend(); it++) {
             AddAssetDir(*it, /* insert_at_front= */ true);
         }
     }
@@ -810,15 +810,14 @@ void Application::InitStandardKnobs()
     mStandardOpts.pAssetsPaths =
         mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>("assets-path", defaultEmptyList);
     mStandardOpts.pAssetsPaths->SetFlagDescription(
-        "Add a path in front of the assets search path list.");
+        "Add a path before the default assets folder in the search list.");
     mStandardOpts.pAssetsPaths->SetFlagParameters("<path>");
 
     mStandardOpts.pConfigJsonPaths = mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>(mCommandLineParser.GetJsonConfigFlagName(), defaultEmptyList);
     mStandardOpts.pConfigJsonPaths->SetFlagDescription(
         "Additional commandline flags specified in a JSON file. Values specified in JSON files are "
-        "always lower priority than those specified on the command line. Between different files, the "
-        "later ones take priority. For lists, the JSON values will come earlier in the array than the "
-        "command-line values");
+        "always overwritten by those specified on the command line. Between different files, the "
+        "later ones take priority.");
     mStandardOpts.pConfigJsonPaths->SetFlagParameters("<path>");
 
     mStandardOpts.pDeterministic =

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -151,7 +151,10 @@ std::optional<CommandLineParser::ParsingError> CommandLineParser::Parse(int argc
     std::vector<std::string> configJsonPaths;
     configJsonPaths = mOpts.GetOptionValueOrDefault("config-json-path", configJsonPaths);
     for (const auto& jsonPath : configJsonPaths) {
-        std::ifstream  f(jsonPath);
+        std::ifstream f(jsonPath);
+        if (f.fail()) {
+            return "Invalid --config-json-path: " + jsonPath;
+        }
         nlohmann::json data = nlohmann::json::parse(f);
         if (auto error = AddJsonOptions(data)) {
             return error;

--- a/src/ppx/command_line_parser.cpp
+++ b/src/ppx/command_line_parser.cpp
@@ -38,7 +38,7 @@ bool StartsWithDoubleDash(std::string_view s)
 
 namespace ppx {
 
-std::pair<int, int> CliOptions::GetOptionValueOrDefault(std::string_view optionName, const std::pair<int, int>& defaultValue) const
+std::pair<int, int> CliOptions::GetOptionValueOrDefault(const std::string& optionName, const std::pair<int, int>& defaultValue) const
 {
     auto it = mAllOptions.find(optionName);
     if (it == mAllOptions.cend()) {
@@ -55,22 +55,25 @@ std::pair<int, int> CliOptions::GetOptionValueOrDefault(std::string_view optionN
     return std::make_pair(N, M);
 }
 
-void CliOptions::AddOption(std::string_view optionName, std::string_view valueStr)
+void CliOptions::AddOption(std::string_view optionName, std::string_view value)
 {
-    auto it = mAllOptions.find(optionName);
+    std::string optionNameStr{optionName};
+    std::string valueStr{value};
+    auto        it = mAllOptions.find(optionNameStr);
     if (it == mAllOptions.cend()) {
-        std::vector<std::string> v{std::string(valueStr)};
-        mAllOptions.emplace(std::string(optionName), v);
+        std::vector<std::string> v{valueStr};
+        mAllOptions.emplace(optionName, v);
         return;
     }
-    it->second.push_back(std::string(valueStr));
+    it->second.push_back(valueStr);
 }
 
 void CliOptions::AddOption(std::string_view optionName, const std::vector<std::string>& valueArray)
 {
-    auto it = mAllOptions.find(optionName);
+    std::string optionNameStr{optionName};
+    auto        it = mAllOptions.find(optionNameStr);
     if (it == mAllOptions.cend()) {
-        mAllOptions.emplace(std::string(optionName), valueArray);
+        mAllOptions.emplace(optionNameStr, valueArray);
         return;
     }
     auto storedValueArray = it->second;

--- a/src/test/command_line_parser_test.cpp
+++ b/src/test/command_line_parser_test.cpp
@@ -22,7 +22,7 @@ namespace {
 
 using ::testing::HasSubstr;
 
-TEST(CommandLineParserTest, ZeroArguments)
+TEST(CommandLineParserTest, Parse_ZeroArguments)
 {
     CommandLineParser parser;
     if (auto error = parser.Parse(0, nullptr)) {
@@ -31,7 +31,7 @@ TEST(CommandLineParserTest, ZeroArguments)
     EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 0);
 }
 
-TEST(CommandLineParserTest, FirstArgumentIgnored)
+TEST(CommandLineParserTest, Parse_FirstArgumentIgnored)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable"};
@@ -41,7 +41,7 @@ TEST(CommandLineParserTest, FirstArgumentIgnored)
     EXPECT_EQ(parser.GetOptions().GetNumUniqueOptions(), 0);
 }
 
-TEST(CommandLineParserTest, BooleansSuccessfullyParsed)
+TEST(CommandLineParserTest, Parse_Booleans)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "--b", "1", "--c", "true", "--no-d", "--e", "0", "--f", "false"};
@@ -58,7 +58,7 @@ TEST(CommandLineParserTest, BooleansSuccessfullyParsed)
     EXPECT_EQ(gotOptions.GetOptionValueOrDefault<bool>("f", true), false);
 }
 
-TEST(CommandLineParserTest, StringsSuccessfullyParsed)
+TEST(CommandLineParserTest, Parse_Strings)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "filename with spaces", "--b", "filenameWithoutSpaces", "--c", "filename,with/.punctuation,", "--d", "", "--e"};
@@ -74,7 +74,7 @@ TEST(CommandLineParserTest, StringsSuccessfullyParsed)
     EXPECT_EQ(gotOptions.GetOptionValueOrDefault<std::string>("e", "foo"), "");
 }
 
-TEST(CommandLineParserTest, IntegersSuccessfullyParsed)
+TEST(CommandLineParserTest, Parse_Integers)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "0", "--b", "-5", "--c", "300", "--d", "0", "--e", "1000"};
@@ -90,7 +90,7 @@ TEST(CommandLineParserTest, IntegersSuccessfullyParsed)
     EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("e", -1), 1000);
 }
 
-TEST(CommandLineParserTest, FloatsSuccessfullyParsed)
+TEST(CommandLineParserTest, Parse_Floats)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "1.0", "--b", "-6.5", "--c", "300"};
@@ -104,7 +104,7 @@ TEST(CommandLineParserTest, FloatsSuccessfullyParsed)
     EXPECT_EQ(gotOptions.GetOptionValueOrDefault<float>("c", 0.0f), 300.0f);
 }
 
-TEST(CommandLineParserTest, StringListSuccesfullyParsed)
+TEST(CommandLineParserTest, Parse_StringList)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "some-path", "--a", "some-other-path", "--a", "last-path"};
@@ -122,7 +122,7 @@ TEST(CommandLineParserTest, StringListSuccesfullyParsed)
     }
 }
 
-TEST(CommandLineParserTest, ResolutionSuccesfullyParsed)
+TEST(CommandLineParserTest, Parse_Resolution)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "1000x2000"};
@@ -136,7 +136,7 @@ TEST(CommandLineParserTest, ResolutionSuccesfullyParsed)
     EXPECT_EQ(res.second, 2000);
 }
 
-TEST(CommandLineParserTest, ResolutionSuccessfullyParsedButDefaulted)
+TEST(CommandLineParserTest, Parse_ResolutionDefaulted)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "1000X2000"};
@@ -150,7 +150,7 @@ TEST(CommandLineParserTest, ResolutionSuccessfullyParsedButDefaulted)
     EXPECT_EQ(res.second, 0);
 }
 
-TEST(CommandLineParserTest, EqualSignsSuccessfullyParsed)
+TEST(CommandLineParserTest, Parse_EqualSigns)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "--b=5", "--c", "--d", "11"};
@@ -165,7 +165,7 @@ TEST(CommandLineParserTest, EqualSignsSuccessfullyParsed)
     EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("d", 0), 11);
 }
 
-TEST(CommandLineParserTest, EqualSignsMultipleFailedParsed)
+TEST(CommandLineParserTest, Parse_EqualSignsMultipleFail)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "--b=5=8", "--c", "--d", "11"};
@@ -174,7 +174,7 @@ TEST(CommandLineParserTest, EqualSignsMultipleFailedParsed)
     EXPECT_THAT(error->errorMsg, HasSubstr("Unexpected number of '=' symbols in the following string"));
 }
 
-TEST(CommandLineParserTest, EqualSignsMalformedFailedParsed)
+TEST(CommandLineParserTest, Parse_EqualSignsMalformedFail)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "--b=", "--c", "--d", "11"};
@@ -183,7 +183,7 @@ TEST(CommandLineParserTest, EqualSignsMalformedFailedParsed)
     EXPECT_THAT(error->errorMsg, HasSubstr("Malformed flag with '='"));
 }
 
-TEST(CommandLineParserTest, LeadingParameterFailedParsed)
+TEST(CommandLineParserTest, Parse_LeadingParameterFail)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "10", "--a", "--b", "5", "--c", "--d", "11"};
@@ -192,7 +192,7 @@ TEST(CommandLineParserTest, LeadingParameterFailedParsed)
     EXPECT_THAT(error->errorMsg, HasSubstr("Invalid command-line option"));
 }
 
-TEST(CommandLineParserTest, AdjacentParameterFailedParsed)
+TEST(CommandLineParserTest, Parse_AdjacentParameterFail)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "--b", "5", "8", "--c", "--d", "11"};
@@ -201,7 +201,7 @@ TEST(CommandLineParserTest, AdjacentParameterFailedParsed)
     EXPECT_THAT(error->errorMsg, HasSubstr("Invalid command-line option"));
 }
 
-TEST(CommandLineParserTest, LastValueIsTaken)
+TEST(CommandLineParserTest, Parse_LastValueIsTaken)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--a", "1", "--b", "1", "--a", "2", "--a", "3"};
@@ -214,7 +214,7 @@ TEST(CommandLineParserTest, LastValueIsTaken)
     EXPECT_EQ(gotOptions.GetOptionValueOrDefault<int>("b", 0), 1);
 }
 
-TEST(CommandLineParserTest, ExtraOptionsSuccessfullyParsed)
+TEST(CommandLineParserTest, Parse_ExtraOptions)
 {
     CommandLineParser parser;
     const char*       args[] = {"/path/to/executable", "--extra-option-bool", "true", "--extra-option-int", "123", "--extra-option-no-param", "--extra-option-str", "option string value"};
@@ -230,20 +230,21 @@ TEST(CommandLineParserTest, ExtraOptionsSuccessfullyParsed)
     EXPECT_TRUE(opts.HasExtraOption("extra-option-no-param"));
 }
 
-TEST(CommandLineParserTest, JsonEmptyParsedSuccessfully)
+TEST(CommandLineParserTest, ParseJson_Empty)
 {
     CommandLineParser parser;
+    CliOptions        opts;
     nlohmann::json    jsonConfig;
-    if (auto error = parser.AddJsonOptions(jsonConfig)) {
+    if (auto error = parser.ParseJson(opts, jsonConfig)) {
         FAIL() << error->errorMsg;
     }
-    auto opts = parser.GetOptions();
     EXPECT_EQ(opts.GetNumUniqueOptions(), 0);
 }
 
-TEST(CommandLineParserTest, JsonSimpleParsedSuccessfully)
+TEST(CommandLineParserTest, ParseJson_Simple)
 {
     CommandLineParser parser;
+    CliOptions        opts;
     std::string       jsonText   = R"(
   {
     "a": true,
@@ -256,10 +257,9 @@ TEST(CommandLineParserTest, JsonSimpleParsedSuccessfully)
   }
 )";
     nlohmann::json    jsonConfig = nlohmann::json::parse(jsonText);
-    if (auto error = parser.AddJsonOptions(jsonConfig)) {
+    if (auto error = parser.ParseJson(opts, jsonConfig)) {
         FAIL() << error->errorMsg;
     }
-    auto opts = parser.GetOptions();
     EXPECT_EQ(opts.GetNumUniqueOptions(), 7);
     EXPECT_EQ(opts.GetOptionValueOrDefault<bool>("a", false), true);
     EXPECT_EQ(opts.GetOptionValueOrDefault<bool>("b", true), false);
@@ -272,9 +272,10 @@ TEST(CommandLineParserTest, JsonSimpleParsedSuccessfully)
     EXPECT_EQ(gFlag.second, 300);
 }
 
-TEST(CommandLineParserTest, JsonWithNestedStructure)
+TEST(CommandLineParserTest, ParseJson_NestedStructure)
 {
     CommandLineParser parser;
+    CliOptions        opts;
     std::string       jsonText   = R"(
   {
     "a": true,
@@ -285,10 +286,9 @@ TEST(CommandLineParserTest, JsonWithNestedStructure)
   }
 )";
     nlohmann::json    jsonConfig = nlohmann::json::parse(jsonText);
-    if (auto error = parser.AddJsonOptions(jsonConfig)) {
+    if (auto error = parser.ParseJson(opts, jsonConfig)) {
         FAIL() << error->errorMsg;
     }
-    auto opts = parser.GetOptions();
     EXPECT_EQ(opts.GetNumUniqueOptions(), 2);
     EXPECT_EQ(opts.GetOptionValueOrDefault<bool>("a", false), true);
     EXPECT_TRUE(opts.HasExtraOption("b"));
@@ -297,9 +297,10 @@ TEST(CommandLineParserTest, JsonWithNestedStructure)
     EXPECT_FALSE(opts.HasExtraOption("d"));
 }
 
-TEST(CommandLineParserTest, JsonWithIntArray)
+TEST(CommandLineParserTest, ParseJson_IntArray)
 {
     CommandLineParser parser;
+    CliOptions        opts;
     std::string       jsonText   = R"(
   {
     "a": true,
@@ -307,10 +308,9 @@ TEST(CommandLineParserTest, JsonWithIntArray)
   }
 )";
     nlohmann::json    jsonConfig = nlohmann::json::parse(jsonText);
-    if (auto error = parser.AddJsonOptions(jsonConfig)) {
+    if (auto error = parser.ParseJson(opts, jsonConfig)) {
         FAIL() << error->errorMsg;
     }
-    auto opts = parser.GetOptions();
     EXPECT_EQ(opts.GetNumUniqueOptions(), 2);
     EXPECT_EQ(opts.GetOptionValueOrDefault<bool>("a", false), true);
     EXPECT_TRUE(opts.HasExtraOption("b"));
@@ -322,9 +322,10 @@ TEST(CommandLineParserTest, JsonWithIntArray)
     EXPECT_EQ(gotB.at(2), 3);
 }
 
-TEST(CommandLineParserTest, JsonWithStrArray)
+TEST(CommandLineParserTest, ParseJson_StrArray)
 {
     CommandLineParser parser;
+    CliOptions        opts;
     std::string       jsonText   = R"(
   {
     "a": true,
@@ -332,10 +333,9 @@ TEST(CommandLineParserTest, JsonWithStrArray)
   }
 )";
     nlohmann::json    jsonConfig = nlohmann::json::parse(jsonText);
-    if (auto error = parser.AddJsonOptions(jsonConfig)) {
+    if (auto error = parser.ParseJson(opts, jsonConfig)) {
         FAIL() << error->errorMsg;
     }
-    auto opts = parser.GetOptions();
     EXPECT_EQ(opts.GetNumUniqueOptions(), 2);
     EXPECT_EQ(opts.GetOptionValueOrDefault<bool>("a", false), true);
     EXPECT_TRUE(opts.HasExtraOption("b"));
@@ -347,9 +347,10 @@ TEST(CommandLineParserTest, JsonWithStrArray)
     EXPECT_EQ(gotB.at(2), "third");
 }
 
-TEST(CommandLineParserTest, JsonWithHeterogeneousArray)
+TEST(CommandLineParserTest, ParseJson_HeterogeneousArray)
 {
     CommandLineParser parser;
+    CliOptions        opts;
     std::string       jsonText   = R"(
   {
     "a": true,
@@ -357,10 +358,9 @@ TEST(CommandLineParserTest, JsonWithHeterogeneousArray)
   }
 )";
     nlohmann::json    jsonConfig = nlohmann::json::parse(jsonText);
-    if (auto error = parser.AddJsonOptions(jsonConfig)) {
+    if (auto error = parser.ParseJson(opts, jsonConfig)) {
         FAIL() << error->errorMsg;
     }
-    auto opts = parser.GetOptions();
     EXPECT_EQ(opts.GetNumUniqueOptions(), 2);
     EXPECT_EQ(opts.GetOptionValueOrDefault<bool>("a", false), true);
     EXPECT_TRUE(opts.HasExtraOption("b"));
@@ -373,37 +373,28 @@ TEST(CommandLineParserTest, JsonWithHeterogeneousArray)
     EXPECT_EQ(gotB.at(3), "4.0");
 }
 
-TEST(CommandLineParserTest, JsonVsCommandlinePriority)
+TEST(CommandLineParserTest, ParseOption_Simple)
 {
     CommandLineParser parser;
-    std::string       jsonText   = R"(
-  {
-    "a": 1,
-    "b": ["one", "two", "three"]
-  }
-)";
-    nlohmann::json    jsonConfig = nlohmann::json::parse(jsonText);
-    if (auto error = parser.AddJsonOptions(jsonConfig)) {
+    CliOptions        opts;
+    if (auto error = parser.ParseOption(opts, "flag-name", "true")) {
         FAIL() << error->errorMsg;
     }
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 1);
+    EXPECT_TRUE(opts.HasExtraOption("flag-name"));
+    EXPECT_EQ(opts.GetOptionValueOrDefault<bool>("flag-name", false), true);
+}
 
-    const char* args[] = {"/path/to/executable", "--b", "four", "--a", "2", "--b", "five", "--a", "3"};
-    if (auto error = parser.Parse(sizeof(args) / sizeof(args[0]), args)) {
+TEST(CommandLineParserTest, ParseOption_NoPrefix)
+{
+    CommandLineParser parser;
+    CliOptions        opts;
+    if (auto error = parser.ParseOption(opts, "no-flag-name", "")) {
         FAIL() << error->errorMsg;
     }
-
-    auto opts = parser.GetOptions();
-    EXPECT_EQ(opts.GetNumUniqueOptions(), 2);
-    EXPECT_EQ(opts.GetOptionValueOrDefault<int>("a", 0), 3);
-    EXPECT_TRUE(opts.HasExtraOption("b"));
-    std::vector<std::string> defaultB = {};
-    std::vector<std::string> gotB     = opts.GetOptionValueOrDefault<std::string>("b", defaultB);
-    EXPECT_EQ(gotB.size(), 5);
-    EXPECT_EQ(gotB.at(0), "one");
-    EXPECT_EQ(gotB.at(1), "two");
-    EXPECT_EQ(gotB.at(2), "three");
-    EXPECT_EQ(gotB.at(3), "four");
-    EXPECT_EQ(gotB.at(4), "five");
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 1);
+    EXPECT_TRUE(opts.HasExtraOption("flag-name"));
+    EXPECT_EQ(opts.GetOptionValueOrDefault<bool>("flag-name", true), false);
 }
 
 } // namespace


### PR DESCRIPTION
Add flag --config-json-path to accept commandline flags that are specified in a JSON file. This flag can be used multiple times. The priority of any conflicting flags is as follows:

later flag on commandline > earlier flag on commandline > flag in later JSON file > flag in earlier JSON file

For flags that accept multiple values, the same priority is used and only flags specified in the same JSON file or flags all on the commandline will be combined.

Detailed changes:
* Changed map `mAllOptions` to hold `strings` instead of `string_views` since there are now temporary strings originating from the JSON structure, changed some input parameters for `CliOptions` member functions to match.
* Created some `CommandLineParser` methods to aid in parsing options (these are public for unit testing purposes)
  * `ParseJson`
  * `ParseOption`
* Created more methods for `CliOptions`
  * `AddOption` overload that accepts one key and a vector of values to reduce the time needed to insert arrays. This function is only used by the JSON parsing flow. On the command line the flag must still be specified multiple times (`--flag-name 1,2,3` is still invalid)
  * `OverwriteOptions`
* Updated `CommandLineParser::Parse`
  * Added a second initial pass of argv during commandline parsing to identify any provided JSON config files
  * Implemented overwriting
* Added `mJsonConfigFlagName` to `CommandLineParser` so that the string `config-json-path` isn't specified in multiple places