### PR TITLE
 Adjust the vertex shader input signature to match the vertex binding

### DIFF
--- a/assets/benchmarks/shaders/Benchmark_VsAluBound.hlsl
+++ b/assets/benchmarks/shaders/Benchmark_VsAluBound.hlsl
@@ -15,7 +15,7 @@
 #include "Benchmark.hlsli"
 
 VSOutput vsmain(
-    float4 position : POSITION,
+    float3 position : POSITION,
     float2 uv       : TEXCOORD,
     float3 normal   : NORMAL,
     float3 tangent   : TANGENT)
@@ -47,7 +47,7 @@ VSOutput vsmain(
     jointWeights.z * jointMat[int(jointIndices.z)] +
     jointWeights.w * jointMat[int(jointIndices.w)];
 
-  result.world_position = mul(Scene.ModelMatrix, position);
+  result.world_position = mul(Scene.ModelMatrix, float4(position, 1));
   result.position = mul(Scene.CameraViewProjectionMatrix, result.world_position);
   result.position = mul(skinMat, result.position);
   result.uv = uv;

--- a/assets/benchmarks/shaders/Benchmark_VsSimple.hlsl
+++ b/assets/benchmarks/shaders/Benchmark_VsSimple.hlsl
@@ -15,14 +15,14 @@
 #include "Benchmark.hlsli"
 
 VSOutput vsmain(
-    float4 position : POSITION,
+    float3 position : POSITION,
     float2 uv       : TEXCOORD,
     float3 normal   : NORMAL,
     float3 tangent   : TANGENT)
 {
   VSOutput result;
 
-  result.world_position = mul(Scene.ModelMatrix, position);
+  result.world_position = mul(Scene.ModelMatrix, float4(position, 1));
   result.position = mul(Scene.CameraViewProjectionMatrix, result.world_position);
   result.uv = uv;
   result.normal      = mul(Scene.ITModelMatrix, float4(normal, 0)).xyz;


### PR DESCRIPTION
- The type of POSITION (float4) in the vertex shader input signature has
  been modified, as it didn't correspond with the type of POSITION
  (float3) in the vertex binding.