### PR TITLE
Graphics clear funtions

### DIFF
--- a/include/ppx/grfx/dx12/dx12_command.h
+++ b/include/ppx/grfx/dx12/dx12_command.h
@@ -51,6 +51,14 @@ private:
         const grfx::Sampler*           pSampler) override;
 
 public:
+    virtual void ClearRenderTarget(
+        grfx::Image*                        pImage,
+        const grfx::RenderTargetClearValue& clearValue) override;
+    virtual void ClearDepthStencil(
+        grfx::Image*                        pImage,
+        const grfx::DepthStencilClearValue& clearValue,
+        uint32_t                            clearFlags) override;
+
     virtual void TransitionImageLayout(
         const grfx::Image*  pImage,
         uint32_t            mipLevel,

--- a/include/ppx/grfx/grfx_command.h
+++ b/include/ppx/grfx/grfx_command.h
@@ -245,7 +245,7 @@ public:
     CommandBuffer() {}
     virtual ~CommandBuffer() {}
 
-    grfx::CommandType GetCommandType() { return mCreateInfo.pPool->GetCommandType(); }
+    grfx::CommandType GetCommandType() const { return mCreateInfo.pPool->GetCommandType(); }
 
     virtual Result Begin() = 0;
     virtual Result End()   = 0;

--- a/include/ppx/grfx/grfx_command.h
+++ b/include/ppx/grfx/grfx_command.h
@@ -245,13 +245,27 @@ public:
     CommandBuffer() {}
     virtual ~CommandBuffer() {}
 
+    grfx::CommandType GetCommandType() { return mCreateInfo.pPool->GetCommandType(); }
+
     virtual Result Begin() = 0;
     virtual Result End()   = 0;
 
     void BeginRenderPass(const grfx::RenderPassBeginInfo* pBeginInfo);
     void EndRenderPass();
 
-    grfx::CommandType GetCommandType() { return mCreateInfo.pPool->GetCommandType(); }
+    const grfx::RenderPass* GetCurrentRenderPass() const { return mCurrentRenderPass; }
+
+    //
+    // Clear functions must be called between BeginRenderPass and EndRenderPass.
+    // Arg for pImage must be an image in the current render pass.
+    //
+    virtual void ClearRenderTarget(
+        grfx::Image*                        pImage,
+        const grfx::RenderTargetClearValue& clearValue) = 0;
+    virtual void ClearDepthStencil(
+        grfx::Image*                        pImage,
+        const grfx::DepthStencilClearValue& clearValue,
+        uint32_t                            clearFlags) = 0;
 
     //! @fn TransitionImageLayout
     //!

--- a/include/ppx/grfx/grfx_config.h
+++ b/include/ppx/grfx/grfx_config.h
@@ -176,7 +176,7 @@ struct Viewport
 //!
 //! If a member object's ownership is set to OWNERSHIP_EXCLUSIVE or
 //! OWNERSHIP_RESTRICTED, this means that the containing object must
-//! destroy it durnig the destruction process.
+//! destroy it during the destruction process.
 //!
 //! If the containing object fails to destroy OWNERSHIP_EXCLUSIVE and
 //! OWNERSHIP_RESTRICTED objects, then either grfx::Device or grfx::Instance

--- a/include/ppx/grfx/grfx_enums.h
+++ b/include/ppx/grfx/grfx_enums.h
@@ -218,6 +218,12 @@ enum D3DDescriptorType
     D3D_DESCRIPTOR_TYPE_SAMPLER   = 4,
 };
 
+enum ClearFlagBits
+{
+    CLEAR_FLAG_DEPTH   = 0x1,
+    CLEAR_FLAG_STENCIL = 0x2,
+};
+
 enum DescriptorType
 {
     // NOTE: These *DO NOT* match the enums in Vulkan

--- a/include/ppx/grfx/grfx_image.h
+++ b/include/ppx/grfx/grfx_image.h
@@ -208,6 +208,8 @@ public:
 
     grfx::ImagePtr          GetImage() const { return mCreateInfo.pImage; }
     grfx::Format            GetFormat() const { return mCreateInfo.format; }
+    uint32_t                GetMipLevel() const { return mCreateInfo.mipLevel; }
+    uint32_t                GetArrayLayer() const { return mCreateInfo.arrayLayer; }
     grfx::AttachmentLoadOp  GetDepthLoadOp() const { return mCreateInfo.depthLoadOp; }
     grfx::AttachmentStoreOp GetDepthStoreOp() const { return mCreateInfo.depthStoreOp; }
     grfx::AttachmentLoadOp  GetStencilLoadOp() const { return mCreateInfo.stencilLoadOp; }
@@ -251,6 +253,8 @@ public:
     grfx::ImagePtr          GetImage() const { return mCreateInfo.pImage; }
     grfx::Format            GetFormat() const { return mCreateInfo.format; }
     grfx::SampleCount       GetSampleCount() const { return mCreateInfo.sampleCount; }
+    uint32_t                GetMipLevel() const { return mCreateInfo.mipLevel; }
+    uint32_t                GetArrayLayer() const { return mCreateInfo.arrayLayer; }
     grfx::AttachmentLoadOp  GetLoadOp() const { return mCreateInfo.loadOp; }
     grfx::AttachmentStoreOp GetStoreOp() const { return mCreateInfo.storeOp; }
 };

--- a/include/ppx/grfx/grfx_render_pass.h
+++ b/include/ppx/grfx/grfx_render_pass.h
@@ -210,6 +210,12 @@ public:
     grfx::ImagePtr            GetRenderTargetImage(uint32_t index) const;
     grfx::ImagePtr            GetDepthStencilImage() const;
 
+    // Returns index of pImage otherwise returns UINT32_MAX
+    uint32_t GetRenderTargetImageIndex(const grfx::Image* pImage) const;
+
+    // Returns true if render targets or depth stencil contains ATTACHMENT_LOAD_OP_CLEAR
+    bool HasLoadOpClear() const { return mHasLoadOpClear; }
+
 protected:
     virtual Result Create(const grfx::internal::RenderPassCreateInfo* pCreateInfo) override;
     virtual void   Destroy() override;
@@ -227,6 +233,7 @@ protected:
     grfx::DepthStencilViewPtr              mDepthStencilView;
     std::vector<grfx::ImagePtr>            mRenderTargetImages;
     grfx::ImagePtr                         mDepthStencilImage;
+    bool                                   mHasLoadOpClear = false;
 };
 
 } // namespace grfx

--- a/include/ppx/grfx/vk/vk_command.h
+++ b/include/ppx/grfx/vk/vk_command.h
@@ -51,6 +51,14 @@ private:
         const grfx::Sampler*           pSampler) override;
 
 public:
+    virtual void ClearRenderTarget(
+        grfx::Image*                        pImage,
+        const grfx::RenderTargetClearValue& clearValue) override;
+    virtual void ClearDepthStencil(
+        grfx::Image*                        pImage,
+        const grfx::DepthStencilClearValue& clearValue,
+        uint32_t                            clearFlags) override;
+
     virtual void TransitionImageLayout(
         const grfx::Image*  pImage,
         uint32_t            mipLevel,

--- a/projects/04_cube/Cube.h
+++ b/projects/04_cube/Cube.h
@@ -36,17 +36,18 @@ private:
         grfx::FencePtr         renderCompleteFence;
     };
 
-    std::vector<PerFrame>        mPerFrame;
-    grfx::ShaderModulePtr        mVS;
-    grfx::ShaderModulePtr        mPS;
-    grfx::PipelineInterfacePtr   mPipelineInterface;
-    grfx::GraphicsPipelinePtr    mPipeline;
-    grfx::BufferPtr              mVertexBuffer;
-    grfx::DescriptorPoolPtr      mDescriptorPool;
-    grfx::DescriptorSetLayoutPtr mDescriptorSetLayout;
-    grfx::DescriptorSetPtr       mDescriptorSet;
-    grfx::BufferPtr              mUniformBuffer;
-    grfx::VertexBinding          mVertexBinding;
+    std::vector<PerFrame>            mPerFrame;
+    std::vector<grfx::RenderPassPtr> mRenderPasses; // Tests grfx::CommandBuffer::Clear* functions
+    grfx::ShaderModulePtr            mVS;
+    grfx::ShaderModulePtr            mPS;
+    grfx::PipelineInterfacePtr       mPipelineInterface;
+    grfx::GraphicsPipelinePtr        mPipeline;
+    grfx::BufferPtr                  mVertexBuffer;
+    grfx::DescriptorPoolPtr          mDescriptorPool;
+    grfx::DescriptorSetLayoutPtr     mDescriptorSetLayout;
+    grfx::DescriptorSetPtr           mDescriptorSet;
+    grfx::BufferPtr                  mUniformBuffer;
+    grfx::VertexBinding              mVertexBinding;
 };
 
 #endif // CUBE_H

--- a/src/ppx/grfx/grfx_command.cpp
+++ b/src/ppx/grfx/grfx_command.cpp
@@ -36,10 +36,12 @@ void CommandBuffer::BeginRenderPass(const grfx::RenderPassBeginInfo* pBeginInfo)
         PPX_ASSERT_MSG(false, "cannot nest render passes");
     }
 
-    uint32_t rtvCount   = pBeginInfo->pRenderPass->GetRenderTargetCount();
-    uint32_t clearCount = pBeginInfo->RTVClearCount;
-    if (clearCount < rtvCount) {
-        PPX_ASSERT_MSG(false, "clear count cannot less than RTV count");
+    if (pBeginInfo->pRenderPass->HasLoadOpClear()) {
+        uint32_t rtvCount   = pBeginInfo->pRenderPass->GetRenderTargetCount();
+        uint32_t clearCount = pBeginInfo->RTVClearCount;
+        if (clearCount < rtvCount) {
+            PPX_ASSERT_MSG(false, "clear count cannot less than RTV count");
+        }
     }
 
     BeginRenderPassImpl(pBeginInfo);

--- a/src/ppx/grfx/grfx_render_pass.cpp
+++ b/src/ppx/grfx/grfx_render_pass.cpp
@@ -217,6 +217,8 @@ Result RenderPass::CreateImagesAndViewsV1(const grfx::internal::RenderPassCreate
 
         mRenderTargetViews.push_back(rtv);
         mRenderTargetImages.push_back(rtv->GetImage());
+
+        mHasLoadOpClear |= (rtv->GetLoadOp() == grfx::ATTACHMENT_LOAD_OP_CLEAR);
     }
     // Copy DSV and image
     if (!IsNull(pCreateInfo->V1.pDepthStencilView)) {
@@ -224,6 +226,9 @@ Result RenderPass::CreateImagesAndViewsV1(const grfx::internal::RenderPassCreate
 
         mDepthStencilView  = dsv;
         mDepthStencilImage = dsv->GetImage();
+
+        mHasLoadOpClear |= (dsv->GetDepthLoadOp() == grfx::ATTACHMENT_LOAD_OP_CLEAR);
+        mHasLoadOpClear |= (dsv->GetStencilLoadOp() == grfx::ATTACHMENT_LOAD_OP_CLEAR);
     }
 
     return ppx::SUCCESS;
@@ -326,6 +331,8 @@ Result RenderPass::CreateImagesAndViewsV2(const grfx::internal::RenderPassCreate
             }
 
             mRenderTargetViews.push_back(rtv);
+
+            mHasLoadOpClear |= (rtvCreateInfo.loadOp == grfx::ATTACHMENT_LOAD_OP_CLEAR);
         }
 
         // DSV
@@ -355,6 +362,9 @@ Result RenderPass::CreateImagesAndViewsV2(const grfx::internal::RenderPassCreate
             }
 
             mDepthStencilView = dsv;
+
+            mHasLoadOpClear |= (dsvCreateInfo.depthLoadOp == grfx::ATTACHMENT_LOAD_OP_CLEAR);
+            mHasLoadOpClear |= (dsvCreateInfo.stencilLoadOp == grfx::ATTACHMENT_LOAD_OP_CLEAR);
         }
     }
 
@@ -409,6 +419,8 @@ Result RenderPass::CreateImagesAndViewsV3(const grfx::internal::RenderPassCreate
             }
 
             mRenderTargetViews.push_back(rtv);
+
+            mHasLoadOpClear |= (rtvCreateInfo.loadOp == grfx::ATTACHMENT_LOAD_OP_CLEAR);
         }
 
         // DSV
@@ -438,6 +450,9 @@ Result RenderPass::CreateImagesAndViewsV3(const grfx::internal::RenderPassCreate
             }
 
             mDepthStencilView = dsv;
+
+            mHasLoadOpClear |= (dsvCreateInfo.depthLoadOp == grfx::ATTACHMENT_LOAD_OP_CLEAR);
+            mHasLoadOpClear |= (dsvCreateInfo.stencilLoadOp == grfx::ATTACHMENT_LOAD_OP_CLEAR);
         }
     }
 
@@ -575,6 +590,18 @@ grfx::ImagePtr RenderPass::GetDepthStencilImage() const
     grfx::ImagePtr object;
     GetDepthStencilImage(&object);
     return object;
+}
+
+uint32_t RenderPass::GetRenderTargetImageIndex(const grfx::Image* pImage) const
+{
+    uint32_t index = UINT32_MAX;
+    for (uint32_t i = 0; i < CountU32(mRenderTargetImages); ++i) {
+        if (mRenderTargetImages[i] == pImage) {
+            index = i;
+            break;
+        }
+    }
+    return index;
 }
 
 Result RenderPass::DisownRenderTargetView(uint32_t index, grfx::RenderTargetView** ppView)


### PR DESCRIPTION
This CL adds missing clear functions for render targets and depth stencils that clear images within a render pass.

- Added clear functions for render targets and depth stencil.
- Added depth/stencil clear flag enum bits.
- Added functions to expose mip level and array layer in RTV and DSV.
- Added logic to determine if grfx::RenderPass contains any attachments with clear ops.
- Changed clear count check in grfx::CommandBuffer::BeingRenderPass to only check if there's a clear attachment.
- Added function to grfx::RenderPass to return index of an image.
- Added clear function implementation to Vulkan and D3D12.
- Modified 04_cube to use clear functions.