### PR TITLE
Re-factor simulation instance creation

### DIFF
--- a/projects/fluid_simulation/main.cpp
+++ b/projects/fluid_simulation/main.cpp
@@ -183,7 +183,7 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 void ProjApp::Setup()
 {
     // Create the main simulation driver.
-    mSim = std::make_unique<FluidSimulation>(this);
+    FluidSim::FluidSimulation::Create(this, GetDevice(), ppx::uint2(GetWindowWidth(), GetWindowHeight()), mConfig, &mSim);
 
     // Generate the initial screen with random splashes of color.
     mSim->GenerateInitialSplat();

--- a/projects/fluid_simulation/shaders.cpp
+++ b/projects/fluid_simulation/shaders.cpp
@@ -84,17 +84,17 @@ Texture::Texture(FluidSimulation* sim, const std::string& textureFile)
     PPX_CHECKED_CALL(GetApp()->GetDevice()->CreateStorageImageView(&storageVCI, &mStorageView));
 }
 
-ProjApp* Texture::GetApp() const
+ppx::Application* Texture::GetApp() const
 {
     return mSim->GetApp();
 }
 
 ppx::float2 Texture::GetNormalizedSize() const
 {
-    return ppx::float2(GetWidth() * 2.0f / GetApp()->GetWindowWidth(), GetHeight() * 2.0f / GetApp()->GetWindowHeight());
+    return ppx::float2(GetWidth() * 2.0f / mSim->GetWidth(), GetHeight() * 2.0f / mSim->GetHeight());
 }
 
-ProjApp* Shader::GetApp() const
+ppx::Application* Shader::GetApp() const
 {
     return mSim->GetApp();
 }

--- a/projects/fluid_simulation/shaders.h
+++ b/projects/fluid_simulation/shaders.h
@@ -8,6 +8,7 @@
 #ifndef FLUID_SIMULATION_SHADERS_H
 #define FLUID_SIMULATION_SHADERS_H
 
+#include "ppx/application.h"
 #include "ppx/graphics_util.h"
 #include "ppx/grfx/grfx_buffer.h"
 #include "ppx/grfx/grfx_config.h"
@@ -19,7 +20,6 @@
 
 namespace FluidSim {
 
-class ProjApp;
 class FluidSimulation;
 
 // Pipeline interface, descriptor layout and sampler used by compute shaders.
@@ -89,7 +89,7 @@ public:
     }
 
 private:
-    ProjApp* GetApp() const;
+    ppx::Application* GetApp() const;
 
     FluidSimulation*               mSim;
     ppx::grfx::ImagePtr            mTexture;
@@ -158,7 +158,7 @@ public:
 
     const std::string& GetName() const { return mShaderFile; }
     FluidSimulation*   GetSim() const { return mSim; }
-    ProjApp*           GetApp() const;
+    ppx::Application*  GetApp() const;
     GraphicsResources* GetGraphicsResources() const;
     ComputeResources*  GetComputeResources() const;
 

--- a/projects/fluid_simulation/sim.h
+++ b/projects/fluid_simulation/sim.h
@@ -67,13 +67,34 @@ class ProjApp;
 class FluidSimulation
 {
 public:
-    FluidSimulation(ProjApp* app);
-    ProjApp*                     GetApp() const { return mApp; }
-    const SimulationConfig&      GetConfig() const;
+    FluidSimulation(ppx::Application* app, ppx::grfx::DevicePtr device, ppx::uint2 resolution, const SimulationConfig& config)
+        : mApp(app), mDevice(device), mResolution(resolution), mConfig(config)
+    {
+    }
+
+    // Create a new fluid simulation instance.
+    //
+    // device       The device to use.
+    // resolution   A 2 element vector with the desired resolution in pixels.
+    // config       An instance of SimulationConfig describing all the inputs to the simulation.
+    // ppSim        A pointer the the newly created simulator instance.  If an error occurred during creation,
+    //              this will be set to nullptr and an error code will be returned.
+    static ppx::Result Create(ppx::Application* app, ppx::grfx::DevicePtr device, ppx::uint2 resolution, const SimulationConfig& config, std::unique_ptr<FluidSimulation>* ppSim);
+
+    ppx::Application*            GetApp() const { return mApp; }
+    const SimulationConfig&      GetConfig() const { return mConfig; }
     ppx::grfx::DescriptorPoolPtr GetDescriptorPool() const { return mDescriptorPool; }
     ComputeResources*            GetComputeResources() { return &mCompute; }
     GraphicsResources*           GetGraphicsResources() { return &mGraphics; }
     PerFrame&                    GetFrame(size_t ix) { return mPerFrame[ix]; }
+    ppx::uint2                   GetResolution() const { return mResolution; }
+    float                        GetResolutionAspect() const { return static_cast<float>(GetWidth()) / static_cast<float>(GetHeight()); }
+    uint32_t                     GetWidth() const { return mResolution.x; }
+    uint32_t                     GetHeight() const { return mResolution.y; }
+    ppx::grfx::DevicePtr         GetDevice() const { return mDevice; }
+
+    // Initialize the simulation.
+    ppx::Result Initialize();
 
     // Generate the initial splash of color.
     void GenerateInitialSplat();
@@ -104,7 +125,16 @@ public:
 
 private:
     // Parent application data.
-    ProjApp* mApp;
+    ppx::Application* mApp;
+
+    // Device to use.
+    ppx::grfx::DevicePtr mDevice;
+
+    // Resolution to use for the simulation.
+    ppx::uint2 mResolution;
+
+    // Simulation parameters.
+    SimulationConfig mConfig;
 
     // Frame synchronization data.
     std::vector<PerFrame> mPerFrame;


### PR DESCRIPTION
This is the first step to fix #299.  It moves the creation of the simulation instance into a static method and starts disentangling it from the application.

Further cleanups will remove the ppx::Application link and the command buffer creation.