### PR TITLE
Add Vertex/Pixel shader knobs + output 0.5 alpha for all PS

### DIFF
--- a/assets/benchmarks/shaders/Benchmark_PsAluBound.hlsl
+++ b/assets/benchmarks/shaders/Benchmark_PsAluBound.hlsl
@@ -87,5 +87,5 @@ float4 psmain(VSOutput input) : SV_TARGET
     const float3 specularBRDF = (F * D * G) / max(0.00001, 4.0 * cosLi * cosLo);
     const float3 Co = (diffuseBRDF + specularBRDF) * Lrad * cosLi + Scene.Ambient.rrr * albedo.rgb;
 
-    return float4(Co / (Co + 1.f), 1);
+    return float4(Co / (Co + 1.f), 0.5);
 }

--- a/assets/benchmarks/shaders/Benchmark_PsMemBound.hlsl
+++ b/assets/benchmarks/shaders/Benchmark_PsMemBound.hlsl
@@ -98,5 +98,5 @@ float4 psmain(VSOutput input) : SV_TARGET
 
     float3 result = (ambient + diffuse ) * albedo.rgb + specular;
     
-    return float4(result.rgb, 1.0);
+    return float4(result.rgb, 0.5);
 }

--- a/assets/benchmarks/shaders/Benchmark_PsSimple.hlsl
+++ b/assets/benchmarks/shaders/Benchmark_PsSimple.hlsl
@@ -16,5 +16,5 @@
 
 float4 psmain(VSOutput input) : SV_TARGET
 {
-    return float4(input.uv, 0.0, 1.0);
+    return float4(input.uv, 0.0, 0.5);
 }


### PR DESCRIPTION
- An alpha value of 0.5 is set to facilitate whether alpha blending is on or off.
- The textures and samplers (Albedo, Normal and MetalR) will be added in an upcoming PR.