### PR TITLE
Some changes for graphics_pipeline fullscreen quads, and Render()

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -599,7 +599,7 @@ void GraphicsBenchmarkApp::Render()
         // Write start timestamp
         frame.cmd->WriteTimestamp(frame.timestampQuery, grfx::PIPELINE_STAGE_TOP_OF_PIPE_BIT, /* queryIndex = */ 0);
 
-        // Note: Transitions image layout PRESENT->RENDER
+        // Note: Transitions image layout PRESENT->RENDER before this first renderpass
         RenderScene(swapchain, frame, imageIndex);
 
         RenderFullscreenQuads(swapchain, frame, imageIndex);
@@ -607,7 +607,7 @@ void GraphicsBenchmarkApp::Render()
         // Write end timestamp
         frame.cmd->WriteTimestamp(frame.timestampQuery, grfx::PIPELINE_STAGE_TOP_OF_PIPE_BIT, /* queryIndex = */ 1);
 
-        // Note: Transitions image layout RENDER->PRESENT
+        // Note: Transitions image layout RENDER->PRESENT after this last renderpass
         RenderGUI(swapchain, frame, imageIndex);
 
         // Resolve queries
@@ -765,7 +765,7 @@ void GraphicsBenchmarkApp::RenderFullscreenQuads(grfx::SwapchainPtr swapchain, P
                 uint32_t noiseQuadRandomSeed = (uint32_t)i;
                 frame.cmd->PushGraphicsConstants(mFullscreenQuads.pipelineInterface, 1, &noiseQuadRandomSeed);
             }
-            frame.cmd->Draw(4, 1, 0, 0);
+            frame.cmd->Draw(3, 1, 0, 0);
 
             if (!singleRenderpass) {
                 frame.cmd->EndRenderPass();

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -232,10 +232,14 @@ private:
     void UpdateGUI();
     void DrawExtraInfo();
 
-    // Render to swapchain image
-    void RenderScene(grfx::SwapchainPtr swapchain, PerFrame& frame, uint32_t imageIndex);
-    void RenderFullscreenQuads(grfx::SwapchainPtr swapchain, PerFrame& frame, uint32_t imageIndex);
-    void RenderGUI(grfx::SwapchainPtr swapchain, PerFrame& frame, uint32_t imageIndex);
+    // Record this frame's command buffer with multiple renderpasses
+    void RecordCommandBuffer(PerFrame& frame, grfx::SwapchainPtr swapchain, uint32_t imageIndex);
+
+    // Records commands to render * in this frame's command buffer, with the current renderpass
+    void RecordCommandBufferSkybox(PerFrame& frame);
+    void RecordCommandBufferSpheres(PerFrame& frame);
+    void RecordCommandBufferFullscreenQuad(PerFrame& frame, size_t seed);
+    void RecordCommandBufferGUI(PerFrame& frame);
 
     // =====================================================================
     // UTILITY

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -247,9 +247,6 @@ private:
 
     // Loads shader at shaderBaseDir/fileName and creates it at ppShaderModule
     void SetupShader(const std::filesystem::path& fileName, grfx::ShaderModule** ppShaderModule);
-
-    // Fetch current renderpass
-    grfx::RenderPassPtr GetRenderpass(grfx::SwapchainPtr swapchain, uint32_t imageIndex);
 };
 
 #endif // BENCHMARKS_GRAPHICS_PIPELINE_GRAPHICS_BENCHMARK_APP_H

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -190,6 +190,7 @@ private:
     std::shared_ptr<KnobSlider<int>>           pDrawCallCount;
     std::shared_ptr<KnobSlider<int>>           pFullscreenQuadsCount;
     std::shared_ptr<KnobDropdown<std::string>> pFullscreenQuadsColor;
+    std::shared_ptr<KnobCheckbox>              pFullscreenQuadsSingleRenderpass;
     std::shared_ptr<KnobCheckbox>              pAlphaBlend;
     std::shared_ptr<KnobCheckbox>              pDepthTestWrite;
 
@@ -231,12 +232,20 @@ private:
     void UpdateGUI();
     void DrawExtraInfo();
 
+    // Render to swapchain image
+    void RenderScene(grfx::SwapchainPtr swapchain, PerFrame& frame, uint32_t imageIndex);
+    void RenderFullscreenQuads(grfx::SwapchainPtr swapchain, PerFrame& frame, uint32_t imageIndex);
+    void RenderGUI(grfx::SwapchainPtr swapchain, PerFrame& frame, uint32_t imageIndex);
+
     // =====================================================================
     // UTILITY
     // =====================================================================
 
     // Loads shader at shaderBaseDir/fileName and creates it at ppShaderModule
     void SetupShader(const std::filesystem::path& fileName, grfx::ShaderModule** ppShaderModule);
+
+    // Fetch current renderpass
+    grfx::RenderPassPtr GetRenderpass(grfx::SwapchainPtr swapchain, uint32_t imageIndex);
 };
 
 #endif // BENCHMARKS_GRAPHICS_PIPELINE_GRAPHICS_BENCHMARK_APP_H


### PR DESCRIPTION
Fullscreen quads
* Adding knob for toggling if they are rendered on a single renderpass or on separate ones
* Changing the vertex data to create one large triangle instead of two smaller ones, to avoid different behaviour for the shading of pixels on the diagonal

`Render()`
* Some refactoring of the following logic for clarity:
  * Command buffer recording  