### PR TITLE
Use vulkan descriptor arrays instead of flattening them

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - name: Setup necessary packages
         run: |
+          sudo add-apt-repository ppa:kisak/kisak-mesa -y
           sudo apt update && sudo apt install libxrandr-dev libxinerama-dev libx11-dev libxcursor-dev libxi-dev libx11-xcb-dev clang \
           mesa-vulkan-drivers
       - name: Setup Vulkan SDK

--- a/cmake/ShaderCompile.cmake
+++ b/cmake/ShaderCompile.cmake
@@ -111,7 +111,7 @@ function(internal_generate_rules_for_shader TARGET_NAME)
             SHADER_STAGE "${ARG_SHADER_STAGE}"
             OUTPUT_FORMAT "SPV_6_6"
             TARGET_FOLDER "${TARGET_NAME}"
-            COMPILER_FLAGS "-spirv" "-fspv-flatten-resource-arrays" "-fspv-target-env=vulkan1.1" "-fvk-use-dx-layout" "-DPPX_VULKAN=1" "-T" "${ARG_SHADER_STAGE}_6_6" "-E" "${ARG_SHADER_STAGE}main")
+            COMPILER_FLAGS "-spirv" "-fspv-target-env=vulkan1.1" "-fvk-use-dx-layout" "-DPPX_VULKAN=1" "-T" "${ARG_SHADER_STAGE}_6_6" "-E" "${ARG_SHADER_STAGE}main")
         add_dependencies("vk_${TARGET_NAME}" "vk_${TARGET_NAME}_${ARG_SHADER_STAGE}")
     endif ()
 endfunction()

--- a/src/ppx/grfx/grfx_descriptor.cpp
+++ b/src/ppx/grfx/grfx_descriptor.cpp
@@ -108,7 +108,10 @@ Result DescriptorSet::UpdateUniformBuffer(
 Result DescriptorSetLayout::Create(const grfx::DescriptorSetLayoutCreateInfo* pCreateInfo)
 {
     // Bail if there's any binding overlaps - overlaps are not permitted to
-    // make D3D12 and Vulkan agreeable.
+    // make D3D12 and Vulkan agreeable. Even though we use descriptor arrays
+    // in Vulkan, we do not allow the subsequent bindings to be occupied,
+    // to keep descriptor binding register occupancy consistent between
+    // Vulkan and D3D12.
     //
     std::vector<ppx::RangeU32> ranges;
     const size_t               bindingCount = pCreateInfo->bindings.size();

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -208,6 +208,38 @@ Result Device::ConfigureFeatures(const grfx::DeviceCreateInfo* pCreateInfo, VkPh
         features                                  = *pFeatures;
     }
 
+    // Enable shader resource array dynamic indexing.
+    // This can be used to choose a texture within an array based on
+    // a push constant, among other things.
+    std::vector<std::string_view> missingFeatures;
+    if (!foundFeatures.shaderUniformBufferArrayDynamicIndexing) {
+        missingFeatures.push_back("shaderUniformBufferArrayDynamicIndexing");
+    }
+    if (!foundFeatures.shaderSampledImageArrayDynamicIndexing) {
+        missingFeatures.push_back("shaderSampledImageArrayDynamicIndexing");
+    }
+    if (!foundFeatures.shaderStorageBufferArrayDynamicIndexing) {
+        missingFeatures.push_back("shaderStorageBufferArrayDynamicIndexing");
+    }
+    if (!foundFeatures.shaderStorageImageArrayDynamicIndexing) {
+        missingFeatures.push_back("shaderStorageImageArrayDynamicIndexing");
+    }
+
+    if (!missingFeatures.empty()) {
+        std::stringstream ss;
+        ss << "Device does not support required features:" << PPX_LOG_ENDL;
+        for (const auto& elem : missingFeatures) {
+            ss << " " << elem << PPX_LOG_ENDL;
+        }
+        PPX_ASSERT_MSG(false, ss.str());
+        return ppx::ERROR_REQUIRED_FEATURE_UNAVAILABLE;
+    }
+
+    features.shaderUniformBufferArrayDynamicIndexing = VK_TRUE;
+    features.shaderSampledImageArrayDynamicIndexing  = VK_TRUE;
+    features.shaderStorageBufferArrayDynamicIndexing = VK_TRUE;
+    features.shaderStorageImageArrayDynamicIndexing  = VK_TRUE;
+
     return ppx::SUCCESS;
 }
 
@@ -389,7 +421,7 @@ Result Device::CreateApiObjects(const grfx::DeviceCreateInfo* pCreateInfo)
     if (vkres != VK_SUCCESS) {
         // clang-format off
         std::stringstream ss;
-        ss << "vkCreateInstance failed: " << ToString(vkres);
+        ss << "vkCreateDevice failed: " << ToString(vkres);
         if (vkres == VK_ERROR_EXTENSION_NOT_PRESENT) {
             std::vector<std::string> missing = GetNotFound(mExtensions, mFoundExtensions);
             ss << PPX_LOG_ENDL;


### PR DESCRIPTION
In order to fully support resource arrays, also require and enable shader*ArrayDynamicIndexing device features.
This allows one to use push constants to select texture within an array of textures like in 24_push_constants

Does not add support for using push descriptors with arrays.

Dynamic indexing features are not required for just using shader resource arrays with constant indices.
Currently, from what I can tell, only 24_push_constants requires enabling shaderSampledImageArrayDynamicIndexing and there are some small number of gpus that don't support those features (software lavapipe).

We could handle this in a few different ways:
1) Enable dynamic indexing features across the board, fail on the devices that don't support them. This would mean that BigWheels won't run on some devices (lavapipe)
2) Let applications make sure the used features are supported, and provide a way for applications to enable those device features. 
3) Only flatten resource arrays on devices that support dynamic indexing features. This would require compiling/loading shaders conditionally, and might get messy. 