### PR TITLE
Fix 08_basic_geometry

### DIFF
--- a/projects/08_basic_geometry/CMakeLists.txt
+++ b/projects/08_basic_geometry/CMakeLists.txt
@@ -18,4 +18,4 @@ project(08_basic_geometry)
 add_samples_for_all_apis(
     NAME ${PROJECT_NAME}
     SOURCES "main.cpp"
-    SHADER_DEPENDENCIES "shader_vertex_colors")
+    SHADER_DEPENDENCIES "shader_vertex_layout_test")

--- a/projects/08_basic_geometry/main.cpp
+++ b/projects/08_basic_geometry/main.cpp
@@ -107,7 +107,8 @@ void ProjApp::Setup()
     // Descriptor stuff
     {
         grfx::DescriptorPoolCreateInfo poolCreateInfo = {};
-        poolCreateInfo.uniformBuffer                  = 6;
+        // For the 9 entities created below.
+        poolCreateInfo.uniformBuffer = 9;
         PPX_CHECKED_CALL(GetDevice()->CreateDescriptorPool(&poolCreateInfo, &mDescriptorPool));
 
         grfx::DescriptorSetLayoutCreateInfo layoutCreateInfo = {};
@@ -118,6 +119,8 @@ void ProjApp::Setup()
     // Entities
     {
         TriMesh mesh = TriMesh::CreateCube(float3(2, 2, 2), TriMeshOptions().VertexColors().Normals());
+        // 9 total entities. Each uses a descriptor with a uniform buffer
+        // allocated from the descriptor pool created above.
         SetupEntity(mesh, GeometryOptions::InterleavedU16().AddColor().AddNormal(), &mInterleavedU16);
         SetupEntity(mesh, GeometryOptions::InterleavedU32().AddColor().AddNormal(), &mInterleavedU32);
         SetupEntity(mesh, GeometryOptions::Interleaved().AddColor().AddNormal(), &mInterleaved);


### PR DESCRIPTION
Addressing 2 issues following: https://github.com/google/bigwheels/pull/252
1) Updating the shader dependency for the new shader that is being used
2) Allocating the right number size for the descriptor pool, since the number of entities has increased