### PR TITLE
Emulate some mouse movement/press with touch on Android

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -269,6 +269,10 @@ struct ApplicationSettings
     bool        enableImGui           = false;
     bool        allowThirdPartyAssets = false;
 
+#if defined(PPX_ANDROID)
+    bool emulateMouseAndroid = true;
+#endif
+
     struct
     {
         bool enable             = false;
@@ -522,6 +526,7 @@ private:
 
 private:
     friend struct WindowEvents;
+    friend class WindowImplAndroid;
     //
     // These functions exists so that applications can override the
     // corresponding Dispatch* methods without interfering with the

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -526,7 +526,6 @@ private:
 
 private:
     friend struct WindowEvents;
-    friend class WindowImplAndroid;
     //
     // These functions exists so that applications can override the
     // corresponding Dispatch* methods without interfering with the

--- a/src/ppx/window_android.cpp
+++ b/src/ppx/window_android.cpp
@@ -183,56 +183,58 @@ void WindowImplAndroid::OnResizeEvent()
 void WindowEvents::ProcessInputEvent(Application* pApp, AInputEvent* pEvent)
 {
     int32_t eventType = AInputEvent_getType(pEvent);
-    if (eventType == AINPUT_EVENT_TYPE_MOTION) {
-        int32_t  eventAction = AMotionEvent_getAction(pEvent);
-        uint32_t flags       = eventAction & AMOTION_EVENT_ACTION_MASK;
+    if (eventType != AINPUT_EVENT_TYPE_MOTION) {
+        return;
+    }
 
-        switch (flags) {
-            case AMOTION_EVENT_ACTION_DOWN: {
-                // First touch event becomes the primary touch we track.
-                mFirstTouchId = AMotionEvent_getPointerId(pEvent, 0);
+    int32_t  eventAction = AMotionEvent_getAction(pEvent);
+    uint32_t flags       = eventAction & AMOTION_EVENT_ACTION_MASK;
+
+    switch (flags) {
+        default:
+            break;
+        case AMOTION_EVENT_ACTION_DOWN: {
+            // First touch event becomes the primary touch we track.
+            mFirstTouchId = AMotionEvent_getPointerId(pEvent, 0);
+            float x       = AMotionEvent_getX(pEvent, 0);
+            float y       = AMotionEvent_getY(pEvent, 0);
+            // Call MouseMoveCallback first without any buttons "pressed",
+            // to update the mouse location, since it is not tracked otherwise.
+            pApp->MouseMoveCallback(x, y, 0);
+            pApp->MouseDownCallback(x, y, MOUSE_BUTTON_LEFT);
+            break;
+        }
+        case AMOTION_EVENT_ACTION_UP: {
+            // Last touch event is up, if this was the first touch
+            // that went up, end mouse down event.
+            if (mFirstTouchId > 0) {
+                mFirstTouchId = -1;
                 float x       = AMotionEvent_getX(pEvent, 0);
                 float y       = AMotionEvent_getY(pEvent, 0);
-                // Call MouseMoveCallback first without any buttons "pressed",
-                // to update the mouse location, since it is not tracked otherwise.
-                pApp->MouseMoveCallback(x, y, 0);
-                pApp->MouseDownCallback(x, y, MOUSE_BUTTON_LEFT);
-                break;
+                pApp->MouseUpCallback(x, y, MOUSE_BUTTON_LEFT);
             }
-            case AMOTION_EVENT_ACTION_UP: {
-                // Last touch event is up, if this was the first touch
-                // that went up, end mouse down event.
-                if (mFirstTouchId > 0) {
-                    mFirstTouchId = -1;
-                    float x       = AMotionEvent_getX(pEvent, 0);
-                    float y       = AMotionEvent_getY(pEvent, 0);
-                    pApp->MouseUpCallback(x, y, MOUSE_BUTTON_LEFT);
-                }
-                break;
+            break;
+        }
+        case AMOTION_EVENT_ACTION_POINTER_UP: {
+            int32_t pointerIndex = (eventAction & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
+            int32_t pointerId    = AMotionEvent_getPointerId(pEvent, pointerIndex);
+            // Only issue mouse up event, if the first registered touch has ended.
+            if (pointerId == mFirstTouchId) {
+                mFirstTouchId = -1;
+                float x       = AMotionEvent_getX(pEvent, pointerIndex);
+                float y       = AMotionEvent_getY(pEvent, pointerIndex);
+                pApp->MouseUpCallback(x, y, MOUSE_BUTTON_LEFT);
             }
-            case AMOTION_EVENT_ACTION_POINTER_UP: {
-                int32_t pointerIndex = (eventAction & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
-                int32_t pointerId    = AMotionEvent_getPointerId(pEvent, pointerIndex);
-                // Only issue mouse up event, if the first registered touch has ended.
-                if (pointerId == mFirstTouchId) {
-                    mFirstTouchId = -1;
-                    float x       = AMotionEvent_getX(pEvent, pointerIndex);
-                    float y       = AMotionEvent_getY(pEvent, pointerIndex);
-                    pApp->MouseUpCallback(x, y, MOUSE_BUTTON_LEFT);
-                }
-                break;
+            break;
+        }
+        case AMOTION_EVENT_ACTION_MOVE: {
+            if (mFirstTouchId != -1) {
+                // Only track the first registered touch event.
+                float x = AMotionEvent_getX(pEvent, 0);
+                float y = AMotionEvent_getY(pEvent, 0);
+                pApp->MouseMoveCallback(x, y, MOUSE_BUTTON_LEFT);
             }
-            case AMOTION_EVENT_ACTION_MOVE: {
-                if (mFirstTouchId != -1) {
-                    // Only track the first registered touch event.
-                    float x = AMotionEvent_getX(pEvent, 0);
-                    float y = AMotionEvent_getY(pEvent, 0);
-                    pApp->MouseMoveCallback(x, y, MOUSE_BUTTON_LEFT);
-                }
-                break;
-            }
-            default:
-                break;
+            break;
         }
     }
 }


### PR DESCRIPTION
Convert touch events to mouse movement:
- First touch will issue left mouse button press
- While the first touch is active it will be tracked as a mouse movement with left button pressed
- Other touches will not be registered
- When the first registered touch is lifted, the tracking will stop, until all touch points have lifted and a new "primary" touch is being tracked