### PR TITLE
Adding knob for rendering N fullscreen random quads 

### DIFF
--- a/assets/benchmarks/shaders/Benchmark_RandomNoise.hlsl
+++ b/assets/benchmarks/shaders/Benchmark_RandomNoise.hlsl
@@ -1,0 +1,46 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+struct RandomParams
+{
+    uint32_t Seed;
+};
+
+#if defined(__spirv__)
+[[vk::push_constant]]
+#endif
+ConstantBuffer<RandomParams> Random : register(b0);
+
+struct VSOutput {
+    float4 position : SV_POSITION;
+};
+
+VSOutput vsmain(float4 Position : POSITION)
+{
+	VSOutput result;
+	result.position = Position;
+	return result;
+}
+
+float random(float2 st, uint32_t seed) {
+    float underOne = sin(float(seed) + 0.5f);
+    float2 randomVector = float2(15.0f + underOne, 15.0f - underOne);
+    return frac(cos(dot(st.xy, randomVector))*40000.0f);
+}
+
+float4 psmain(VSOutput input) : SV_TARGET
+{
+    float rnd = random(input.position.xy, Random.Seed);
+    return float4(rnd, rnd, rnd, 1.0f);
+}

--- a/assets/benchmarks/shaders/CMakeLists.txt
+++ b/assets/benchmarks/shaders/CMakeLists.txt
@@ -90,3 +90,8 @@ generate_rules_for_shader("shader_benchmark_skybox"
     SOURCE "${PPX_DIR}/assets/benchmarks/shaders/Benchmark_SkyBox.hlsl"
     INCLUDES ${INCLUDE_FILES}
     STAGES "vs" "ps")
+
+generate_rules_for_shader("shader_benchmark_random_noise"
+    SOURCE "${PPX_DIR}/assets/benchmarks/shaders/Benchmark_RandomNoise.hlsl"
+    INCLUDES ${INCLUDE_FILES}
+    STAGES "vs" "ps")

--- a/benchmarks/graphics_pipeline/CMakeLists.txt
+++ b/benchmarks/graphics_pipeline/CMakeLists.txt
@@ -24,4 +24,5 @@ add_samples_for_all_apis(
       "shader_benchmark_ps_simple"
       "shader_benchmark_ps_alu_bound"
       "shader_benchmark_ps_mem_bound"
+      "shader_benchmark_random_noise"
       "shader_benchmark_skybox")


### PR DESCRIPTION
Adding knob for rendering N fullscreen random quads to graphics_pipeline benchmark

Added
* Pseudo random noise shader
* Slider knob for adjusting number of quads
* `Entity2D` structure for holding info related to noise quads