### PR TITLE
Updates to Vulkan device extension handling

### DIFF
--- a/include/ppx/grfx/grfx_enums.h
+++ b/include/ppx/grfx/grfx_enums.h
@@ -21,10 +21,11 @@ namespace grfx {
 enum Api
 {
     API_UNDEFINED = 0,
-    API_VK_1_1,
-    API_VK_1_2,
-    API_DX_12_0,
-    API_DX_12_1,
+    API_VK_1_1    = (1 << 16) | (1 << 0),
+    API_VK_1_2    = (1 << 16) | (2 << 0),
+    API_VK_1_3    = (1 << 16) | (3 << 0),
+    API_DX_12_0   = (12 << 16) | (0 << 0),
+    API_DX_12_1   = (12 << 16) | (1 << 0),
 };
 
 enum AttachmentLoadOp

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -285,7 +285,7 @@ Result Device::CreateApiObjects(const grfx::DeviceCreateInfo* pCreateInfo)
     VkPhysicalDeviceDescriptorIndexingFeatures descriptorIndexingFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES};
     if ((GetInstance()->GetApi() >= grfx::API_VK_1_2) || ElementExists(std::string(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME), mExtensions)) {
         //
-        // 2023/10/01 - Just runtimeDescriptorArrays for now - need to survey what Android 
+        // 2023/10/01 - Just runtimeDescriptorArrays for now - need to survey what Android
         //              usage is like before enabling other freatures.
         //
         descriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing          = VK_FALSE;

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -333,7 +333,7 @@ Result Device::CreateApiObjects(const grfx::DeviceCreateInfo* pCreateInfo)
 
     // Chain pNexts
     for (size_t i = 0; i < (extensionStructs.size() - 1); ++i) {
-        extensionStructs[i]->pNext = extensionStructs[i+1];
+        extensionStructs[i]->pNext = extensionStructs[i + 1];
     }
 
     // Get C strings

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -165,19 +165,7 @@ Result Device::ConfigureExtensions(const grfx::DeviceCreateInfo* pCreateInfo)
         mExtensions.push_back(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
     }
 
-    // Dynamic rendering - if present. It also requires
-    // VK_KHR_depth_stencil_resolve and VK_KHR_create_renderpass2.
-#if defined(VK_KHR_dynamic_rendering)
-    if (ElementExists(std::string(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME), mFoundExtensions) &&
-        ElementExists(std::string(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME), mFoundExtensions) &&
-        ElementExists(std::string(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME), mFoundExtensions)) {
-        mExtensions.push_back(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
-        mExtensions.push_back(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME);
-        mExtensions.push_back(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-        mHasDynamicRendering = true;
-    }
-#endif
-
+    // Push descriptors
     if (ElementExists(std::string(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME), mFoundExtensions)) {
         mExtensions.push_back(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     }
@@ -293,34 +281,54 @@ Result Device::CreateApiObjects(const grfx::DeviceCreateInfo* pCreateInfo)
         return ppxres;
     }
 
-    // VK_EXT_host_query_reset
-#ifndef VK_API_VERSION_1_2
-    VkPhysicalDeviceHostQueryResetFeaturesEXT queryResetFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT};
-#else
-    VkPhysicalDeviceHostQueryResetFeatures queryResetFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES};
-#endif
-    queryResetFeatures.hostQueryReset = VK_TRUE;
-
-    // VkPhysicalDeviceDynamicRenderingFeatures
-#if defined(VK_KHR_dynamic_rendering)
-
-#ifndef VK_API_VERSION_1_3
-    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamicRenderingFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR};
-#else
-    VkPhysicalDeviceDynamicRenderingFeatures dynamicRenderingFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES};
-#endif
-
-    if (mHasDynamicRendering) {
-        dynamicRenderingFeatures.dynamicRendering = VK_TRUE;
-        queryResetFeatures.pNext                  = &dynamicRenderingFeatures;
+    // VK_EXT_descriptor_indexing
+    VkPhysicalDeviceDescriptorIndexingFeatures descriptorIndexingFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES};
+    if ((GetInstance()->GetApi() >= grfx::API_VK_1_2) || ElementExists(std::string(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME), mExtensions)) {
+        //
+        // 2023/10/01 - Just runtimeDescriptorArrays for now - need to survey what Android 
+        //              usage is like before enabling other freatures.
+        //
+        descriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing          = VK_FALSE;
+        descriptorIndexingFeatures.shaderUniformTexelBufferArrayDynamicIndexing       = VK_FALSE;
+        descriptorIndexingFeatures.shaderStorageTexelBufferArrayDynamicIndexing       = VK_FALSE;
+        descriptorIndexingFeatures.shaderUniformBufferArrayNonUniformIndexing         = VK_FALSE;
+        descriptorIndexingFeatures.shaderSampledImageArrayNonUniformIndexing          = VK_FALSE;
+        descriptorIndexingFeatures.shaderStorageBufferArrayNonUniformIndexing         = VK_FALSE;
+        descriptorIndexingFeatures.shaderStorageImageArrayNonUniformIndexing          = VK_FALSE;
+        descriptorIndexingFeatures.shaderInputAttachmentArrayNonUniformIndexing       = VK_FALSE;
+        descriptorIndexingFeatures.shaderUniformTexelBufferArrayNonUniformIndexing    = VK_FALSE;
+        descriptorIndexingFeatures.shaderStorageTexelBufferArrayNonUniformIndexing    = VK_FALSE;
+        descriptorIndexingFeatures.descriptorBindingUniformBufferUpdateAfterBind      = VK_FALSE;
+        descriptorIndexingFeatures.descriptorBindingSampledImageUpdateAfterBind       = VK_FALSE;
+        descriptorIndexingFeatures.descriptorBindingStorageImageUpdateAfterBind       = VK_FALSE;
+        descriptorIndexingFeatures.descriptorBindingStorageBufferUpdateAfterBind      = VK_FALSE;
+        descriptorIndexingFeatures.descriptorBindingUniformTexelBufferUpdateAfterBind = VK_FALSE;
+        descriptorIndexingFeatures.descriptorBindingStorageTexelBufferUpdateAfterBind = VK_FALSE;
+        descriptorIndexingFeatures.descriptorBindingUpdateUnusedWhilePending          = VK_FALSE;
+        descriptorIndexingFeatures.descriptorBindingPartiallyBound                    = VK_FALSE;
+        descriptorIndexingFeatures.descriptorBindingVariableDescriptorCount           = VK_FALSE;
+        descriptorIndexingFeatures.runtimeDescriptorArray                             = VK_TRUE;
     }
-#endif
+
+    // VK_KHR_timeline_semaphore
+    VkPhysicalDeviceTimelineSemaphoreFeatures timelineSemaphoreFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES};
+    if ((GetInstance()->GetApi() >= grfx::API_VK_1_2) || ElementExists(std::string(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME), mExtensions)) {
+        timelineSemaphoreFeatures.timelineSemaphore = VK_TRUE;
+    }
+    descriptorIndexingFeatures.pNext = &timelineSemaphoreFeatures;
+
+    // VK_EXT_host_query_reset
+    VkPhysicalDeviceHostQueryResetFeatures queryResetFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT};
+    if ((GetInstance()->GetApi() >= grfx::API_VK_1_2) || ElementExists(std::string(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME), mExtensions)) {
+        queryResetFeatures.hostQueryReset = VK_TRUE;
+    }
+    timelineSemaphoreFeatures.pNext = &queryResetFeatures;
 
     // Get C strings
     std::vector<const char*> extensions = GetCStrings(mExtensions);
 
     VkDeviceCreateInfo vkci      = {VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
-    vkci.pNext                   = &queryResetFeatures;
+    vkci.pNext                   = &descriptorIndexingFeatures;
     vkci.flags                   = 0;
     vkci.queueCreateInfoCount    = CountU32(queueCreateInfos);
     vkci.pQueueCreateInfos       = DataPtr(queueCreateInfos);


### PR DESCRIPTION
This CL fixes some issues with how Vulkan device extensions were being handled:
- Updated grfx::Api enum values to take concrete values to allow for version checking.
- Add VK_EXT_descriptor_indexing features.
- Updated loading / feature handling for timeline host query reset and timeline semaphores.
- Removed VK_KHR_dynamic_rendering loading since it's not used anywhere. Will add it back when full support for dynamic rendering gets added.