### PR TITLE
Add back the `--metrics-filename` knob.

### DIFF
--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -842,6 +842,16 @@ void Application::InitStandardKnobs()
         "Prints a list of the available GPUs on the current system with their "
         "index and exits (see --gpu).");
 
+    mStandardOpts.pMetricsFilename =
+        mKnobManager.CreateKnob<KnobFlag<std::string>>("metrics-filename", "report_@");
+    mStandardOpts.pMetricsFilename->SetFlagDescription(
+        "If metrics are enabled, save the metrics report to the "
+        "provided filename (including path). If used, any `@` "
+        "symbols in the filename (not the path) will be replaced "
+        "with the current timestamp. If the filename does not end in "
+        "`.json`, it will be appended. Default: `report_@`. See also: "
+        "`--enable-metrics` and `--overwrite-metrics-file`.");
+
     mStandardOpts.pOverwriteMetricsFile =
         mKnobManager.CreateKnob<KnobFlag<bool>>("overwrite-metrics-file", false);
     mStandardOpts.pOverwriteMetricsFile->SetFlagDescription(

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -788,18 +788,19 @@ void Application::ShutdownMetrics()
 
 void Application::SaveMetricsReportToDisk()
 {
-    if (mStandardOpts.pEnableMetrics == nullptr || !mStandardOpts.pEnableMetrics->GetValue()) {
+    // Ensure the base metrics knob was initialized by the KnobManager.
+    PPX_ASSERT_MSG(mStandardOpts.pEnableMetrics != nullptr, "The --enable-metrics knob was not initialized.");
+    if (!mStandardOpts.pEnableMetrics->GetValue()) {
         return;
     }
 
-    std::string metricsFilename;
-    if (mStandardOpts.pMetricsFilename != nullptr) {
-        metricsFilename = mStandardOpts.pMetricsFilename->GetValue();
-    }
+    // Ensure the needed knobs were initialized by the KnobManager.
+    PPX_ASSERT_MSG(mStandardOpts.pMetricsFilename != nullptr, "The --metrics-filename knob was not initialized.");
+    PPX_ASSERT_MSG(mStandardOpts.pOverwriteMetricsFile != nullptr, "The --overwrite-metrics-file knob was not initialized.");
 
     // Export the report from the metrics manager to the disk.
-    auto report = mMetrics.manager.CreateReport(metricsFilename);
-    report.WriteToDisk(mStandardOpts.pOverwriteMetricsFile != nullptr && mStandardOpts.pOverwriteMetricsFile->GetValue());
+    auto report = mMetrics.manager.CreateReport(mStandardOpts.pMetricsFilename->GetValue());
+    report.WriteToDisk(mStandardOpts.pOverwriteMetricsFile->GetValue());
 }
 
 void Application::InitStandardKnobs()

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -849,7 +849,7 @@ void Application::InitStandardKnobs()
         "index and exits (see --gpu).");
 
     mStandardOpts.pMetricsFilename =
-        mKnobManager.CreateKnob<KnobFlag<std::string>>("metrics-filename", "report_@");
+        mKnobManager.CreateKnob<KnobFlag<std::string>>("metrics-filename", "");
     mStandardOpts.pMetricsFilename->SetFlagDescription(
         "If metrics are enabled, save the metrics report to the "
         "provided filename (including path). If used, any `@` "

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -788,13 +788,18 @@ void Application::ShutdownMetrics()
 
 void Application::SaveMetricsReportToDisk()
 {
-    if (!mStandardOpts.pEnableMetrics->GetValue()) {
+    if (mStandardOpts.pEnableMetrics == nullptr || !mStandardOpts.pEnableMetrics->GetValue()) {
         return;
     }
 
+    std::string metricsFilename;
+    if (mStandardOpts.pMetricsFilename != nullptr) {
+        metricsFilename = mStandardOpts.pMetricsFilename->GetValue();
+    }
+
     // Export the report from the metrics manager to the disk.
-    auto report = mMetrics.manager.CreateReport(mStandardOpts.pMetricsFilename->GetValue());
-    report.WriteToDisk(mStandardOpts.pOverwriteMetricsFile->GetValue());
+    auto report = mMetrics.manager.CreateReport(metricsFilename);
+    report.WriteToDisk(mStandardOpts.pOverwriteMetricsFile != nullptr && mStandardOpts.pOverwriteMetricsFile->GetValue());
 }
 
 void Application::InitStandardKnobs()


### PR DESCRIPTION
This knob happened to be removed as part of https://github.com/google/bigwheels/pull/260. Adding it back, so that we can fully use the metrics feature again.