### PR TITLE
Set up the Benchmark app for Android

### DIFF
--- a/benchmarks/graphics_pipeline/build.gradle
+++ b/benchmarks/graphics_pipeline/build.gradle
@@ -1,0 +1,6 @@
+ArrayList projectAssets = [
+    "benchmarks/shaders/spv",
+    "basic/models",
+]
+
+project.assets = projectAssets

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,3 +31,10 @@ file('projects').eachDir { sub ->
         project(":$sub.name").projectDir = new File("projects/$sub.name")
     }
 }
+
+file('benchmarks').eachDir { sub ->
+    if (file("benchmarks/$sub.name/build.gradle").exists()) {
+        include ":$sub.name"
+        project(":$sub.name").projectDir = new File("benchmarks/$sub.name")
+    }
+}


### PR DESCRIPTION
- Even though the benchmark app does not run on Android devices that don't support the `push_descriptor` extension, this is the first step.