### PR TITLE
Fix gradle isssue with packaging generated shaders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,3 @@
-ext {
-    assetsPath = "${rootProject.projectDir}/assets"
-    thirdPartyAssetsPath = "${rootProject.projectDir}/third_party/assets"
-}
-
 subprojects {
     repositories {
         mavenCentral()
@@ -20,6 +15,36 @@ subprojects {
     }
 
     buildDir = "${rootProject.buildDir}/android/${project.name}"
+
+    ext {
+        assets = []
+        thirdPartyAssets = []
+    }
+
+    // copyTask copies project specific assets into a build asset folder,
+    // so they can be packaged into the APK.
+    task copyTask {
+        // doLast to make sure we get subproject assets value, and
+        // execute in execution phase.
+        doLast {
+            project.assets.each {
+                def fromFile = "${rootProject.projectDir}/assets/${it}"
+                def intoFile = "${buildDir}/assets/${it}"
+                copy {
+                    from fromFile
+                    into intoFile
+                }
+            }
+            project.thirdPartyAssets.each {
+                def fromFile = "${rootProject.projectDir}/third_party/assets/${it}"
+                def intoFile = "${buildDir}/assets/${it}"
+                copy {
+                    from fromFile
+                    into intoFile
+                }
+            }
+        }
+    }
 
     android {
         namespace 'com.google.bigwheels'
@@ -97,7 +122,6 @@ subprojects {
             it.buildConfigField "String", "sample_library_name", '"vk_' + project.name + '"'
             sourceSets.main {
                 java.srcDirs = [ "${rootProject.projectDir}/src/android" ]
-                assets.srcDirs = [ "assets" ]
                 if (project.name.contains("_xr")) {
                     manifest.srcFile "${rootProject.projectDir}/src/android/AndroidManifest.XR.xml"
                 } else {
@@ -105,9 +129,17 @@ subprojects {
                 }
             }
         }
-    }
 
-    // Each sample project must define copyTask for copying assets
-    // that are used in the project.
-    preBuild.dependsOn ":" + project.name + ":copyTask"
+        sourceSets.main.assets.srcDirs += new File("${buildDir}/assets")
+
+        applicationVariants.all { variant ->
+            // copyTask copies generated shaders, so it must be run after
+            // they are built. mustRunAfter only makes sure copyTask executes
+            // after the task if that task is already supposed to execute,
+            // but does not force it to be executed.
+            tasks["copyTask"].mustRunAfter("externalNativeBuild${variant.name.capitalize()}")
+            tasks["generate${variant.name.capitalize()}Assets"]
+              .dependsOn(copyTask)
+        }
+    }
 }

--- a/projects/01_triangle/build.gradle
+++ b/projects/01_triangle/build.gradle
@@ -1,7 +1,5 @@
-task copyTask {
-    copy {
-        from rootProject.ext.assetsPath + '/basic/shaders/spv'
-        into 'assets/basic/shaders/spv'
-        include '*.spv'
-    }
-}
+ArrayList projectAssets = [
+    "basic/shaders/spv"
+]
+
+project.assets = projectAssets

--- a/projects/04_cube/build.gradle
+++ b/projects/04_cube/build.gradle
@@ -1,7 +1,5 @@
-task copyTask {
-    copy {
-        from rootProject.ext.assetsPath + '/basic/shaders/spv'
-        into 'assets/basic/shaders/spv'
-        include '*.spv'
-    }
-}
+ArrayList projectAssets = [
+    "basic/shaders/spv"
+]
+
+project.assets = projectAssets

--- a/projects/04_cube_xr/build.gradle
+++ b/projects/04_cube_xr/build.gradle
@@ -1,7 +1,5 @@
-task copyTask {
-    copy {
-        from rootProject.ext.assetsPath + '/basic/shaders/spv'
-        into 'assets/basic/shaders/spv'
-        include '*.spv'
-    }
-}
+ArrayList projectAssets = [
+    "basic/shaders/spv"
+]
+
+project.assets = projectAssets

--- a/projects/08_basic_geometry/build.gradle
+++ b/projects/08_basic_geometry/build.gradle
@@ -1,7 +1,5 @@
-task copyTask {
-    copy {
-        from rootProject.ext.assetsPath + '/basic/shaders/spv'
-        into 'assets/basic/shaders/spv'
-        include '*.spv'
-    }
-}
+ArrayList projectAssets = [
+    "basic/shaders/spv"
+]
+
+project.assets = projectAssets

--- a/projects/15_basic_material/build.gradle
+++ b/projects/15_basic_material/build.gradle
@@ -1,23 +1,13 @@
-task copyTask {
-    copy {
-        from rootProject.ext.assetsPath + '/basic/models'
-        into 'assets/basic/models'
-    }
-    copy {
-        from rootProject.ext.assetsPath + '/basic/shaders/spv'
-        into 'assets/basic/shaders/spv'
-        include '*.spv'
-    }
-    copy {
-        from rootProject.ext.assetsPath + '/common/textures'
-        into 'assets/common/textures'
-    }
-    copy {
-        from rootProject.ext.assetsPath + '/materials/shaders'
-        into 'assets/materials/shaders'
-    }
-    copy {
-        from rootProject.ext.thirdPartyAssetsPath + '/poly_haven'
-        into 'assets/poly_haven'
-    }
-}
+ArrayList projectAssets = [
+    "basic/models",
+    "basic/shaders/spv",
+    "common/textures",
+    "materials/shaders",
+]
+
+ArrayList projectThirdPartyAssets = [
+    "poly_haven"
+]
+
+project.assets = projectAssets
+project.thirdPartyAssets = projectThirdPartyAssets

--- a/projects/15_basic_material/build.gradle
+++ b/projects/15_basic_material/build.gradle
@@ -2,7 +2,7 @@ ArrayList projectAssets = [
     "basic/models",
     "basic/shaders/spv",
     "common/textures",
-    "materials/shaders",
+    "materials/shaders/spv",
 ]
 
 ArrayList projectThirdPartyAssets = [

--- a/projects/16_gbuffer/build.gradle
+++ b/projects/16_gbuffer/build.gradle
@@ -1,16 +1,7 @@
-task copyTask {
-    copy {
-        from rootProject.ext.assetsPath + '/basic/shaders/spv'
-        into 'assets/basic/shaders/spv'
-        include '*.spv'
-    }
-    copy {
-        from rootProject.ext.assetsPath + '/gbuffer/shaders/spv'
-        into 'assets/gbuffer/shaders/spv'
-        include '*.spv'
-    }
-    copy {
-        from rootProject.ext.assetsPath + '/materials/textures'
-        into 'assets/materials/textures'
-    }
-}
+ArrayList projectAssets = [
+    "basic/shaders/spv",
+    "gbuffer/shaders/spv",
+    "materials/textures"
+]
+
+project.assets = projectAssets

--- a/projects/fishtornado/build.gradle
+++ b/projects/fishtornado/build.gradle
@@ -1,11 +1,6 @@
-task copyTask {
-    copy {
-        from rootProject.ext.assetsPath + '/basic/shaders/spv'
-        into 'assets/basic/shaders/spv'
-        include '*.spv'
-    }
-    copy {
-        from rootProject.ext.assetsPath + '/fishtornado'
-        into 'assets/fishtornado'
-    }
-}
+ArrayList projectAssets = [
+    "basic/shaders/spv",
+    "fishtornado"
+]
+
+project.assets = projectAssets

--- a/projects/fishtornado_xr/build.gradle
+++ b/projects/fishtornado_xr/build.gradle
@@ -1,11 +1,6 @@
-task copyTask {
-    copy {
-        from rootProject.ext.assetsPath + '/basic/shaders/spv'
-        into 'assets/basic/shaders/spv'
-        include '*.spv'
-    }
-    copy {
-        from rootProject.ext.assetsPath + '/fishtornado'
-        into 'assets/fishtornado'
-    }
-}
+ArrayList projectAssets = [
+    "basic/shaders/spv",
+    "fishtornado"
+]
+
+project.assets = projectAssets


### PR DESCRIPTION
Previously copyTask would run before shaders are actually generated, so they wouldn't be included correctly on the first try after a clean build.

This changes a few things:
- copyTask must now run after the native build that generates shaders, and before generate assets task
- subprojects specify a list of assets, and a task defined at the root build.gradle copies them
- the shaders are copied into a build folder, instead of a new assets folder in a subproject