### PR TITLE
Changes to Buffer and Geometry to accommodate faster bulk writes

### DIFF
--- a/include/ppx/geometry.h
+++ b/include/ppx/geometry.h
@@ -59,6 +59,8 @@ struct GeometryOptions
     uint32_t                      vertexBindingCount                      = 0;
     grfx::VertexBinding           vertexBindings[PPX_MAX_VERTEX_BINDINGS] = {};
     grfx::PrimitiveTopology       primtiveTopology                        = grfx::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    uint32_t                      maxIndexCount                           = 0;
+    uint32_t                      maxVertexCount                          = 0;
 
     // Creates a create info objects with a UINT16 or UINT32 index
     // type and position vertex attribute.
@@ -101,6 +103,11 @@ struct GeometryOptions
     GeometryOptions& AddTexCoord(grfx::Format format = grfx::FORMAT_R32G32_FLOAT);
     GeometryOptions& AddTangent(grfx::Format format = grfx::FORMAT_R32G32B32A32_FLOAT);
     GeometryOptions& AddBitangent(grfx::Format format = grfx::FORMAT_R32G32B32_FLOAT);
+
+    // NOTE: Setting max index/vertex counts will set up index/vertex
+    // buffers for "Use #2"
+    GeometryOptions& MaxIndexCount(uint32_t count);
+    GeometryOptions& MaxVertexCount(uint32_t count);
 
 private:
     GeometryOptions& AddAttribute(grfx::VertexSemantic semantic, grfx::Format format);
@@ -146,8 +153,14 @@ public:
     {
     public:
         Buffer() {}
-        Buffer(BufferType type, uint32_t elementSize)
-            : mType(type), mElementSize(elementSize) {}
+        Buffer(BufferType type, uint32_t elementSize, uint32_t knownElementCount = 0)
+            : mType(type), mElementSize(elementSize), mKnownElementCount(knownElementCount)
+        {
+            if (mKnownElementCount > 0) {
+                // Pre-determined final size of buffer
+                mData.resize(mKnownElementCount * mElementSize);
+            }
+        }
         ~Buffer() {}
 
         BufferType  GetType() const { return mType; }
@@ -157,6 +170,11 @@ public:
         char*       GetData() { return DataPtr(mData); }
         const char* GetData() const { return DataPtr(mData); }
         uint32_t    GetElementCount() const;
+        uint32_t    GetSizeOfData() const;
+
+        // Append() will automatically adjust mOffset, but it may need to be
+        // manually adjusted if Overwrite() is used
+        void SetOffset(uint32_t offset) { mOffset = offset; }
 
         // Trusts that calling code is well behaved :)
         //
@@ -165,14 +183,17 @@ public:
         {
             uint32_t sizeOfValue = static_cast<uint32_t>(sizeof(T));
 
-            // Current size
-            size_t offset = mData.size();
-            // Allocate storage for incoming data
-            mData.resize(offset + sizeOfValue);
+            if (mKnownElementCount == 0) {
+                // Allocate storage for incoming data
+                SetSize(mOffset + sizeOfValue);
+            }
+
             // Copy data
             const void* pSrc = &value;
-            void*       pDst = mData.data() + offset;
+            void*       pDst = mData.data() + mOffset;
             memcpy(pDst, pSrc, sizeOfValue);
+
+            mOffset += sizeOfValue;
         }
 
         template <typename T>
@@ -180,20 +201,41 @@ public:
         {
             uint32_t sizeOfValues = count * static_cast<uint32_t>(sizeof(T));
 
-            // Current size
-            size_t offset = mData.size();
-            // Allocate storage for incoming data
-            mData.resize(offset + sizeOfValues);
+            if (mKnownElementCount == 0) {
+                // Allocate storage for incoming data
+                SetSize(mOffset + sizeOfValues);
+            }
+
             // Copy data
             const void* pSrc = pValues;
-            void*       pDst = mData.data() + offset;
+            void*       pDst = mData.data() + mOffset;
             memcpy(pDst, pSrc, sizeOfValues);
+
+            mOffset += sizeOfValues;
+        }
+
+        // If Overwrite is used to write new data, calling code will also
+        // have to SetOffset() appropriately
+        //
+        template <typename T>
+        void Overwrite(const T& value, size_t offset)
+        {
+            uint32_t sizeOfValue = static_cast<uint32_t>(sizeof(T));
+
+            PPX_ASSERT_MSG(offset + sizeOfValue <= GetSize(), "Attempting to overwrite with value of size " << sizeOfValue << " at offset " << offset << " will overflow the buffer of size " << GetSize());
+
+            // Copy data
+            const void* pSrc = &value;
+            void*       pDst = mData.data() + offset;
+            memcpy(pDst, pSrc, sizeOfValue);
         }
 
     private:
-        BufferType        mType        = BUFFER_TYPE_VERTEX;
-        uint32_t          mElementSize = 0;
+        BufferType        mType              = BUFFER_TYPE_VERTEX;
+        uint32_t          mElementSize       = 0;
+        uint32_t          mKnownElementCount = 0;
         std::vector<char> mData;
+        uint32_t          mOffset = 0;
     };
 
     // ---------------------------------------------------------------------------------------------
@@ -249,7 +291,7 @@ public:
     // Append a chunk of UINT32 indices
     void AppendIndicesU32(uint32_t count, const uint32_t* pIndices);
 
-    // Append multiple attributes at once
+    // Append multiple attributes at once, returns the total number of vertices whose data is currently stored
     //
     uint32_t AppendVertexData(const TriMeshVertexData& vtx);
     uint32_t AppendVertexData(const TriMeshVertexDataCompressed& vtx);
@@ -261,6 +303,10 @@ public:
     void AppendTriangle(const TriMeshVertexData& vtx0, const TriMeshVertexData& vtx1, const TriMeshVertexData& vtx2);
     void AppendEdge(const WireMeshVertexData& vtx0, const WireMeshVertexData& vtx1);
 
+    // Directly overwrites index/vertex buffers
+    void SetIndexBuffer(const Geometry::Buffer* indexBuffer) { mIndexBuffer = *indexBuffer; }
+    void SetVertexBuffer(const Geometry::Buffer* vertexBuffer, size_t vertexBufferIndex) { mVertexBuffers[vertexBufferIndex] = *vertexBuffer; }
+
 private:
     // This is intialized to point to a static var of derived class of VertexDataProcessorBase
     // which is shared by geometry objects, it is not supposed to be deleted
@@ -270,7 +316,7 @@ private:
     Geometry::Buffer                                      mIndexBuffer;
     std::vector<Geometry::Buffer>                         mVertexBuffers;
     uint32_t                                              mPositionBufferIndex  = PPX_VALUE_IGNORED;
-    uint32_t                                              mNormaBufferIndex     = PPX_VALUE_IGNORED;
+    uint32_t                                              mNormalBufferIndex    = PPX_VALUE_IGNORED;
     uint32_t                                              mColorBufferIndex     = PPX_VALUE_IGNORED;
     uint32_t                                              mTexCoordBufferIndex  = PPX_VALUE_IGNORED;
     uint32_t                                              mTangentBufferIndex   = PPX_VALUE_IGNORED;

--- a/include/ppx/geometry.h
+++ b/include/ppx/geometry.h
@@ -153,13 +153,10 @@ public:
     {
     public:
         Buffer() {}
-        Buffer(BufferType type, uint32_t elementSize, uint32_t knownElementCount = 0)
-            : mType(type), mElementSize(elementSize), mKnownElementCount(knownElementCount)
+        Buffer(BufferType type, uint32_t elementSize, uint32_t maxElementCount = 0)
+            : mType(type), mElementSize(elementSize), mMaxElementCount(maxElementCount)
         {
-            if (mKnownElementCount > 0) {
-                // Pre-determined final size of buffer
-                mData.resize(mKnownElementCount * mElementSize);
-            }
+            mData.resize(mMaxElementCount * mElementSize);
         }
         ~Buffer() {}
 
@@ -170,7 +167,7 @@ public:
         char*       GetData() { return DataPtr(mData); }
         const char* GetData() const { return DataPtr(mData); }
         uint32_t    GetElementCount() const;
-        uint32_t    GetSizeOfData() const;
+        uint32_t    GetDataSize() const;
 
         // Append() will automatically adjust mOffset, but it may need to be
         // manually adjusted if Overwrite() is used
@@ -183,7 +180,7 @@ public:
         {
             uint32_t sizeOfValue = static_cast<uint32_t>(sizeof(T));
 
-            if (mKnownElementCount == 0) {
+            if (mMaxElementCount == 0) {
                 // Allocate storage for incoming data
                 SetSize(mOffset + sizeOfValue);
             }
@@ -201,7 +198,7 @@ public:
         {
             uint32_t sizeOfValues = count * static_cast<uint32_t>(sizeof(T));
 
-            if (mKnownElementCount == 0) {
+            if (mMaxElementCount == 0) {
                 // Allocate storage for incoming data
                 SetSize(mOffset + sizeOfValues);
             }
@@ -231,11 +228,11 @@ public:
         }
 
     private:
-        BufferType        mType              = BUFFER_TYPE_VERTEX;
-        uint32_t          mElementSize       = 0;
-        uint32_t          mKnownElementCount = 0;
+        BufferType        mType            = BUFFER_TYPE_VERTEX;
+        uint32_t          mElementSize     = 0;
+        uint32_t          mMaxElementCount = 0;
         std::vector<char> mData;
-        uint32_t          mOffset = 0;
+        uint32_t          mOffset = 0; // bytes
     };
 
     // ---------------------------------------------------------------------------------------------

--- a/src/ppx/geometry.cpp
+++ b/src/ppx/geometry.cpp
@@ -61,9 +61,9 @@ protected:
     {
         if (bufferIndex != PPX_VALUE_IGNORED) {
             PPX_ASSERT_MSG((bufferIndex >= 0) && (bufferIndex < pGeom->mVertexBuffers.size()), "buffer index is not valid");
-            uint32_t originalSize = pGeom->mVertexBuffers[bufferIndex].GetSizeOfData();
+            uint32_t originalSize = pGeom->mVertexBuffers[bufferIndex].GetDataSize();
             pGeom->mVertexBuffers[bufferIndex].Append(data);
-            return pGeom->mVertexBuffers[bufferIndex].GetSizeOfData() - originalSize;
+            return pGeom->mVertexBuffers[bufferIndex].GetDataSize() - originalSize;
         }
         return 0;
     }
@@ -619,16 +619,16 @@ GeometryOptions& GeometryOptions::MaxVertexCount(uint32_t count)
 // -------------------------------------------------------------------------------------------------
 uint32_t Geometry::Buffer::GetElementCount() const
 {
-    size_t sizeOfData = GetSizeOfData();
+    size_t sizeOfData = GetDataSize();
     PPX_ASSERT_MSG(sizeOfData % mElementSize == 0, "Buffer contains data of size " << sizeOfData << " which is not a multiple of element size " << mElementSize);
     uint32_t count = sizeOfData / mElementSize;
     return count;
 }
 
-uint32_t Geometry::Buffer::GetSizeOfData() const
+uint32_t Geometry::Buffer::GetDataSize() const
 {
     size_t sizeOfData = mData.size();
-    if (mKnownElementCount > 0) {
+    if (mMaxElementCount > 0) {
         sizeOfData = mOffset;
     }
     return sizeOfData;

--- a/src/ppx/geometry.cpp
+++ b/src/ppx/geometry.cpp
@@ -62,7 +62,7 @@ protected:
         if (bufferIndex != PPX_VALUE_IGNORED) {
             PPX_ASSERT_MSG((bufferIndex >= 0) && (bufferIndex < pGeom->mVertexBuffers.size()), "buffer index is not valid");
             uint32_t originalSize = pGeom->mVertexBuffers[bufferIndex].GetDataSize();
-            pGeom->mVertexBuffers[bufferIndex].Append(data);
+            pGeom->mVertexBuffers[bufferIndex].Write(data);
             return pGeom->mVertexBuffers[bufferIndex].GetDataSize() - originalSize;
         }
         return 0;
@@ -602,13 +602,13 @@ GeometryOptions& GeometryOptions::AddBitangent(grfx::Format format)
     return *this;
 }
 
-GeometryOptions& GeometryOptions::MaxIndexCount(uint32_t count)
+GeometryOptions& GeometryOptions::SetMaxIndexCount(uint32_t count)
 {
     maxIndexCount = count;
     return *this;
 }
 
-GeometryOptions& GeometryOptions::MaxVertexCount(uint32_t count)
+GeometryOptions& GeometryOptions::SetMaxVertexCount(uint32_t count)
 {
     maxVertexCount = count;
     return *this;
@@ -628,7 +628,7 @@ uint32_t Geometry::Buffer::GetElementCount() const
 uint32_t Geometry::Buffer::GetDataSize() const
 {
     size_t sizeOfData = mData.size();
-    if (mMaxElementCount > 0) {
+    if (mFinalSizeSet) {
         sizeOfData = mOffset;
     }
     return sizeOfData;
@@ -1085,36 +1085,36 @@ uint32_t Geometry::GetLargestBufferSize() const
 void Geometry::AppendIndex(uint32_t idx)
 {
     if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT16) {
-        mIndexBuffer.Append(static_cast<uint16_t>(idx));
+        mIndexBuffer.Write(static_cast<uint16_t>(idx));
     }
     else if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT32) {
-        mIndexBuffer.Append(idx);
+        mIndexBuffer.Write(idx);
     }
 }
 
 void Geometry::AppendIndicesTriangle(uint32_t idx0, uint32_t idx1, uint32_t idx2)
 {
     if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT16) {
-        mIndexBuffer.Append(static_cast<uint16_t>(idx0));
-        mIndexBuffer.Append(static_cast<uint16_t>(idx1));
-        mIndexBuffer.Append(static_cast<uint16_t>(idx2));
+        mIndexBuffer.Write(static_cast<uint16_t>(idx0));
+        mIndexBuffer.Write(static_cast<uint16_t>(idx1));
+        mIndexBuffer.Write(static_cast<uint16_t>(idx2));
     }
     else if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT32) {
-        mIndexBuffer.Append(idx0);
-        mIndexBuffer.Append(idx1);
-        mIndexBuffer.Append(idx2);
+        mIndexBuffer.Write(idx0);
+        mIndexBuffer.Write(idx1);
+        mIndexBuffer.Write(idx2);
     }
 }
 
 void Geometry::AppendIndicesEdge(uint32_t idx0, uint32_t idx1)
 {
     if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT16) {
-        mIndexBuffer.Append(static_cast<uint16_t>(idx0));
-        mIndexBuffer.Append(static_cast<uint16_t>(idx1));
+        mIndexBuffer.Write(static_cast<uint16_t>(idx0));
+        mIndexBuffer.Write(static_cast<uint16_t>(idx1));
     }
     else if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT32) {
-        mIndexBuffer.Append(idx0);
-        mIndexBuffer.Append(idx1);
+        mIndexBuffer.Write(idx0);
+        mIndexBuffer.Write(idx1);
     }
 }
 
@@ -1124,7 +1124,7 @@ void Geometry::AppendIndicesU32(uint32_t count, const uint32_t* pIndices)
         PPX_ASSERT_MSG(false, "Invalid geometry index type, trying to append UINT32 data to UINT16 indices");
         return;
     }
-    mIndexBuffer.Append(count, pIndices);
+    mIndexBuffer.Write(count, pIndices);
 }
 
 uint32_t Geometry::AppendVertexData(const TriMeshVertexData& vtx)


### PR DESCRIPTION
Changes:

* Added `maxIndexCount` and `maxVertexCount` to `GeometryOptions` to allow caller to set pre-determined sizes and only do one initial resize of the buffer. Note: This is faster than reserving the space at the beginning and resizing the vector each append.
* Some changes to `Buffer` to accommodate pre-determined sizes and add functionality for overwriting data within the buffer.
* Fixed typo for `mNormalBufferIndex`

Changes for Buffer element count logic:
* Added `GetSizeOfData()` to report the size of data that has been written, useful for when partial elements have been written
* Changed `GetElementCount()` logic, should only be called when buffer contains an integer number of elements.
* Changed `AppendDataToVertexBuffer()` to call `GetSizeOfData()` instead of `GetElementCount()` since it is called to write partial elements.
