### PR TITLE
Explicitly create RTVs and DSVs in Swapchain

### DIFF
--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -130,11 +130,15 @@ public:
     Result GetColorImage(uint32_t imageIndex, grfx::Image** ppImage) const;
     Result GetDepthImage(uint32_t imageIndex, grfx::Image** ppImage) const;
     Result GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::RenderPass** ppRenderPass) const;
+    Result GetRenderTargetView(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::RenderTargetView** ppView) const;
+    Result GetDepthStencilView(uint32_t imageIndex, grfx::DepthStencilView** ppView) const;
 
     // Convenience functions - returns empty object if index is invalid
     grfx::ImagePtr      GetColorImage(uint32_t imageIndex) const;
     grfx::ImagePtr      GetDepthImage(uint32_t imageIndex) const;
     grfx::RenderPassPtr GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR) const;
+    grfx::RenderTargetViewPtr GetRenderTargetView(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR) const;
+    grfx::DepthStencilViewPtr GetDepthStencilView(uint32_t imageIndex) const;
 
     Result AcquireNextImage(
         uint64_t         timeout,    // Nanoseconds
@@ -178,6 +182,8 @@ protected:
     void   DestroyDepthImages();
     Result CreateRenderPasses();
     void   DestroyRenderPasses();
+    Result CreateRenderTargets();
+    void   DestroyRenderTargets();
 
 private:
     virtual Result AcquireNextImageInternal(
@@ -208,6 +214,9 @@ protected:
     grfx::QueuePtr                   mQueue;
     std::vector<grfx::ImagePtr>      mDepthImages;
     std::vector<grfx::ImagePtr>      mColorImages;
+    std::vector<grfx::RenderTargetViewPtr> mClearRenderTargets;
+    std::vector<grfx::RenderTargetViewPtr> mLoadRenderTargets;
+    std::vector<grfx::DepthStencilViewPtr> mDepthStencilViews;
     std::vector<grfx::RenderPassPtr> mClearRenderPasses;
     std::vector<grfx::RenderPassPtr> mLoadRenderPasses;
 

--- a/src/ppx/grfx/dx12/dx12_swapchain.cpp
+++ b/src/ppx/grfx/dx12/dx12_swapchain.cpp
@@ -410,6 +410,7 @@ Result Swapchain::Resize(uint32_t width, uint32_t height)
 
     // Destroy these to make sure there's no reference before resizing
     DestroyRenderPasses();
+    DestroyRenderTargets();
     DestroyDepthImages();
     DestroyColorImages();
 
@@ -453,6 +454,9 @@ Result Swapchain::Resize(uint32_t width, uint32_t height)
 
     // Create depth images
     CreateDepthImages();
+
+    // Create render targets
+    CreateRenderTargets();
 
     // Create render passes
     CreateRenderPasses();

--- a/src/ppx/grfx/grfx_swapchain.cpp
+++ b/src/ppx/grfx/grfx_swapchain.cpp
@@ -193,6 +193,7 @@ Result Swapchain::CreateRenderTargets()
         grfx::RenderTargetViewCreateInfo rtvCreateInfo = grfx::RenderTargetViewCreateInfo::GuessFromImage(imagePtr);
         rtvCreateInfo.loadOp                           = ppx::grfx::ATTACHMENT_LOAD_OP_CLEAR;
         rtvCreateInfo.ownership                        = grfx::OWNERSHIP_RESTRICTED;
+
         grfx::RenderTargetViewPtr rtv;
         Result                    ppxres = GetDevice()->CreateRenderTargetView(&rtvCreateInfo, &rtv);
         if (Failed(ppxres)) {
@@ -215,6 +216,7 @@ Result Swapchain::CreateRenderTargets()
             dsvCreateInfo.depthLoadOp                      = ppx::grfx::ATTACHMENT_LOAD_OP_CLEAR;
             dsvCreateInfo.stencilLoadOp                    = ppx::grfx::ATTACHMENT_LOAD_OP_CLEAR;
             dsvCreateInfo.ownership                        = ppx::grfx::OWNERSHIP_RESTRICTED;
+
             grfx::DepthStencilViewPtr dsv;
             ppxres = GetDevice()->CreateDepthStencilView(&dsvCreateInfo, &dsv);
             if (Failed(ppxres)) {
@@ -371,7 +373,11 @@ Result Swapchain::GetRenderTargetView(uint32_t imageIndex, grfx::AttachmentLoadO
 
 Result Swapchain::GetDepthStencilView(uint32_t imageIndex, grfx::DepthStencilView** ppView) const
 {
-    return mClearRenderPasses[imageIndex]->GetDepthStencilView(ppView);
+    if (!IsIndexInRange(imageIndex, mDepthStencilViews)) {
+        return ppx::ERROR_OUT_OF_RANGE;
+    }
+    *ppView = mDepthStencilViews[imageIndex];
+    return ppx::SUCCESS;
 }
 
 grfx::ImagePtr Swapchain::GetColorImage(uint32_t imageIndex) const
@@ -404,7 +410,9 @@ grfx::RenderTargetViewPtr Swapchain::GetRenderTargetView(uint32_t imageIndex, gr
 
 grfx::DepthStencilViewPtr Swapchain::GetDepthStencilView(uint32_t imageIndex) const
 {
-    return mClearRenderPasses[imageIndex]->GetDepthStencilView();
+    grfx::DepthStencilViewPtr object;
+    GetDepthStencilView(imageIndex, &object);
+    return object;
 }
 
 Result Swapchain::AcquireNextImage(


### PR DESCRIPTION
Instead of creating them in a RenderPass.
This is in preparation for dynamic rendering where we still need to get RTVs and DSVs but do not need a render pass.