### PR TITLE
geometry: change resize policy to be double

### DIFF
--- a/include/ppx/geometry.h
+++ b/include/ppx/geometry.h
@@ -157,6 +157,15 @@ public:
         const char* GetData() const { return DataPtr(mData); }
         uint32_t    GetElementCount() const;
 
+        // Changes the buffer size to `size`.
+        // If this operations grows the vector, this class considers all the elements
+        // to be initialized. It is the caller responsibility to initialize those elements.
+        void SetSize(uint32_t size)
+        {
+            mUsedSize = size;
+            mData.resize(size);
+        }
+
         // Trusts that calling code is well behaved :)
         template <typename T>
         void Append(const T& value)

--- a/include/ppx/geometry.h
+++ b/include/ppx/geometry.h
@@ -159,23 +159,19 @@ public:
 
         // Trusts that calling code is well behaved :)
         template <typename T>
-        inline void Append(const T& value)
+        void Append(const T& value)
         {
             Append(1, &value);
         }
 
         template <typename T>
-        inline void Append(uint32_t count, const T* pValues)
+        void Append(uint32_t count, const T* pValues)
         {
             uint32_t sizeOfValues = count * static_cast<uint32_t>(sizeof(T));
-            if (mUsedSize + sizeOfValues > mData.size()) {
+            if ((mUsedSize + sizeOfValues) > mData.size()) {
                 mData.resize(std::max<size_t>(mUsedSize + sizeOfValues, mData.size() * 2));
             }
 
-            //// Current size
-            // size_t offset = mData.size();
-            //// Allocate storage for incoming data
-            // mData.resize(offset + sizeOfValues);
             //  Copy data
             const void* pSrc = pValues;
             void*       pDst = mData.data() + mUsedSize;

--- a/include/ppx/geometry.h
+++ b/include/ppx/geometry.h
@@ -152,47 +152,41 @@ public:
 
         BufferType  GetType() const { return mType; }
         uint32_t    GetElementSize() const { return mElementSize; }
-        uint32_t    GetSize() const { return CountU32(mData); }
-        void        SetSize(uint32_t size) { mData.resize(size); }
+        uint32_t    GetSize() const { return static_cast<uint32_t>(mUsedSize); }
         char*       GetData() { return DataPtr(mData); }
         const char* GetData() const { return DataPtr(mData); }
         uint32_t    GetElementCount() const;
 
         // Trusts that calling code is well behaved :)
-        //
         template <typename T>
-        void Append(const T& value)
+        inline void Append(const T& value)
         {
-            uint32_t sizeOfValue = static_cast<uint32_t>(sizeof(T));
-
-            // Current size
-            size_t offset = mData.size();
-            // Allocate storage for incoming data
-            mData.resize(offset + sizeOfValue);
-            // Copy data
-            const void* pSrc = &value;
-            void*       pDst = mData.data() + offset;
-            memcpy(pDst, pSrc, sizeOfValue);
+            Append(1, &value);
         }
 
         template <typename T>
-        void Append(uint32_t count, const T* pValues)
+        inline void Append(uint32_t count, const T* pValues)
         {
             uint32_t sizeOfValues = count * static_cast<uint32_t>(sizeof(T));
+            if (mUsedSize + sizeOfValues > mData.size()) {
+                mData.resize(std::max<size_t>(mUsedSize + sizeOfValues, mData.size() * 2));
+            }
 
-            // Current size
-            size_t offset = mData.size();
-            // Allocate storage for incoming data
-            mData.resize(offset + sizeOfValues);
-            // Copy data
+            //// Current size
+            // size_t offset = mData.size();
+            //// Allocate storage for incoming data
+            // mData.resize(offset + sizeOfValues);
+            //  Copy data
             const void* pSrc = pValues;
-            void*       pDst = mData.data() + offset;
+            void*       pDst = mData.data() + mUsedSize;
             memcpy(pDst, pSrc, sizeOfValues);
+            mUsedSize += sizeOfValues;
         }
 
     private:
         BufferType        mType        = BUFFER_TYPE_VERTEX;
         uint32_t          mElementSize = 0;
+        size_t            mUsedSize    = 0;
         std::vector<char> mData;
     };
 

--- a/src/ppx/geometry.cpp
+++ b/src/ppx/geometry.cpp
@@ -619,7 +619,7 @@ GeometryOptions& GeometryOptions::AddBitangent(grfx::Format format)
 // -------------------------------------------------------------------------------------------------
 uint32_t Geometry::Buffer::GetElementCount() const
 {
-    size_t sizeOfData = mData.size();
+    size_t sizeOfData = mUsedSize;
     // round up for the case of interleaved buffers
     uint32_t count = static_cast<uint32_t>(std::ceil(static_cast<double>(sizeOfData) / static_cast<double>(mElementSize)));
     return count;


### PR DESCRIPTION
The initial resize policy for the buffer was "minimalist". Only resized to match the added element.

Changed this policy to be "double the size". Every time we reach the size limit, the underlying container size is doubled.

This reduces the benchmark loading time from 30s to 15s in debug. (367M resize calls to 725).