### PR TITLE
Add ability to add additional OpenXR layers.

### DIFF
--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -31,6 +31,7 @@
 #include <android_native_app_glue.h>
 #endif // defined(PPX_ANDROID)
 
+#include <queue>
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 #include <ppx/grfx/grfx_config.h>
@@ -47,6 +48,21 @@
     }
 
 namespace ppx {
+namespace {
+
+// Strict weak ordering by XrLayerBase zIndex.
+struct OrderXrLayers
+{
+    bool operator()(const XrLayerBase* left, const XrLayerBase* right) const
+    {
+        return left->zIndex() > right->zIndex();
+    }
+};
+
+// Type alias for a priority queue that uses the OrderXrLayers compare type.
+using XrLayerBaseQueue = std::priority_queue<XrLayerBase*, std::vector<XrLayerBase*>, OrderXrLayers>;
+
+} // namespace
 
 enum struct XrRefSpace
 {
@@ -91,7 +107,8 @@ struct XrComponentCreateInfo
     XrComponentResolution   uiResolution         = {0, 0};
 };
 
-typedef uint32_t LayerRef;
+// Used to reference OpenXR layers added to XrComponent through XrComponent::AddLayer.
+using LayerRef = uint32_t;
 
 //! @class XrComponent
 class XrComponent
@@ -165,12 +182,23 @@ public:
     virtual void EndPassthrough();
     virtual void TogglePassthrough();
 
+    // Adds an OpenXR Layer to the layers used to render OpenXR frames. The XrComponent
+    // assumes ownership over the given layer, and returns a reference that can be used
+    // to remove the layer from future frames as needed.
     LayerRef AddLayer(std::unique_ptr<XrLayerBase> layer);
-    bool     RemoveLayer(LayerRef layerRef);
+
+    // Removes a XrLayerBase from being rendered in future frames. Removing a layer will
+    // cause the XrComponent to deinitialize the referenced layer. Returns true if the
+    // requested layer was successfully removed from the owned layers, and false otherwise.
+    bool RemoveLayer(LayerRef layerRef);
 
 private:
     const XrEventDataBaseHeader* TryReadNextEvent();
     void                         HandleSessionStateChangedEvent(const XrEventDataSessionStateChanged& stateChangedEvent, bool& exitRenderLoop);
+
+    void PopulateProjectionLayer(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t startIndex, XrLayerBaseQueue& layerQueue, XrProjectionLayer& projectionLayer);
+    void PopulateImGuiLayer(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t index, XrLayerBaseQueue& layerQueue, XrQuadLayer& quadLayer);
+    void PopulatePassthroughFbLayer(XrLayerBaseQueue& layerQueue, XrPassthroughFbLayer& passthroughFbLayer);
 
     XrInstance mInstance = XR_NULL_HANDLE;
     XrSystemId mSystemId = XR_NULL_SYSTEM_ID;

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -36,6 +36,9 @@
 #include <ppx/grfx/grfx_config.h>
 
 #include <optional>
+#include <unordered_map>
+
+#include "ppx/xr_composition_layers.h"
 
 #define CHECK_XR_CALL(CMD__)                                                                       \
     {                                                                                              \
@@ -87,6 +90,8 @@ struct XrComponentCreateInfo
     XrComponentResolution   resolution           = {0, 0};
     XrComponentResolution   uiResolution         = {0, 0};
 };
+
+typedef uint32_t LayerRef;
 
 //! @class XrComponent
 class XrComponent
@@ -160,6 +165,9 @@ public:
     virtual void EndPassthrough();
     virtual void TogglePassthrough();
 
+    LayerRef AddLayer(std::unique_ptr<XrLayerBase> layer);
+    bool     RemoveLayer(LayerRef layerRef);
+
 private:
     const XrEventDataBaseHeader* TryReadNextEvent();
     void                         HandleSessionStateChangedEvent(const XrEventDataSessionStateChanged& stateChangedEvent, bool& exitRenderLoop);
@@ -175,6 +183,9 @@ private:
     std::vector<XrView>                  mViews;
     std::vector<XrEnvironmentBlendMode>  mBlendModes;
     uint32_t                             mCurrentViewIndex = 0;
+
+    std::unordered_map<LayerRef, std::unique_ptr<XrLayerBase>> mLayers;
+    LayerRef                                                   mNextLayerRef = 0;
 
     XrSpace                  mRefSpace           = XR_NULL_HANDLE;
     XrSpace                  mUISpace            = XR_NULL_HANDLE;

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -31,12 +31,12 @@
 #include <android_native_app_glue.h>
 #endif // defined(PPX_ANDROID)
 
-#include <queue>
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 #include <ppx/grfx/grfx_config.h>
 
 #include <optional>
+#include <queue>
 #include <unordered_map>
 
 #include "ppx/xr_composition_layers.h"
@@ -196,9 +196,11 @@ private:
     const XrEventDataBaseHeader* TryReadNextEvent();
     void                         HandleSessionStateChangedEvent(const XrEventDataSessionStateChanged& stateChangedEvent, bool& exitRenderLoop);
 
-    void PopulateProjectionLayer(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t startIndex, XrLayerBaseQueue& layerQueue, XrProjectionLayer& projectionLayer);
-    void PopulateImGuiLayer(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t index, XrLayerBaseQueue& layerQueue, XrQuadLayer& quadLayer);
-    void PopulatePassthroughFbLayer(XrLayerBaseQueue& layerQueue, XrPassthroughFbLayer& passthroughFbLayer);
+    // Methods that populate the OpenXR composition layers with information when they are needed for rendering.
+    // Used by XrComponent::EndFrame to support the base application composition layers.
+    void ConditionallyPopulateProjectionLayer(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t startIndex, XrLayerBaseQueue& layerQueue, XrProjectionLayer& projectionLayer);
+    void ConditionallyPopulateImGuiLayer(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t index, XrLayerBaseQueue& layerQueue, XrQuadLayer& quadLayer);
+    void ConditionallyPopulatePassthroughFbLayer(XrLayerBaseQueue& layerQueue, XrPassthroughFbLayer& passthroughFbLayer);
 
     XrInstance mInstance = XR_NULL_HANDLE;
     XrSystemId mSystemId = XR_NULL_SYSTEM_ID;

--- a/include/ppx/xr_composition_layers.h
+++ b/include/ppx/xr_composition_layers.h
@@ -20,6 +20,7 @@
 #include <openxr/openxr.h>
 
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -89,8 +90,10 @@ public:
     void AddView(XrCompositionLayerProjectionView view, XrCompositionLayerDepthInfoKHR depthInfo);
 
 private:
-    std::vector<XrCompositionLayerProjectionView> mViews;
-    std::vector<XrCompositionLayerDepthInfoKHR>   mDepthInfos;
+    void FixViewReferences();
+
+    std::vector<XrCompositionLayerProjectionView>              mViews;
+    std::vector<std::optional<XrCompositionLayerDepthInfoKHR>> mDepthInfos;
 };
 
 // XrLayerBase implementation for XrCompositionLayerQuad layers.

--- a/include/ppx/xr_composition_layers.h
+++ b/include/ppx/xr_composition_layers.h
@@ -1,0 +1,89 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PPX_XR_COMPOSITION_LAYERS_H
+#define PPX_XR_COMPOSITION_LAYERS_H
+
+#if defined(PPX_BUILD_XR)
+
+#include <openxr/openxr.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace ppx {
+
+//! @class XrLayerBase
+class XrLayerBase
+{
+public:
+    virtual ~XrLayerBase()                                = default;
+    virtual XrCompositionLayerBaseHeader* basePtr() const = 0;
+    virtual uint32_t                      zIndex() const  = 0;
+};
+
+//! @class XrLayer
+template <typename T>
+class XrLayer : public XrLayerBase
+{
+public:
+    XrLayer()
+        : mLayer(std::make_unique<T>()) {}
+    virtual ~XrLayer() override = default;
+
+    XrCompositionLayerBaseHeader* basePtr() const override
+    {
+        return reinterpret_cast<XrCompositionLayerBaseHeader*>(mLayer.get());
+    }
+
+    T& layer()
+    {
+        return *mLayer;
+    }
+
+    uint32_t zIndex() const override
+    {
+        return mZIndex;
+    }
+    void SetZIndex(uint32_t zIndex)
+    {
+        mZIndex = zIndex;
+    }
+
+private:
+    uint32_t           mZIndex = 0;
+    std::unique_ptr<T> mLayer;
+};
+
+//! @class XrProjectionLayer
+class XrProjectionLayer : public XrLayer<XrCompositionLayerProjection>
+{
+public:
+    XrProjectionLayer();
+    void AddView(XrCompositionLayerProjectionView view);
+    void AddView(XrCompositionLayerProjectionView view, XrCompositionLayerDepthInfoKHR depthInfo);
+
+private:
+    std::vector<XrCompositionLayerProjectionView> mViews;
+    std::vector<XrCompositionLayerDepthInfoKHR>   mDepthInfos;
+};
+
+typedef XrLayer<XrCompositionLayerQuad>          XrQuadLayer;
+typedef XrLayer<XrCompositionLayerPassthroughFB> XrPassthroughFbLayer;
+
+} // namespace ppx
+
+#endif // defined(PPX_BUILD_XR)
+#endif // PPX_XR_COMPOSITION_LAYERS_H

--- a/include/ppx/xr_composition_layers.h
+++ b/include/ppx/xr_composition_layers.h
@@ -90,10 +90,8 @@ public:
     void AddView(XrCompositionLayerProjectionView view, XrCompositionLayerDepthInfoKHR depthInfo);
 
 private:
-    void FixViewReferences();
-
-    std::vector<XrCompositionLayerProjectionView>              mViews;
-    std::vector<std::optional<XrCompositionLayerDepthInfoKHR>> mDepthInfos;
+    std::vector<XrCompositionLayerProjectionView>                mViews;
+    std::vector<std::unique_ptr<XrCompositionLayerDepthInfoKHR>> mDepthInfos;
 };
 
 // XrLayerBase implementation for XrCompositionLayerQuad layers.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,6 +182,7 @@ list(
     ${INC_DIR}/ppx/window.h
     ${INC_DIR}/ppx/wire_mesh.h
     ${INC_DIR}/ppx/xr_component.h
+    ${INC_DIR}/ppx/xr_composition_layers.h
 )
 
 list(
@@ -215,6 +216,7 @@ list(
     ${SRC_DIR}/ppx/window.cpp
     ${SRC_DIR}/ppx/wire_mesh.cpp
     ${SRC_DIR}/ppx/xr_component.cpp
+    ${SRC_DIR}/ppx/xr_composition_layers.cpp
     ${SRC_DIR}/ppx/imgui/font_inconsolata.h
     ${SRC_DIR}/ppx/imgui/font_inconsolata.cpp
 )

--- a/src/ppx/xr_component.cpp
+++ b/src/ppx/xr_component.cpp
@@ -559,8 +559,8 @@ void XrComponent::EndFrame(const std::vector<grfx::SwapchainPtr>& swapchains, ui
 
 void XrComponent::PopulateProjectionLayer(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t startIndex, XrLayerBaseQueue& layerQueue, XrProjectionLayer& projectionLayer)
 {
-    size_t viewCount = mViews.size();
-    PPX_ASSERT_MSG(swapchains.size() >= viewCount, "Number of swapchains needs to be larger than or equal to the number of views!");
+    const size_t viewCount = mViews.size();
+    PPX_ASSERT_MSG(swapchains.size() >= (viewCount + startIndex), "Number of swapchains needs to be larger than or equal to the number of views!");
 
     if (!mShouldRender) {
         return;

--- a/src/ppx/xr_component.cpp
+++ b/src/ppx/xr_component.cpp
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #if defined(PPX_BUILD_XR)
+#include <queue>
 #include "ppx/xr_component.h"
+#include "ppx/xr_composition_layers.h"
 #include "ppx/grfx/grfx_instance.h"
 #include <glm/gtc/type_ptr.hpp>
 
@@ -505,68 +507,87 @@ void XrComponent::EndFrame(const std::vector<grfx::SwapchainPtr>& swapchains, ui
     size_t viewCount = mViews.size();
     PPX_ASSERT_MSG(swapchains.size() >= viewCount, "Number of swapchains needs to be larger than or equal to the number of views!");
 
-    std::vector<XrCompositionLayerProjectionView> compositionLayerProjectionViews(viewCount);
-    std::vector<XrCompositionLayerDepthInfoKHR>   compositionLayerDepthInfos(viewCount);
-    XrCompositionLayerQuad                        compositionLayerQuad = {XR_TYPE_COMPOSITION_LAYER_QUAD};
+    XrProjectionLayer projectionLayer;
+    XrQuadLayer       quadLayer;
     // Used when mPassthroughSupported == XR_PASSTHROUGH_OCULUS
-    XrCompositionLayerFlags         compositionLayerPassthroughFbFlags = {};
-    XrCompositionLayerPassthroughFB compositionLayerPassthroughFb      = {XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB};
+    XrPassthroughFbLayer passthroughFbLayer;
+
     if (mShouldRender) {
         // Projection and (optional) depth info layer from color+depth swapchains.
         for (size_t i = 0; i < viewCount; ++i) {
-            compositionLayerProjectionViews[i]                           = {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW};
-            compositionLayerProjectionViews[i].pose                      = mViews[i].pose;
-            compositionLayerProjectionViews[i].fov                       = mViews[i].fov;
-            compositionLayerProjectionViews[i].subImage.swapchain        = swapchains[layerProjStartIndex + i]->GetXrColorSwapchain();
-            compositionLayerProjectionViews[i].subImage.imageRect.offset = {0, 0};
-            compositionLayerProjectionViews[i].subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
+            XrCompositionLayerProjectionView view;
+
+            view                           = {XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW};
+            view.pose                      = mViews[i].pose;
+            view.fov                       = mViews[i].fov;
+            view.subImage.swapchain        = swapchains[layerProjStartIndex + i]->GetXrColorSwapchain();
+            view.subImage.imageRect.offset = {0, 0};
+            view.subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
 
             if (mShouldSubmitDepthInfo && swapchains[layerProjStartIndex + i]->GetXrDepthSwapchain() != XR_NULL_HANDLE) {
                 PPX_ASSERT_MSG(mNearPlaneForFrame.has_value() && mFarPlaneForFrame.has_value(), "Depth info layer cannot be submitted because near and far plane values are not set. "
                                                                                                 "Call GetProjectionMatrixForCurrentViewAndSetFrustumPlanes to set per-frame values.");
-                compositionLayerDepthInfos[i]                           = {XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR};
-                compositionLayerDepthInfos[i].minDepth                  = 0.0f;
-                compositionLayerDepthInfos[i].maxDepth                  = 1.0f;
-                compositionLayerDepthInfos[i].nearZ                     = *mNearPlaneForFrame;
-                compositionLayerDepthInfos[i].farZ                      = *mFarPlaneForFrame;
-                compositionLayerDepthInfos[i].subImage.swapchain        = swapchains[layerProjStartIndex + i]->GetXrDepthSwapchain();
-                compositionLayerDepthInfos[i].subImage.imageRect.offset = {0, 0};
-                compositionLayerDepthInfos[i].subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
+                XrCompositionLayerDepthInfoKHR depthInfo;
+                depthInfo                           = {XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR};
+                depthInfo.minDepth                  = 0.0f;
+                depthInfo.maxDepth                  = 1.0f;
+                depthInfo.nearZ                     = *mNearPlaneForFrame;
+                depthInfo.farZ                      = *mFarPlaneForFrame;
+                depthInfo.subImage.swapchain        = swapchains[layerProjStartIndex + i]->GetXrDepthSwapchain();
+                depthInfo.subImage.imageRect.offset = {0, 0};
+                depthInfo.subImage.imageRect.extent = {static_cast<int>(GetWidth()), static_cast<int>(GetHeight())};
 
-                compositionLayerProjectionViews[i].next = &compositionLayerDepthInfos[i];
+                projectionLayer.AddView(view, depthInfo);
+            }
+            else {
+                projectionLayer.AddView(view);
             }
         }
 
         // Optional UI composition layer.
         if (mCreateInfo.enableQuadLayer) {
-            compositionLayerQuad.layerFlags                = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
-            compositionLayerQuad.space                     = mUISpace;
-            compositionLayerQuad.eyeVisibility             = XR_EYE_VISIBILITY_BOTH;
-            compositionLayerQuad.subImage.swapchain        = swapchains[layerQuadStartIndex]->GetXrColorSwapchain();
-            compositionLayerQuad.subImage.imageRect.offset = {0, 0};
-            compositionLayerQuad.subImage.imageRect.extent = {static_cast<int>(GetUIWidth()), static_cast<int>(GetUIHeight())};
-            compositionLayerQuad.pose                      = {{0, 0, 0, 1}, {0, 0, -0.5f}};
-            compositionLayerQuad.size                      = {1, 1};
+            quadLayer.layer().type                      = XR_TYPE_COMPOSITION_LAYER_QUAD;
+            quadLayer.layer().layerFlags                = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+            quadLayer.layer().space                     = mUISpace;
+            quadLayer.layer().eyeVisibility             = XR_EYE_VISIBILITY_BOTH;
+            quadLayer.layer().subImage.swapchain        = swapchains[layerQuadStartIndex]->GetXrColorSwapchain();
+            quadLayer.layer().subImage.imageRect.offset = {0, 0};
+            quadLayer.layer().subImage.imageRect.extent = {static_cast<int>(GetUIWidth()), static_cast<int>(GetUIHeight())};
+            quadLayer.layer().pose                      = {{0, 0, 0, 1}, {0, 0, -0.5f}};
+            quadLayer.layer().size                      = {1, 1};
+        }
+
+        if (mPassthroughEnabled && mPassthroughSupported == XR_PASSTHROUGH_OCULUS) {
+            passthroughFbLayer.layer().type        = XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB;
+            passthroughFbLayer.layer().next        = nullptr;
+            passthroughFbLayer.layer().flags       = XrCompositionLayerFlags{};
+            passthroughFbLayer.layer().space       = XR_NULL_HANDLE;
+            passthroughFbLayer.layer().layerHandle = mPassthroughLayer;
         }
     }
 
-    XrEnvironmentBlendMode                     blendMode = mBlendModes[0];
-    std::vector<XrCompositionLayerBaseHeader*> layers;
-    XrCompositionLayerProjection               compositionLayerProjection = {XR_TYPE_COMPOSITION_LAYER_PROJECTION};
-    compositionLayerProjection.layerFlags                                 = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
-    compositionLayerProjection.space                                      = mRefSpace;
-    compositionLayerProjection.viewCount                                  = static_cast<uint32_t>(GetViewCount());
-    compositionLayerProjection.views                                      = compositionLayerProjectionViews.data();
+    XrEnvironmentBlendMode blendMode   = mBlendModes[0];
+    projectionLayer.layer().type       = XR_TYPE_COMPOSITION_LAYER_PROJECTION;
+    projectionLayer.layer().layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+    projectionLayer.layer().space      = mRefSpace;
+
+    // Set the order the default layers should be rendered in.
+    // Higher numbers are rendered later, and space is purposefully provided
+    // between each layer.
+    passthroughFbLayer.SetZIndex(100);
+    projectionLayer.SetZIndex(200);
+    quadLayer.SetZIndex(300);
+
+    auto cmp = [](XrLayerBase* left, XrLayerBase* right) { return left->zIndex() > right->zIndex(); };
+
+    std::priority_queue<XrLayerBase*, std::vector<XrLayerBase*>, decltype(cmp)> layerQueue(cmp);
+
     if (mShouldRender) {
         if (mPassthroughEnabled) {
             switch (mPassthroughSupported) {
                 case XR_PASSTHROUGH_OCULUS: {
                     if (mPassthroughLayer != XR_NULL_HANDLE) {
-                        compositionLayerPassthroughFb.next        = nullptr;
-                        compositionLayerPassthroughFb.flags       = compositionLayerPassthroughFbFlags;
-                        compositionLayerPassthroughFb.space       = XR_NULL_HANDLE;
-                        compositionLayerPassthroughFb.layerHandle = mPassthroughLayer;
-                        layers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&compositionLayerPassthroughFb));
+                        layerQueue.push(&passthroughFbLayer);
                     }
                     break;
                 }
@@ -579,10 +600,19 @@ void XrComponent::EndFrame(const std::vector<grfx::SwapchainPtr>& swapchains, ui
                     break;
             }
         }
-        layers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&compositionLayerProjection));
+        layerQueue.push(&projectionLayer);
         if (mCreateInfo.enableQuadLayer) {
-            layers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&compositionLayerQuad));
+            layerQueue.push(&quadLayer);
         }
+    }
+
+    for (const auto& [ref, layer] : mLayers) {
+        layerQueue.push(layer.get());
+    }
+
+    std::vector<XrCompositionLayerBaseHeader*> layers;
+    for (; !layerQueue.empty(); layerQueue.pop()) {
+        layers.push_back(layerQueue.top()->basePtr());
     }
 
     // Submit layers and end frame.
@@ -596,6 +626,17 @@ void XrComponent::EndFrame(const std::vector<grfx::SwapchainPtr>& swapchains, ui
     };
 
     CHECK_XR_CALL(xrEndFrame(mSession, &frameEndInfo));
+}
+
+LayerRef XrComponent::AddLayer(std::unique_ptr<XrLayerBase> layer)
+{
+    mLayers.insert(std::make_pair(++mNextLayerRef, std::move(layer)));
+    return mNextLayerRef;
+}
+
+bool XrComponent::RemoveLayer(LayerRef layerRef)
+{
+    return mLayers.erase(layerRef);
 }
 
 glm::mat4 XrComponent::GetViewMatrixForCurrentView() const

--- a/src/ppx/xr_composition_layers.cpp
+++ b/src/ppx/xr_composition_layers.cpp
@@ -1,0 +1,47 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(PPX_BUILD_XR)
+#include "ppx/xr_composition_layers.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace ppx {
+
+XrProjectionLayer::XrProjectionLayer()
+{
+    layer().views = mViews.data();
+}
+
+void XrProjectionLayer::AddView(XrCompositionLayerProjectionView view)
+{
+    mViews.emplace_back(view);
+    layer().views     = mViews.data();
+    layer().viewCount = static_cast<uint32_t>(mViews.size());
+}
+
+void XrProjectionLayer::AddView(XrCompositionLayerProjectionView view, XrCompositionLayerDepthInfoKHR depthInfo)
+{
+    view.next = &depthInfo;
+    mViews.emplace_back(view);
+    mDepthInfos.emplace_back(depthInfo);
+    layer().views     = mViews.data();
+    layer().viewCount = static_cast<uint32_t>(mViews.size());
+}
+
+} // namespace ppx
+
+#endif // defined(PPX_BUILD_XR)

--- a/src/ppx/xr_composition_layers.cpp
+++ b/src/ppx/xr_composition_layers.cpp
@@ -35,11 +35,11 @@ void XrProjectionLayer::AddView(XrCompositionLayerProjectionView view)
 
 void XrProjectionLayer::AddView(XrCompositionLayerProjectionView view, XrCompositionLayerDepthInfoKHR depthInfo)
 {
-    view.next = &depthInfo;
-    mViews.emplace_back(view);
     mDepthInfos.emplace_back(depthInfo);
-    layer().views     = mViews.data();
-    layer().viewCount = static_cast<uint32_t>(mViews.size());
+    mViews.emplace_back(view);
+    mViews.back().next = &mDepthInfos.back();
+    layer().views      = mViews.data();
+    layer().viewCount  = static_cast<uint32_t>(mViews.size());
 }
 
 } // namespace ppx

--- a/src/ppx/xr_composition_layers.cpp
+++ b/src/ppx/xr_composition_layers.cpp
@@ -29,31 +29,20 @@ XrProjectionLayer::XrProjectionLayer()
 
 void XrProjectionLayer::AddView(XrCompositionLayerProjectionView view)
 {
-    mDepthInfos.push_back(std::nullopt);
     mViews.emplace_back(view);
-    FixViewReferences();
+
+    layer().views     = mViews.data();
+    layer().viewCount = static_cast<uint32_t>(mViews.size());
 }
 
 void XrProjectionLayer::AddView(XrCompositionLayerProjectionView view, XrCompositionLayerDepthInfoKHR depthInfo)
 {
-    mDepthInfos.emplace_back(std::make_optional(depthInfo));
+    mDepthInfos.emplace_back(std::make_unique<XrCompositionLayerDepthInfoKHR>(depthInfo));
     mViews.emplace_back(view);
-    FixViewReferences();
-}
 
-void XrProjectionLayer::FixViewReferences()
-{
-    for (size_t i = 0; i < mViews.size(); i++) {
-        if (mDepthInfos[i].has_value()) {
-            mViews[i].next = &mDepthInfos[i].value();
-        }
-        else {
-            mViews[i].next = NULL;
-        }
-    }
-
-    layer().views     = mViews.data();
-    layer().viewCount = static_cast<uint32_t>(mViews.size());
+    mViews.back().next = mDepthInfos.back().get();
+    layer().views      = mViews.data();
+    layer().viewCount  = static_cast<uint32_t>(mViews.size());
 }
 
 } // namespace ppx


### PR DESCRIPTION
This allows XR projects, such as FishTornado XR, to add additional OpenXR layers as needed. This could be useful for rendering additional information in a new quad, or drawing multiple projections (such as additional cubes in 04_cube_xr).

Additional layers will be created by the project, moved into XrComponent, and optionally removed later via a reference id.