### PR TITLE
Add new XR knob for requesting OpenXR extensions.

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -248,7 +248,8 @@ struct StandardOptions
 
     std::shared_ptr<KnobFlag<std::pair<int, int>>> pResolution;
 #if defined(PPX_BUILD_XR)
-    std::shared_ptr<KnobFlag<std::pair<int, int>>> pXrUiResolution;
+    std::shared_ptr<KnobFlag<std::pair<int, int>>>      pXrUiResolution;
+    std::shared_ptr<KnobFlag<std::vector<std::string>>> pXrRequiredExtensions;
 #endif
 
     std::shared_ptr<KnobFlag<std::vector<std::string>>> pAssetsPaths;

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -105,6 +105,8 @@ struct XrComponentCreateInfo
     bool                    enableDepthSwapchain = false;
     XrComponentResolution   resolution           = {0, 0};
     XrComponentResolution   uiResolution         = {0, 0};
+
+    std::vector<std::string> requiredExtensions = {};
 };
 
 // Used to reference OpenXR layers added to XrComponent through XrComponent::AddLayer.

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -932,6 +932,15 @@ void Application::InitStandardKnobs()
     mStandardOpts.pXrUiResolution->SetValidator([](std::pair<int, int> res) {
         return res.first >= 0 && res.second >= 0;
     });
+
+    mStandardOpts.pXrRequiredExtensions =
+        mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>(
+            "xr-required-extension", defaultEmptyList);
+    mStandardOpts.pXrRequiredExtensions->SetFlagDescription(
+        "Specify any additional OpenXR extensions that need to be loaded in addition "
+        "to the base extensions. Any required extensions that are not supported by the "
+        "target system will cause the application to immediately exit.");
+    mStandardOpts.pXrRequiredExtensions->SetFlagParameters("<extension>");
 #endif
 }
 
@@ -1263,6 +1272,7 @@ int Application::Run(int argc, char** argv)
         }
         createInfo.uiResolution.width  = mSettings.xr.uiWidth;
         createInfo.uiResolution.height = mSettings.xr.uiHeight;
+        createInfo.requiredExtensions  = mStandardOpts.pXrRequiredExtensions->GetValue();
 
         mXrComponent.InitializeBeforeGrfxDeviceInit(createInfo);
     }

--- a/src/ppx/xr_component.cpp
+++ b/src/ppx/xr_component.cpp
@@ -89,6 +89,10 @@ void XrComponent::InitializeBeforeGrfxDeviceInit(const XrComponentCreateInfo& cr
     xrInstanceExtensions.push_back(XR_KHR_ANDROID_CREATE_INSTANCE_EXTENSION_NAME);
 #endif // defined(PPX_ANDROID)
 
+    for (const auto& extension : createInfo.requiredExtensions) {
+        xrInstanceExtensions.push_back(const_cast<char*>(extension.c_str()));
+    }
+
     if (mCreateInfo.enableDebug) {
         xrInstanceExtensions.push_back(XR_EXT_DEBUG_UTILS_EXTENSION_NAME);
     }


### PR DESCRIPTION
This is designed to allow projects and benchmarks to request additional OpenXR extensions on top of the handful that the `ppx::XrComponent` class requests.