### PR TITLE
More efficient SampleIBLTexture()

### DIFF
--- a/assets/common/shaders/ppx/Math.hlsli
+++ b/assets/common/shaders/ppx/Math.hlsli
@@ -16,8 +16,8 @@
 #define MATH_HLSLI
 
 #define EPSILON 0.00001
-#define PI      3.1415292
-#define INV_PI  (1.0 / 3.1415292)
+#define PI      3.1415926
+#define INV_PI  (1.0 / 3.1415926)
 
 // circular atan2 - converts (x,y) on a unit circle to [0, 2pi]
 //

--- a/assets/common/shaders/ppx/Math.hlsli
+++ b/assets/common/shaders/ppx/Math.hlsli
@@ -17,6 +17,7 @@
 
 #define EPSILON 0.00001
 #define PI      3.1415292
+#define INV_PI  (1.0 / 3.1415292)
 
 // circular atan2 - converts (x,y) on a unit circle to [0, 2pi]
 //
@@ -70,6 +71,17 @@ float2 CartesianToSpherical(float3 pos)
     float theta = catan2(pos.z, pos.x);
     float phi   = acos(pos.y);
     return float2(theta, phi);
+}
+
+//
+// https://github.com/Autodesk/Aurora/ (APL2 License)
+//
+float2 DirectionToLatLongUV(float3 dir)
+{
+    float2 uv;
+    uv.x = atan2(dir.x, -dir.z) * INV_PI * 0.5 + 0.75;
+    uv.y = -asin(dir.y) * INV_PI + 0.5;
+    return uv;
 }
 
 //

--- a/assets/common/shaders/ppx/PBR.hlsli
+++ b/assets/common/shaders/ppx/PBR.hlsli
@@ -50,9 +50,7 @@ float3 SampleIBLTexture(
     float3       dir,
     float        lod)
 {
-    float2 uv = CartesianToSpherical(normalize(dir));
-    uv.x = saturate(uv.x / (2.0 * PI));
-    uv.y = saturate(uv.y / PI);
+    float2 uv = DirectionToLatLongUV(normalize(dir));
     float3 color = iblTexture.SampleLevel(iblSampler, uv, lod).rgb;
     return color;
 }


### PR DESCRIPTION
- Replaced CartesianToSpherical with obstensibly more efficient DirectionToLatLongUV