### PR TITLE
app: fix scoped timer usage

### DIFF
--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1339,7 +1339,7 @@ int Application::Run(int argc, char** argv)
 
     // Call setup
     {
-        ScopedTimer("Setup() finished");
+        ScopedTimer timer("Setup() finished");
         DispatchSetup();
     }
 


### PR DESCRIPTION
This scoped timer usage was invalid. Not giving a variable name means this get destroyed in the same statement it's created, not at the end of the scope.