### PR TITLE
Remove doxygen markers from fluid simulation files - NFC

### DIFF
--- a/projects/fluid_simulation/main.cpp
+++ b/projects/fluid_simulation/main.cpp
@@ -14,9 +14,9 @@
 //
 // sim.cpp
 //     Contains the main simulation logic. Everything is driven by `class FluidSimulation`. Simulation actions
-//     generate dispatch records (@see ComputeDispatchRecord, GraphicsDispatchRecord), which describe the
+//     generate dispatch records (see ComputeDispatchRecord, GraphicsDispatchRecord), which describe the
 //     shader to execute and its inputs. Dispatch records are scheduled for execution using `FluidSimulation::ScheduleDR`.
-//     Most of this code resembles the original JavaScript implementation (@see https://github.com/PavelDoGreat/WebGL-Fluid-Simulation/blob/master/script.js)
+//     Most of this code resembles the original JavaScript implementation (https://github.com/PavelDoGreat/WebGL-Fluid-Simulation/blob/master/script.js)
 //
 // shaders.cpp
 //     Contains most the logic required to interact with the BigWheels API to setup and dispatch compute and graphics shaders.
@@ -27,13 +27,13 @@
 // main.cpp
 //     Contains the BigWheels API calls needed to launch the application and execute the main rendering loop.  On startup,
 //     a single instance of `class FluidSimulation` is created and an initial splash of color computed by calling
-//     `FluidSimulation::GenerateInitialSplat`.  The main rendering loop (@see ProjApp::Render) proceeds as follows:
+//     `FluidSimulation::GenerateInitialSplat`.  The main rendering loop (ProjApp::Render) proceeds as follows:
 //
 //     1.  All the scheduled compute shaders are executed by calling `FluidSimulation::DispatchComputeShaders`.
 //     2.  All the generated textures are drawn by calling `FluidSimulation::Render`.
 //     3.  The resources used by compute shaders are released by calling `FluidSimulation::FreeComputeShaderResources`.
 //         This prevents running out of pool resources and needlessly executing compute operations over and over.
-//     4.  The next iteration of the simulation is executed (@note This is still not implemented).
+//     4.  The next iteration of the simulation is executed.
 
 #include "sim.h"
 #include "shaders.h"

--- a/projects/fluid_simulation/main.cpp
+++ b/projects/fluid_simulation/main.cpp
@@ -5,37 +5,35 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-///
-/// Fluid simulation.
-///
-/// This code has been translated and adapted from the original WebGL implementation at
-/// https://github.com/PavelDoGreat/WebGL-Fluid-Simulation.
-///
-/// The code is organized in 3 files:
-///
-/// sim.cpp
-///     Contains the main simulation logic. Everything is driven by `class FluidSimulation`. Simulation actions
-///     generate dispatch records (@see ComputeDispatchRecord, GraphicsDispatchRecord), which describe the
-///     shader to execute and its inputs. Dispatch records are scheduled for execution using `FluidSimulation::ScheduleDR`.
-///     Most of this code resembles the original JavaScript implementation (@see https://github.com/PavelDoGreat/WebGL-Fluid-Simulation/blob/master/script.js)
-///
-/// shaders.cpp
-///     Contains most the logic required to interact with the BigWheels API to setup and dispatch compute and graphics shaders.
-///     Compute and graphics shaders all inherit from a common `class Shader`.  The main method in those classes is `GetDR()`,
-///     which generates a dispatch record with all the necessary inputs to execute the shader (textures to use and scalar inputs
-///     in `struct ScalarInput`.
-///
-/// main.cpp
-///     Contains the BigWheels API calls needed to launch the application and execute the main rendering loop.  On startup,
-///     a single instance of `class FluidSimulation` is created and an initial splash of color computed by calling
-///     `FluidSimulation::GenerateInitialSplat`.  The main rendering loop (@see ProjApp::Render) proceeds as follows:
-///
-///     1.  All the scheduled compute shaders are executed by calling `FluidSimulation::DispatchComputeShaders`.
-///     2.  All the generated textures are drawn by calling `FluidSimulation::Render`.
-///     3.  The resources used by compute shaders are released by calling `FluidSimulation::FreeComputeShaderResources`.
-///         This prevents running out of pool resources and needlessly executing compute operations over and over.
-///     4.  The next iteration of the simulation is executed (@note This is still not implemented).
-///
+// Fluid simulation.
+//
+// This code has been translated and adapted from the original WebGL implementation at
+// https://github.com/PavelDoGreat/WebGL-Fluid-Simulation.
+//
+// The code is organized in 3 files:
+//
+// sim.cpp
+//     Contains the main simulation logic. Everything is driven by `class FluidSimulation`. Simulation actions
+//     generate dispatch records (@see ComputeDispatchRecord, GraphicsDispatchRecord), which describe the
+//     shader to execute and its inputs. Dispatch records are scheduled for execution using `FluidSimulation::ScheduleDR`.
+//     Most of this code resembles the original JavaScript implementation (@see https://github.com/PavelDoGreat/WebGL-Fluid-Simulation/blob/master/script.js)
+//
+// shaders.cpp
+//     Contains most the logic required to interact with the BigWheels API to setup and dispatch compute and graphics shaders.
+//     Compute and graphics shaders all inherit from a common `class Shader`.  The main method in those classes is `GetDR()`,
+//     which generates a dispatch record with all the necessary inputs to execute the shader (textures to use and scalar inputs
+//     in `struct ScalarInput`.
+//
+// main.cpp
+//     Contains the BigWheels API calls needed to launch the application and execute the main rendering loop.  On startup,
+//     a single instance of `class FluidSimulation` is created and an initial splash of color computed by calling
+//     `FluidSimulation::GenerateInitialSplat`.  The main rendering loop (@see ProjApp::Render) proceeds as follows:
+//
+//     1.  All the scheduled compute shaders are executed by calling `FluidSimulation::DispatchComputeShaders`.
+//     2.  All the generated textures are drawn by calling `FluidSimulation::Render`.
+//     3.  The resources used by compute shaders are released by calling `FluidSimulation::FreeComputeShaderResources`.
+//         This prevents running out of pool resources and needlessly executing compute operations over and over.
+//     4.  The next iteration of the simulation is executed (@note This is still not implemented).
 
 #include "sim.h"
 #include "shaders.h"

--- a/projects/fluid_simulation/shaders.h
+++ b/projects/fluid_simulation/shaders.h
@@ -50,24 +50,24 @@ struct PerFrame
     ppx::grfx::FencePtr         renderCompleteFence;
 };
 
-/// @brief Representation of images used during simulation.
-///
-/// This structure keeps sample and storage views for presenting and modifying
-/// each of the generated textures.
+// Representation of images used during simulation.
+//
+// This structure keeps sample and storage views for presenting and modifying
+// each of the generated textures.
 class Texture
 {
 public:
-    /// @brief Initialize a new empty texture.
-    /// @param sim      Pointer to the main simulator instance (for accessing global state).
-    /// @param name     Name of the texture.
-    /// @param width    Texture width.
-    /// @param height   Texture height.
-    /// @param format   Texture format.
+    // Initialize a new empty texture.
+    // sim      Pointer to the main simulator instance (for accessing global state).
+    // name     Name of the texture.
+    // width    Texture width.
+    // height   Texture height.
+    // format   Texture format.
     Texture(FluidSimulation* sim, const std::string& name, uint32_t width, uint32_t height, ppx::grfx::Format format);
 
-    /// @brief Initialize a new texture from an image file.
-    /// @param sim      Pointer to the main simulator instance (for accessing global state).
-    /// @param fileName Image file to load.
+    // Initialize a new texture from an image file.
+    // sim      Pointer to the main simulator instance (for accessing global state).
+    // fileName Image file to load.
     Texture(FluidSimulation* sim, const std::string& fileName);
 
     uint32_t                       GetWidth() const { return mTexture->GetWidth(); }
@@ -98,14 +98,14 @@ private:
     std::string                    mName;
 };
 
-/// @brief Scalar inputs for the filter programs.
-///
-/// This needs to be 16-bit aligned to be copied into a uniform buffer.
-///
-/// NOTE: Fields are organized so that they are packed into 4 word component vectors
-/// to match the HLSL packing rules (https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-packing-rules)
-///
-/// This must match the CSInputs structure in assets/fluid_simulation/shaders/config.hlsli.
+// Scalar inputs for the filter programs.
+//
+// This needs to be 16-bit aligned to be copied into a uniform buffer.
+//
+// NOTE: Fields are organized so that they are packed into 4 word component vectors
+// to match the HLSL packing rules (https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-packing-rules)
+//
+// This must match the CSInputs structure in assets/fluid_simulation/shaders/config.hlsli.
 struct alignas(16) ScalarInput
 {
     ScalarInput(Texture* output)
@@ -177,13 +177,13 @@ struct ComputeDispatchRecord
     ComputeDispatchRecord(ComputeShader* cs, Texture* output, const ScalarInput& si);
     void FreeResources();
 
-    /// @brief Add a texture to sample from to the given descriptor set.
-    /// @param texture      Texture to bind.
-    /// @param inputBinding Binding slot to bind the texture in.
+    // Add a texture to sample from to the given descriptor set.
+    // texture      Texture to bind.
+    // inputBinding Binding slot to bind the texture in.
     void BindInputTexture(Texture* texture, uint32_t bindingSlot);
 
-    /// @brief Add the output texture to the given descriptor set.
-    /// @param bindingSlot  Binding slot to bind the texture in.
+    // Add the output texture to the given descriptor set.
+    // bindingSlot  Binding slot to bind the texture in.
     void BindOutputTexture(uint32_t bindingSlot);
 
     ComputeShader*              mShader;
@@ -197,9 +197,9 @@ class ComputeShader : public Shader
 public:
     ComputeShader(FluidSimulation* sim, const std::string& shaderFile);
 
-    /// @brief Run this shader using the given dispatch record, output texture and inputs.
-    /// @param frame Frame to use.
-    /// @param dr    Dispatch record to use.
+    // Run this shader using the given dispatch record, output texture and inputs.
+    // frame Frame to use.
+    // dr    Dispatch record to use.
     void Dispatch(const PerFrame& frame, const std::unique_ptr<ComputeDispatchRecord>& dr);
 
 private:
@@ -234,11 +234,10 @@ public:
     BloomBlurShader(FluidSimulation* sim)
         : ComputeShader(sim, "bloom_blur") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param uTexture     Texture to sample from.
-    /// @param output       Texture to write to.
-    /// @param texelSize    Texel size.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // uTexture     Texture to sample from.
+    // output       Texture to write to.
+    // texelSize    Texel size.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* uTexture, Texture* output, ppx::float2 texelSize)
     {
         ScalarInput si(output);
@@ -257,10 +256,9 @@ public:
     BloomBlurAdditiveShader(FluidSimulation* sim)
         : ComputeShader(sim, "bloom_blur_additive") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param uTexture     Texture to sample from.
-    /// @param output       Texture to write to.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // uTexture     Texture to sample from.
+    // output       Texture to write to.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* uTexture, Texture* output, ppx::float2 texelSize)
     {
         ScalarInput si(output);
@@ -279,11 +277,10 @@ public:
     BloomFinalShader(FluidSimulation* sim)
         : ComputeShader(sim, "bloom_final") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param uTexture     Texture to sample from.
-    /// @param output       Texture to write to.
-    /// @param intensity    Intensity parameter.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // uTexture     Texture to sample from.
+    // output       Texture to write to.
+    // intensity    Intensity parameter.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* uTexture, Texture* output, ppx::float2 texelSize, float intensity)
     {
         ScalarInput si(output);
@@ -303,12 +300,11 @@ public:
     BloomPrefilterShader(FluidSimulation* sim)
         : ComputeShader(sim, "bloom_prefilter") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param uTexture     Texture to sample from.
-    /// @param output       Texture to write to.
-    /// @param curve        Curve parameter.
-    /// @param threshold    Threshold parameter.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // uTexture     Texture to sample from.
+    // output       Texture to write to.
+    // curve        Curve parameter.
+    // threshold    Threshold parameter.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* uTexture, Texture* output, ppx::float3 curve, float threshold)
     {
         ScalarInput si(output);
@@ -328,10 +324,9 @@ public:
     BlurShader(FluidSimulation* sim)
         : ComputeShader(sim, "blur") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param uTexture     Texture to sample from.
-    /// @param output       Texture to write to.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // uTexture     Texture to sample from.
+    // output       Texture to write to.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* uTexture, Texture* output, ppx::float2 texelSize)
     {
         ScalarInput si(output);
@@ -350,10 +345,9 @@ public:
     CheckerboardShader(FluidSimulation* sim)
         : ComputeShader(sim, "checkerboard") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param output       Texture to write to.
-    /// @param aspectRatio  Aspect ratio parameter.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // output       Texture to write to.
+    // aspectRatio  Aspect ratio parameter.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* output, float aspectRatio)
     {
         ScalarInput si(output);
@@ -389,10 +383,9 @@ public:
     ColorShader(FluidSimulation* sim)
         : ComputeShader(sim, "color") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param output   Texture to write to.
-    /// @param color    Color to write to the whole texture.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // output   Texture to write to.
+    // color    Color to write to the whole texture.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* output, ppx::float4 color)
     {
         ScalarInput si(output);
@@ -428,10 +421,9 @@ public:
     DisplayShader(FluidSimulation* sim)
         : ComputeShader(sim, "display") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param output   Texture to write to.
-    /// @param color    Color to write to the whole texture.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // output   Texture to write to.
+    // color    Color to write to the whole texture.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* uTexture, Texture* uBloom, Texture* uSunrays, Texture* uDithering, Texture* output, ppx::float2 texelSize, ppx::float2 ditherScale)
     {
         ScalarInput si(output);
@@ -510,15 +502,14 @@ public:
     SplatShader(FluidSimulation* sim)
         : ComputeShader(sim, "splat") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param dr           Dispatch record to update.
-    /// @param uTexture     Texture to sample from.
-    /// @param output       Texture to write to.
-    /// @param coordinate   Coordinate shader parameter.
-    /// @param aspectRatio  Aspect ratio shader parameter.
-    /// @param radius       Radius shader parameter.
-    /// @param color        Color shader parameter.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // dr           Dispatch record to update.
+    // uTexture     Texture to sample from.
+    // output       Texture to write to.
+    // coordinate   Coordinate shader parameter.
+    // aspectRatio  Aspect ratio shader parameter.
+    // radius       Radius shader parameter.
+    // color        Color shader parameter.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* uTexture, Texture* output, ppx::float2 coordinate, float aspectRatio, float radius, ppx::float4 color)
     {
         ScalarInput si(output);
@@ -540,10 +531,9 @@ public:
     SunraysMaskShader(FluidSimulation* sim)
         : ComputeShader(sim, "sunrays_mask") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param uTexture     Texture to sample from.
-    /// @param output       Texture to write to.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // uTexture     Texture to sample from.
+    // output       Texture to write to.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* uTexture, Texture* output)
     {
         ScalarInput si(output);
@@ -561,11 +551,10 @@ public:
     SunraysShader(FluidSimulation* sim)
         : ComputeShader(sim, "sunrays") {}
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param uTexture     Texture to sample from.
-    /// @param output       Texture to write to.
-    /// @param weight       Weight parameter.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // uTexture     Texture to sample from.
+    // output       Texture to write to.
+    // weight       Weight parameter.
     std::unique_ptr<ComputeDispatchRecord> GetDR(Texture* uTexture, Texture* output, float weight)
     {
         ScalarInput si(output);
@@ -619,15 +608,14 @@ class GraphicsShader : public Shader
 public:
     GraphicsShader(FluidSimulation* sim);
 
-    /// @brief Draw the given texture.
-    /// @param frame        Frame to use.
-    /// @param dr           GraphicsDispatchRecord instance to use for setting up the pipeline.
+    // Draw the given texture.
+    // frame        Frame to use.
+    // dr           GraphicsDispatchRecord instance to use for setting up the pipeline.
     void Dispatch(const PerFrame& frame, const std::unique_ptr<GraphicsDispatchRecord>& dr);
 
-    /// @brief Create a dispatch record to execute this shader instance.
-    /// @param image    Texture to draw.
-    /// @param coord    Normalized coordinate where to draw the texture.
-    /// @return The dispatch record to schedule.
+    // Create a dispatch record to execute this shader instance.
+    // image    Texture to draw.
+    // coord    Normalized coordinate where to draw the texture.
     std::unique_ptr<GraphicsDispatchRecord> GetDR(Texture* image, ppx::float2 coord)
     {
         return std::make_unique<GraphicsDispatchRecord>(this, image, coord);

--- a/projects/fluid_simulation/sim.h
+++ b/projects/fluid_simulation/sim.h
@@ -207,7 +207,6 @@ private:
     //
     // dr   The dispatch record describing the shader to be executed and
     //      the data used to execute it (descriptor set and uniform buffer).
-    //      @see ComputeDispatchRecord.
     void ScheduleDR(std::unique_ptr<ComputeDispatchRecord> dr) { mComputeDispatchQueue.push_back(std::move(dr)); }
 
     // Schedule a graphics shader for execution.

--- a/projects/fluid_simulation/sim.h
+++ b/projects/fluid_simulation/sim.h
@@ -54,7 +54,7 @@ struct SimulationConfig
     ppx::float4 backColor = {0.0f, 0.0f, 0.0f, 1.0f};
 };
 
-/// @brief Represents a virtual object bouncing around the field.
+// Represents a virtual object bouncing around the field.
 struct Bouncer
 {
     ppx::float2 coord = {0.5, 0.5};
@@ -75,31 +75,31 @@ public:
     GraphicsResources*           GetGraphicsResources() { return &mGraphics; }
     PerFrame&                    GetFrame(size_t ix) { return mPerFrame[ix]; }
 
-    /// @brief Generate the initial splash of color.
+    // Generate the initial splash of color.
     void GenerateInitialSplat();
 
-    /// @brief Execute all the scheduled compute shaders in sequence.
+    // Execute all the scheduled compute shaders in sequence.
     void DispatchComputeShaders(const PerFrame& frame);
 
-    /// @brief Free descriptor sets and uniform buffers used by compute shaders. This
-    /// also clears the execution schedule.
-    ///
-    /// TODO(https://github.com/google/bigwheels/issues/26): Implement resource pool.
+    // Free descriptor sets and uniform buffers used by compute shaders. This
+    // also clears the execution schedule.
+    //
+    // TODO(https://github.com/google/bigwheels/issues/26): Implement resource pool.
     void FreeComputeShaderResources();
 
-    /// @brief Execute all the scheduled graphics shaders in sequence.
+    // brief Execute all the scheduled graphics shaders in sequence.
     void DispatchGraphicsShaders(const PerFrame& frame);
 
-    /// @brief Free descriptor sets used by graphics shaders. This also clears
-    /// the execution schedule.
+    // Free descriptor sets used by graphics shaders. This also clears
+    // the execution schedule.
     void FreeGraphicsShaderResources();
 
-    /// @brief Register the given texture to be filled with an initial color.
-    /// @param texture Texture to initialize.
+    // Register the given texture to be filled with an initial color.
+    // texture Texture to initialize.
     void AddTextureToInitialize(Texture* texture);
 
-    /// @brief  Update the state of the simulation.  This moves the virtual
-    ///         bodies producing the wake.
+    // Update the state of the simulation.  This moves the virtual
+    // bodies producing the wake.
     void Update();
 
 private:
@@ -183,12 +183,12 @@ private:
     void        MoveMarble();
     void        Step(float deltaTime);
 
-    /// @brief             Return a vector describing a rectangle with dimensions that can fit "resolution" pixels.
-    ///
-    /// @param resolution  The minimum size of the rectangle to fit this many pixels.
-    ///
-    /// @return            A vector of 2 dimensions. The dimensions have the same aspect ratio as
-    ///                    the application window and can fit at least "resolution" pixels in it.
+    // Return a vector describing a rectangle with dimensions that can fit "resolution" pixels.
+    //
+    // resolution  The minimum size of the rectangle to fit this many pixels.
+    //
+    // Returns A vector of 2 dimensions. The dimensions have the same aspect ratio as
+    // the application window and can fit at least "resolution" pixels in it.
     ppx::uint2 GetResolution(uint32_t resolution);
 
     ppx::float3  HSVtoRGB(ppx::float3 hsv);
@@ -203,18 +203,17 @@ private:
     ppx::Random& Random() { return mRandom; }
     void         Splat(ppx::float2 point, ppx::float2 delta, ppx::float3 color);
 
-    /// @brief Schedule a compute shader for execution.
-    ///
-    /// @param dr   The dispatch record describing the shader to be executed and
-    ///             the data used to execute it (descriptor set and uniform buffer).
-    ///             @see ComputeDispatchRecord.
+    // Schedule a compute shader for execution.
+    //
+    // dr   The dispatch record describing the shader to be executed and
+    //      the data used to execute it (descriptor set and uniform buffer).
+    //      @see ComputeDispatchRecord.
     void ScheduleDR(std::unique_ptr<ComputeDispatchRecord> dr) { mComputeDispatchQueue.push_back(std::move(dr)); }
 
-    /// @brief Schedule a graphics shader for execution.
-    ///
-    /// @param dr   The dispatch record describing the shader to be executed and
-    ///             the descriptor set and texture used to execute it.
-    ///             @see GraphicsDispatchRecord.
+    // Schedule a graphics shader for execution.
+    //
+    // dr   The dispatch record describing the shader to be executed and
+    //      the descriptor set and texture used to execute it.
     void ScheduleDR(std::unique_ptr<GraphicsDispatchRecord> dr) { mGraphicsDispatchQueue.push_back(std::move(dr)); }
 };
 


### PR DESCRIPTION
We are not really using doxygen for anything and it doesn't seem to work with github (which was my hope).  So, I give up.

This removes all the markers I had added to the source code.