### PR TITLE
Fixes and speed improvement for graphics_pipeline vertex buffer setup

### DIFF
--- a/benchmarks/graphics_pipeline/main.cpp
+++ b/benchmarks/graphics_pipeline/main.cpp
@@ -503,15 +503,13 @@ void ProjApp::Setup()
             const uint32_t sphereTriCount    = mesh.GetCountTriangles();
 
             PPX_LOG_INFO("LOD: " << lod.name);
-            PPX_LOG_INFO("Sphere vertex count: " << sphereVertexCount);
-            PPX_LOG_INFO("Sphere triangle count: " << sphereTriCount);
+            PPX_LOG_INFO("  Sphere vertex count: " << sphereVertexCount << " | triangle count: " << sphereTriCount);
 
             Geometry lowPrecisionInterleaved;
             PPX_CHECKED_CALL(Geometry::Create(GeometryOptions::InterleavedU32(grfx::FORMAT_R16G16B16_FLOAT).AddTexCoord(grfx::FORMAT_R16G16_FLOAT).AddNormal(grfx::FORMAT_R8G8B8A8_SNORM).AddTangent(grfx::FORMAT_R8G8B8A8_SNORM), &lowPrecisionInterleaved));
             lowPrecisionInterleaved.EnableInitialResizeMode();
             lowPrecisionInterleaved.ResizeIndexBuffer(12 * sphereTriCount * kMaxSphereInstanceCount);        // 12 bytes per triangle
             lowPrecisionInterleaved.ResizeVertexBuffer(0, 18 * sphereVertexCount * kMaxSphereInstanceCount); // 18 bytes per vertex
-            //PPX_LOG_INFO("lowPrecisionInterleaved VERTEX BUFFER COUNT: " << lowPrecisionInterleaved.GetVertexBufferCount());
 
             Geometry lowPrecisionPositionPlanar;
             PPX_CHECKED_CALL(Geometry::Create(GeometryOptions::PositionPlanarU32(grfx::FORMAT_R16G16B16_FLOAT).AddTexCoord(grfx::FORMAT_R16G16_FLOAT).AddNormal(grfx::FORMAT_R8G8B8A8_SNORM).AddTangent(grfx::FORMAT_R8G8B8A8_SNORM), &lowPrecisionPositionPlanar));
@@ -519,14 +517,12 @@ void ProjApp::Setup()
             lowPrecisionPositionPlanar.ResizeIndexBuffer(12 * sphereTriCount * kMaxSphereInstanceCount);        // 12 bytes per triangle
             lowPrecisionPositionPlanar.ResizeVertexBuffer(0, 6 * sphereVertexCount * kMaxSphereInstanceCount);  // 6 bytes per vertex
             lowPrecisionPositionPlanar.ResizeVertexBuffer(1, 12 * sphereVertexCount * kMaxSphereInstanceCount); // 12 bytes per vertex
-            //PPX_LOG_INFO("lowPrecisionPositionPlanar VERTEX BUFFER COUNT: " << lowPrecisionPositionPlanar.GetVertexBufferCount());
 
             Geometry highPrecisionInterleaved;
             PPX_CHECKED_CALL(Geometry::Create(GeometryOptions::InterleavedU32().AddTexCoord().AddNormal().AddTangent(), &highPrecisionInterleaved));
             highPrecisionInterleaved.EnableInitialResizeMode();
             highPrecisionInterleaved.ResizeIndexBuffer(12 * sphereTriCount * kMaxSphereInstanceCount);        // 12 bytes per triangle
             highPrecisionInterleaved.ResizeVertexBuffer(0, 48 * sphereVertexCount * kMaxSphereInstanceCount); // 48 bytes per vertex
-            //PPX_LOG_INFO("highPrecisionInterleaved VERTEX BUFFER COUNT: " << highPrecisionInterleaved.GetVertexBufferCount());
 
             Geometry highPrecisionPositionPlanar;
             PPX_CHECKED_CALL(Geometry::Create(GeometryOptions::PositionPlanarU32().AddTexCoord().AddNormal().AddTangent(), &highPrecisionPositionPlanar));
@@ -534,7 +530,6 @@ void ProjApp::Setup()
             highPrecisionPositionPlanar.ResizeIndexBuffer(12 * sphereTriCount * kMaxSphereInstanceCount);        // 12 bytes per triangle
             highPrecisionPositionPlanar.ResizeVertexBuffer(0, 12 * sphereVertexCount * kMaxSphereInstanceCount); // 12 bytes per vertex
             highPrecisionPositionPlanar.ResizeVertexBuffer(1, 36 * sphereVertexCount * kMaxSphereInstanceCount); // 36 bytes per vertex
-            //PPX_LOG_INFO("highPrecisionPositionPlanar VERTEX BUFFER COUNT: " << highPrecisionPositionPlanar.GetVertexBufferCount());
 
             for (uint32_t i = 0; i < kMaxSphereInstanceCount; i++) {
                 uint32_t index = sphereIndices[i];
@@ -576,25 +571,29 @@ void ProjApp::Setup()
                 }
             }
 
-            PPX_LOG_INFO("Final vertex count of lowPrecisionInterleaved: " << lowPrecisionInterleaved.GetVertexCount());
-            PPX_LOG_INFO("lowPrecisionInterleaved INDEX BUFFER SIZE: " << lowPrecisionInterleaved.GetIndexBuffer()->GetSize());
-            PPX_LOG_INFO("lowPrecisionInterleaved VERTEX BUFFER 0 SIZE: " << lowPrecisionInterleaved.GetVertexBuffer(0)->GetSize());
+            PPX_LOG_INFO("  lowPrecisionInterleaved vertex buffer");
+            PPX_LOG_INFO("    vertex count: " << lowPrecisionInterleaved.GetVertexCount());
+            PPX_LOG_INFO("    index buffer size: " << lowPrecisionInterleaved.GetIndexBuffer()->GetSize());
+            PPX_LOG_INFO("    vertex buffer 0 size: " << lowPrecisionInterleaved.GetVertexBuffer(0)->GetSize());
 
-            PPX_LOG_INFO("Final vertex count of lowPrecisionPositionPlanar: " << lowPrecisionPositionPlanar.GetVertexCount());
-            PPX_LOG_INFO("lowPrecisionPositionPlanar INDEX BUFFER SIZE: " << lowPrecisionPositionPlanar.GetIndexBuffer()->GetSize());
-            PPX_LOG_INFO("lowPrecisionPositionPlanar VERTEX BUFFER 0 SIZE: " << lowPrecisionPositionPlanar.GetVertexBuffer(0)->GetSize());
-            PPX_LOG_INFO("lowPrecisionPositionPlanar VERTEX BUFFER 1 SIZE: " << lowPrecisionPositionPlanar.GetVertexBuffer(1)->GetSize());
+            PPX_LOG_INFO("  lowPrecisionPositionPlanar vertex buffer");
+            PPX_LOG_INFO("    vertex count: " << lowPrecisionPositionPlanar.GetVertexCount());
+            PPX_LOG_INFO("    index buffer size: " << lowPrecisionPositionPlanar.GetIndexBuffer()->GetSize());
+            PPX_LOG_INFO("    vertex buffer 0 size: " << lowPrecisionPositionPlanar.GetVertexBuffer(0)->GetSize());
+            PPX_LOG_INFO("    vertex buffer 1 size: " << lowPrecisionPositionPlanar.GetVertexBuffer(1)->GetSize());
 
-            PPX_LOG_INFO("Final vertex count of highPrecisionInterleaved: " << highPrecisionInterleaved.GetVertexCount());
-            PPX_LOG_INFO("highPrecisionInterleaved INDEX BUFFER SIZE: " << highPrecisionInterleaved.GetIndexBuffer()->GetSize());
-            PPX_LOG_INFO("highPrecisionInterleaved VERTEX BUFFER 0 SIZE: " << highPrecisionInterleaved.GetVertexBuffer(0)->GetSize());
+            PPX_LOG_INFO("  highPrecisionInterleaved vertex buffer");
+            PPX_LOG_INFO("    vertex count: " << highPrecisionInterleaved.GetVertexCount());
+            PPX_LOG_INFO("    index buffer size: " << highPrecisionInterleaved.GetIndexBuffer()->GetSize());
+            PPX_LOG_INFO("    vertex buffer 0 size: " << highPrecisionInterleaved.GetVertexBuffer(0)->GetSize());
 
-            PPX_LOG_INFO("Final vertex count of highPrecisionPositionPlanar: " << highPrecisionPositionPlanar.GetVertexCount());
-            PPX_LOG_INFO("highPrecisionPositionPlanar INDEX BUFFER SIZE: " << highPrecisionPositionPlanar.GetIndexBuffer()->GetSize());
-            PPX_LOG_INFO("highPrecisionPositionPlanar VERTEX BUFFER 0 SIZE: " << highPrecisionPositionPlanar.GetVertexBuffer(0)->GetSize());
-            PPX_LOG_INFO("highPrecisionPositionPlanar VERTEX BUFFER 1 SIZE: " << highPrecisionPositionPlanar.GetVertexBuffer(1)->GetSize());
+            PPX_LOG_INFO("  highPrecisionPositionPlanar vertex buffer");
+            PPX_LOG_INFO("    vertex count: " << highPrecisionPositionPlanar.GetVertexCount());
+            PPX_LOG_INFO("    index buffer size: " << highPrecisionPositionPlanar.GetIndexBuffer()->GetSize());
+            PPX_LOG_INFO("    vertex buffer 0 size: " << highPrecisionPositionPlanar.GetVertexBuffer(0)->GetSize());
+            PPX_LOG_INFO("    vertex buffer 1 size: " << highPrecisionPositionPlanar.GetVertexBuffer(1)->GetSize());
 
-            // Create a giant vertex buffer to accommodate all copies of the sphere mesh
+            // Create a giant vertex buffer for each vb type to accommodate all copies of the sphere mesh
             PPX_CHECKED_CALL(grfx_util::CreateMeshFromGeometry(GetGraphicsQueue(), &lowPrecisionInterleaved, &mSphereMeshes[meshIndex++]));
             PPX_CHECKED_CALL(grfx_util::CreateMeshFromGeometry(GetGraphicsQueue(), &lowPrecisionPositionPlanar, &mSphereMeshes[meshIndex++]));
             PPX_CHECKED_CALL(grfx_util::CreateMeshFromGeometry(GetGraphicsQueue(), &highPrecisionInterleaved, &mSphereMeshes[meshIndex++]));

--- a/benchmarks/graphics_pipeline/main.cpp
+++ b/benchmarks/graphics_pipeline/main.cpp
@@ -490,9 +490,9 @@ void ProjApp::Setup()
         Shuffle(sphereIndices.begin(), sphereIndices.end(), std::mt19937(kSeed));
 
         // LODs for spheres
-        mSphereLODs.push_back(LOD{/* longitudeSegments = */ 10, /* latitudeSegments = */ 10, kAvailableLODs[0]});
+        mSphereLODs.push_back(LOD{/* longitudeSegments = */ 50, /* latitudeSegments = */ 50, kAvailableLODs[0]});
         mSphereLODs.push_back(LOD{/* longitudeSegments = */ 20, /* latitudeSegments = */ 20, kAvailableLODs[1]});
-        mSphereLODs.push_back(LOD{/* longitudeSegments = */ 50, /* latitudeSegments = */ 50, kAvailableLODs[2]});
+        mSphereLODs.push_back(LOD{/* longitudeSegments = */ 10, /* latitudeSegments = */ 10, kAvailableLODs[2]});
         PPX_ASSERT_MSG(mSphereLODs.size() == kAvailableLODs.size(), "LODs for spheres must be the same as the available LODs");
 
         // Create the meshes
@@ -502,17 +502,39 @@ void ProjApp::Setup()
             const uint32_t sphereVertexCount = mesh.GetCountPositions();
             const uint32_t sphereTriCount    = mesh.GetCountTriangles();
 
+            PPX_LOG_INFO("LOD: " << lod.name);
+            PPX_LOG_INFO("Sphere vertex count: " << sphereVertexCount);
+            PPX_LOG_INFO("Sphere triangle count: " << sphereTriCount);
+
             Geometry lowPrecisionInterleaved;
             PPX_CHECKED_CALL(Geometry::Create(GeometryOptions::InterleavedU32(grfx::FORMAT_R16G16B16_FLOAT).AddTexCoord(grfx::FORMAT_R16G16_FLOAT).AddNormal(grfx::FORMAT_R8G8B8A8_SNORM).AddTangent(grfx::FORMAT_R8G8B8A8_SNORM), &lowPrecisionInterleaved));
+            lowPrecisionInterleaved.EnableInitialResizeMode();
+            lowPrecisionInterleaved.ResizeIndexBuffer(12 * sphereTriCount * kMaxSphereInstanceCount);        // 12 bytes per triangle
+            lowPrecisionInterleaved.ResizeVertexBuffer(0, 18 * sphereVertexCount * kMaxSphereInstanceCount); // 18 bytes per vertex
+            //PPX_LOG_INFO("lowPrecisionInterleaved VERTEX BUFFER COUNT: " << lowPrecisionInterleaved.GetVertexBufferCount());
 
             Geometry lowPrecisionPositionPlanar;
             PPX_CHECKED_CALL(Geometry::Create(GeometryOptions::PositionPlanarU32(grfx::FORMAT_R16G16B16_FLOAT).AddTexCoord(grfx::FORMAT_R16G16_FLOAT).AddNormal(grfx::FORMAT_R8G8B8A8_SNORM).AddTangent(grfx::FORMAT_R8G8B8A8_SNORM), &lowPrecisionPositionPlanar));
+            lowPrecisionPositionPlanar.EnableInitialResizeMode();
+            lowPrecisionPositionPlanar.ResizeIndexBuffer(12 * sphereTriCount * kMaxSphereInstanceCount);        // 12 bytes per triangle
+            lowPrecisionPositionPlanar.ResizeVertexBuffer(0, 6 * sphereVertexCount * kMaxSphereInstanceCount);  // 6 bytes per vertex
+            lowPrecisionPositionPlanar.ResizeVertexBuffer(1, 12 * sphereVertexCount * kMaxSphereInstanceCount); // 12 bytes per vertex
+            //PPX_LOG_INFO("lowPrecisionPositionPlanar VERTEX BUFFER COUNT: " << lowPrecisionPositionPlanar.GetVertexBufferCount());
 
             Geometry highPrecisionInterleaved;
             PPX_CHECKED_CALL(Geometry::Create(GeometryOptions::InterleavedU32().AddTexCoord().AddNormal().AddTangent(), &highPrecisionInterleaved));
+            highPrecisionInterleaved.EnableInitialResizeMode();
+            highPrecisionInterleaved.ResizeIndexBuffer(12 * sphereTriCount * kMaxSphereInstanceCount);        // 12 bytes per triangle
+            highPrecisionInterleaved.ResizeVertexBuffer(0, 48 * sphereVertexCount * kMaxSphereInstanceCount); // 48 bytes per vertex
+            //PPX_LOG_INFO("highPrecisionInterleaved VERTEX BUFFER COUNT: " << highPrecisionInterleaved.GetVertexBufferCount());
 
             Geometry highPrecisionPositionPlanar;
             PPX_CHECKED_CALL(Geometry::Create(GeometryOptions::PositionPlanarU32().AddTexCoord().AddNormal().AddTangent(), &highPrecisionPositionPlanar));
+            highPrecisionPositionPlanar.EnableInitialResizeMode();
+            highPrecisionPositionPlanar.ResizeIndexBuffer(12 * sphereTriCount * kMaxSphereInstanceCount);        // 12 bytes per triangle
+            highPrecisionPositionPlanar.ResizeVertexBuffer(0, 12 * sphereVertexCount * kMaxSphereInstanceCount); // 12 bytes per vertex
+            highPrecisionPositionPlanar.ResizeVertexBuffer(1, 36 * sphereVertexCount * kMaxSphereInstanceCount); // 36 bytes per vertex
+            //PPX_LOG_INFO("highPrecisionPositionPlanar VERTEX BUFFER COUNT: " << highPrecisionPositionPlanar.GetVertexBufferCount());
 
             for (uint32_t i = 0; i < kMaxSphereInstanceCount; i++) {
                 uint32_t index = sphereIndices[i];
@@ -553,6 +575,25 @@ void ProjApp::Setup()
                     highPrecisionPositionPlanar.AppendIndicesTriangle(v0 + i * sphereVertexCount, v1 + i * sphereVertexCount, v2 + i * sphereVertexCount);
                 }
             }
+
+            PPX_LOG_INFO("Final vertex count of lowPrecisionInterleaved: " << lowPrecisionInterleaved.GetVertexCount());
+            PPX_LOG_INFO("lowPrecisionInterleaved INDEX BUFFER SIZE: " << lowPrecisionInterleaved.GetIndexBuffer()->GetSize());
+            PPX_LOG_INFO("lowPrecisionInterleaved VERTEX BUFFER 0 SIZE: " << lowPrecisionInterleaved.GetVertexBuffer(0)->GetSize());
+
+            PPX_LOG_INFO("Final vertex count of lowPrecisionPositionPlanar: " << lowPrecisionPositionPlanar.GetVertexCount());
+            PPX_LOG_INFO("lowPrecisionPositionPlanar INDEX BUFFER SIZE: " << lowPrecisionPositionPlanar.GetIndexBuffer()->GetSize());
+            PPX_LOG_INFO("lowPrecisionPositionPlanar VERTEX BUFFER 0 SIZE: " << lowPrecisionPositionPlanar.GetVertexBuffer(0)->GetSize());
+            PPX_LOG_INFO("lowPrecisionPositionPlanar VERTEX BUFFER 1 SIZE: " << lowPrecisionPositionPlanar.GetVertexBuffer(1)->GetSize());
+
+            PPX_LOG_INFO("Final vertex count of highPrecisionInterleaved: " << highPrecisionInterleaved.GetVertexCount());
+            PPX_LOG_INFO("highPrecisionInterleaved INDEX BUFFER SIZE: " << highPrecisionInterleaved.GetIndexBuffer()->GetSize());
+            PPX_LOG_INFO("highPrecisionInterleaved VERTEX BUFFER 0 SIZE: " << highPrecisionInterleaved.GetVertexBuffer(0)->GetSize());
+
+            PPX_LOG_INFO("Final vertex count of highPrecisionPositionPlanar: " << highPrecisionPositionPlanar.GetVertexCount());
+            PPX_LOG_INFO("highPrecisionPositionPlanar INDEX BUFFER SIZE: " << highPrecisionPositionPlanar.GetIndexBuffer()->GetSize());
+            PPX_LOG_INFO("highPrecisionPositionPlanar VERTEX BUFFER 0 SIZE: " << highPrecisionPositionPlanar.GetVertexBuffer(0)->GetSize());
+            PPX_LOG_INFO("highPrecisionPositionPlanar VERTEX BUFFER 1 SIZE: " << highPrecisionPositionPlanar.GetVertexBuffer(1)->GetSize());
+
             // Create a giant vertex buffer to accommodate all copies of the sphere mesh
             PPX_CHECKED_CALL(grfx_util::CreateMeshFromGeometry(GetGraphicsQueue(), &lowPrecisionInterleaved, &mSphereMeshes[meshIndex++]));
             PPX_CHECKED_CALL(grfx_util::CreateMeshFromGeometry(GetGraphicsQueue(), &lowPrecisionPositionPlanar, &mSphereMeshes[meshIndex++]));

--- a/include/ppx/geometry.h
+++ b/include/ppx/geometry.h
@@ -237,6 +237,8 @@ public:
     const Geometry::Buffer* GetVertexBuffer(uint32_t index) const;
     uint32_t                GetLargestBufferSize() const;
 
+    bool GetInitialResizeMode() const { return mInitialResizeMode; }
+
     // Appends single index, triangle, or edge vertex indices to index buffer
     //
     // Will cast to uint16_t if geometry index type is UINT16.

--- a/include/ppx/geometry.h
+++ b/include/ppx/geometry.h
@@ -261,6 +261,18 @@ public:
     void AppendTriangle(const TriMeshVertexData& vtx0, const TriMeshVertexData& vtx1, const TriMeshVertexData& vtx2);
     void AppendEdge(const WireMeshVertexData& vtx0, const WireMeshVertexData& vtx1);
 
+    // Use the following resize functions before using the append functions for speed over convenience,
+    // corresponding to Buffer "Use #1" described above.
+    // Caller is responsible for resizing Buffers to the appropriate size.
+    //
+    // Enabling the initial resize mode will indicate that initial resizing is expected,
+    // and it will change the behaviour of all the Append functions used afterwards to use
+    // the Buffer DataPtrs.
+    //
+    void EnableInitialResizeMode();
+    void ResizeIndexBuffer(uint32_t sizeInBytes);
+    void ResizeVertexBuffer(uint32_t vbIndex, uint32_t sizeInBytes);
+
 private:
     // This is intialized to point to a static var of derived class of VertexDataProcessorBase
     // which is shared by geometry objects, it is not supposed to be deleted
@@ -270,11 +282,15 @@ private:
     Geometry::Buffer                                      mIndexBuffer;
     std::vector<Geometry::Buffer>                         mVertexBuffers;
     uint32_t                                              mPositionBufferIndex  = PPX_VALUE_IGNORED;
-    uint32_t                                              mNormaBufferIndex     = PPX_VALUE_IGNORED;
+    uint32_t                                              mNormalBufferIndex    = PPX_VALUE_IGNORED;
     uint32_t                                              mColorBufferIndex     = PPX_VALUE_IGNORED;
     uint32_t                                              mTexCoordBufferIndex  = PPX_VALUE_IGNORED;
     uint32_t                                              mTangentBufferIndex   = PPX_VALUE_IGNORED;
     uint32_t                                              mBitangentBufferIndex = PPX_VALUE_IGNORED;
+
+    bool               mInitialResizeMode  = false;
+    char*              mIndexBufferDataPtr = nullptr;
+    std::vector<char*> mVertexBuffersDataPtrs;
 };
 
 } // namespace ppx

--- a/src/ppx/geometry.cpp
+++ b/src/ppx/geometry.cpp
@@ -69,7 +69,7 @@ protected:
 
     void AddVertexBuffer(Geometry* pGeom, uint32_t bindingIndex)
     {
-        pGeom->mVertexBuffers.push_back(Geometry::Buffer(Geometry::BUFFER_TYPE_VERTEX, GetVertexBindingStride(pGeom, bindingIndex), pGeom->mCreateInfo.finalVertexCount));
+        pGeom->mVertexBuffers.push_back(Geometry::Buffer(Geometry::BUFFER_TYPE_VERTEX, GetVertexBindingStride(pGeom, bindingIndex), pGeom->mCreateInfo.maxVertexCount));
     }
 
     uint32_t GetVertexBufferSize(const Geometry* pGeom, uint32_t bufferIndex) const
@@ -267,8 +267,6 @@ public:
             }
             // clang-format on
         }
-        uint32_t endSize = this->GetVertexBufferSize(pGeom, kBufferIndex);
-
         uint32_t endElementCount = this->GetVertexBufferElementCount(pGeom, kBufferIndex);
         PPX_ASSERT_MSG(endElementCount - startElementCount == 1, "number of vertices written is not 1: starting: " << startElementCount << " ending: " << endElementCount);
 
@@ -603,15 +601,15 @@ GeometryOptions& GeometryOptions::AddBitangent(grfx::Format format)
     return *this;
 }
 
-GeometryOptions& GeometryOptions::FinalIndexCount(uint32_t count)
+GeometryOptions& GeometryOptions::MaxIndexCount(uint32_t count)
 {
-    finalIndexCount = count;
+    maxIndexCount = count;
     return *this;
 }
 
-GeometryOptions& GeometryOptions::FinalVertexCount(uint32_t count)
+GeometryOptions& GeometryOptions::MaxVertexCount(uint32_t count)
 {
-    finalVertexCount = count;
+    maxVertexCount = count;
     return *this;
 }
 
@@ -621,7 +619,7 @@ GeometryOptions& GeometryOptions::FinalVertexCount(uint32_t count)
 uint32_t Geometry::Buffer::GetElementCount() const
 {
     size_t sizeOfData = mData.size();
-    if (mKnownFinalElementCount > 0) {
+    if (mKnownElementCount > 0) {
         sizeOfData = mOffset;
     }
     // round up for the case of interleaved buffers
@@ -665,7 +663,7 @@ Result Geometry::InternalCtor()
             return ppx::ERROR_FAILED;
         }
 
-        mIndexBuffer = Buffer(BUFFER_TYPE_INDEX, elementSize, mCreateInfo.finalIndexCount);
+        mIndexBuffer = Buffer(BUFFER_TYPE_INDEX, elementSize, mCreateInfo.maxIndexCount);
     }
 
     return mVDProcessor->UpdateVertexBuffer(this);


### PR DESCRIPTION
graphics_pipeline vertex buffers setup
* Changed LOD labels so that now `LOD0` has the highest detail and `LOD2` has the lowest.
* All vertex buffers used for the 4 different settings (high/low precision X interleaved/planar) are resized to their final sizes at the beginning to avoid the need for constant resizing at every append. 
* Added more logging for vertex buffer setup
* Overall setup time is cut in half, from ~70sec to ~35sec

geometry
* Added "Initial resize mode" to allow applications to have the speedier option to set a known size for the vertex buffer before appending/writing values into it, rather than resizing every time a new element is appended.