### PR TITLE
Split rendering in graphics_pipeline into separate renderpasses 

### DIFF
--- a/benchmarks/graphics_pipeline/main.cpp
+++ b/benchmarks/graphics_pipeline/main.cpp
@@ -816,14 +816,14 @@ void ProjApp::Render()
         // Write start timestamp
         frame.cmd->WriteTimestamp(frame.timestampQuery, grfx::PIPELINE_STAGE_TOP_OF_PIPE_BIT, /* queryIndex = */ 0);
 
-        grfx::RenderPassPtr renderPass = swapchain->GetRenderPass(imageIndex);
-        PPX_ASSERT_MSG(!renderPass.IsNull(), "render pass object is null");
+        // =====================================================================
+        // Scene renderpass
+        // =====================================================================
+        grfx::RenderPassPtr currentRenderPass = swapchain->GetRenderPass(imageIndex);
+        PPX_ASSERT_MSG(!currentRenderPass.IsNull(), "render pass object is null");
 
-        // =====================================================================
-        //  Render scene
-        // =====================================================================
-        frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
-        frame.cmd->BeginRenderPass(renderPass);
+        frame.cmd->TransitionImageLayout(currentRenderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
+        frame.cmd->BeginRenderPass(currentRenderPass);
         {
             frame.cmd->SetScissors(GetScissor());
             frame.cmd->SetViewports(GetViewport());
@@ -880,27 +880,53 @@ void ProjApp::Render()
                     frame.cmd->DrawIndexed(indexCount, /* instanceCount = */ 1, firstIndex);
                 }
             }
+        }
+        frame.cmd->EndRenderPass();
 
-            // Noise Quads
-            if (pNoiseQuadsCount->GetValue() > 0) {
-                // Draw noise quads
-                frame.cmd->BindGraphicsPipeline(mNoiseQuads.pipeline);
-                frame.cmd->BindVertexBuffers(1, &mNoiseQuads.vertexBuffer, &mNoiseQuads.vertexBinding.GetStride());
+        // =====================================================================
+        // Fullscreen quads renderpasses
+        // =====================================================================
+        if (pNoiseQuadsCount->GetValue() > 0) {
+            for (size_t i = 0; i < pNoiseQuadsCount->GetValue(); ++i) {
+                currentRenderPass = swapchain->GetRenderPass(imageIndex);
+                PPX_ASSERT_MSG(!currentRenderPass.IsNull(), "render pass object is null");
 
-                for (size_t i = 0; i < pNoiseQuadsCount->GetValue(); ++i) {
+                frame.cmd->BeginRenderPass(currentRenderPass);
+                {
+                    // Draw noise quads
+                    frame.cmd->BindGraphicsPipeline(mNoiseQuads.pipeline);
+                    frame.cmd->BindVertexBuffers(1, &mNoiseQuads.vertexBuffer, &mNoiseQuads.vertexBinding.GetStride());
+
                     uint32_t noiseQuadRandomSeed = (uint32_t)i;
                     frame.cmd->PushGraphicsConstants(mNoiseQuads.pipelineInterface, 1, &noiseQuadRandomSeed);
                     frame.cmd->Draw(4, 1, 0, 0);
                 }
-            }
+                frame.cmd->EndRenderPass();
 
-            DrawImGui(frame.cmd);
+                // Force resolve by transitioning image layout
+                frame.cmd->TransitionImageLayout(currentRenderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_RENDER_TARGET, grfx::RESOURCE_STATE_SHADER_RESOURCE);
+                frame.cmd->TransitionImageLayout(currentRenderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_SHADER_RESOURCE, grfx::RESOURCE_STATE_RENDER_TARGET);
+            }
         }
-        frame.cmd->EndRenderPass();
-        frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_RENDER_TARGET, grfx::RESOURCE_STATE_PRESENT);
 
         // Write end timestamp
         frame.cmd->WriteTimestamp(frame.timestampQuery, grfx::PIPELINE_STAGE_TOP_OF_PIPE_BIT, /* queryIndex = */ 1);
+
+        // =====================================================================
+        // ImGui renderpass
+        // =====================================================================
+        if (GetSettings()->enableImGui) {
+            currentRenderPass = swapchain->GetRenderPass(imageIndex, grfx::ATTACHMENT_LOAD_OP_LOAD);
+            PPX_ASSERT_MSG(!currentRenderPass.IsNull(), "render pass object is null");
+
+            frame.cmd->BeginRenderPass(currentRenderPass);
+            {
+                DrawImGui(frame.cmd);
+            }
+            frame.cmd->EndRenderPass();
+        }
+
+        frame.cmd->TransitionImageLayout(currentRenderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_RENDER_TARGET, grfx::RESOURCE_STATE_PRESENT);
 
         // Resolve queries
         frame.cmd->ResolveQueryData(frame.timestampQuery, /* startIndex= */ 0, frame.timestampQuery->GetCount());


### PR DESCRIPTION

* First renderpass for sphere scene
* [optional] N renderpasses for N noise quads
* [optional] Last renderpass for` ImGui`
* Also moved end timestamp so that it does not include imgui rendering