### PR TITLE
Remove use of push descriptor extension from graphics_pipeline benchmark

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -159,9 +159,9 @@ void GraphicsBenchmarkApp::Setup()
     // Descriptor Pool
     {
         grfx::DescriptorPoolCreateInfo createInfo = {};
-        createInfo.sampler                        = 4; // per frame in flight: 1 for skybox, 3 for spheres
-        createInfo.sampledImage                   = 5; // per frame in flight: 1 for skybox, 3 for spheres, 1 for quads
-        createInfo.uniformBuffer                  = 2; // per frame in flight: 1 for skybox, 1 for spheres
+        createInfo.sampler                        = 4 * GetNumFramesInFlight(); // 1 for skybox, 3 for spheres
+        createInfo.sampledImage                   = 5 * GetNumFramesInFlight(); // 1 for skybox, 3 for spheres, 1 for quads
+        createInfo.uniformBuffer                  = 2 * GetNumFramesInFlight(); // 1 for skybox, 1 for spheres
 
         PPX_CHECKED_CALL(GetDevice()->CreateDescriptorPool(&createInfo, &mDescriptorPool));
     }

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -112,6 +112,7 @@ void GraphicsBenchmarkApp::Config(ppx::ApplicationSettings& settings)
     settings.window.height              = 1080;
     settings.grfx.api                   = kApi;
     settings.grfx.enableDebug           = false;
+    settings.grfx.numFramesInFlight     = 1;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
 #if defined(PPX_BUILD_XR)
     // XR specific settings
@@ -158,9 +159,9 @@ void GraphicsBenchmarkApp::Setup()
     // Descriptor Pool
     {
         grfx::DescriptorPoolCreateInfo createInfo = {};
-        createInfo.sampler                        = 10; // per frame in flight: 1 for skybox, 3 for spheres
-        createInfo.sampledImage                   = 10; // per frame in flight: 1 for skybox, 3 for spheres, 1 for quads
-        createInfo.uniformBuffer                  = 10; // per frame in flight: 1 for skybox, 1 for spheres
+        createInfo.sampler                        = 4; // per frame in flight: 1 for skybox, 3 for spheres
+        createInfo.sampledImage                   = 5; // per frame in flight: 1 for skybox, 3 for spheres, 1 for quads
+        createInfo.uniformBuffer                  = 2; // per frame in flight: 1 for skybox, 1 for spheres
 
         PPX_CHECKED_CALL(GetDevice()->CreateDescriptorPool(&createInfo, &mDescriptorPool));
     }

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -36,6 +36,20 @@ static constexpr uint32_t kMaxSphereInstanceCount  = 3000;
 static constexpr uint32_t kSeed                    = 89977;
 static constexpr uint32_t kMaxFullscreenQuadsCount = 1000;
 
+static constexpr size_t SKYBOX_UNIFORM_BUFFER_REGISTER = 0;
+static constexpr size_t SKYBOX_SAMPLED_IMAGE_REGISTER  = 1;
+static constexpr size_t SKYBOX_SAMPLER_REGISTER        = 2;
+
+static constexpr size_t SPHERE_UNIFORM_BUFFER_REGISTER                = 0;
+static constexpr size_t SPHERE_ALBEDO_SAMPLED_IMAGE_REGISTER          = 1;
+static constexpr size_t SPHERE_ALBEDO_SAMPLER_REGISTER                = 2;
+static constexpr size_t SPHERE_NORMAL_SAMPLED_IMAGE_REGISTER          = 3;
+static constexpr size_t SPHERE_NORMAL_SAMPLER_REGISTER                = 4;
+static constexpr size_t SPHERE_METAL_ROUGHNESS_SAMPLED_IMAGE_REGISTER = 5;
+static constexpr size_t SPHERE_METAL_ROUGHNESS_SAMPLER_REGISTER       = 6;
+
+static constexpr size_t QUADS_SAMPLED_IMAGE_REGISTER = 0;
+
 static constexpr const char* kShaderBaseDir = "benchmarks/shaders";
 
 static constexpr std::array<const char*, 2> kAvailableVsShaders = {
@@ -110,7 +124,7 @@ public:
     virtual void Render() override;
 
 private:
-    struct SkyboxData
+    struct SkyBoxData
     {
         float4x4 MVP;
     };
@@ -147,18 +161,20 @@ private:
 
     struct Entity
     {
-        grfx::MeshPtr                mesh;
-        grfx::BufferPtr              uniformBuffer;
-        grfx::DescriptorSetLayoutPtr descriptorSetLayout;
-        grfx::PipelineInterfacePtr   pipelineInterface;
-        grfx::GraphicsPipelinePtr    pipeline;
+        grfx::MeshPtr                       mesh;
+        grfx::BufferPtr                     uniformBuffer;
+        grfx::DescriptorSetLayoutPtr        descriptorSetLayout;
+        grfx::PipelineInterfacePtr          pipelineInterface;
+        grfx::GraphicsPipelinePtr           pipeline;
+        std::vector<grfx::DescriptorSetPtr> descriptorSets;
     };
 
     struct Entity2D
     {
-        grfx::BufferPtr              vertexBuffer;
-        grfx::VertexBinding          vertexBinding;
-        grfx::DescriptorSetLayoutPtr descriptorSetLayout;
+        grfx::BufferPtr                     vertexBuffer;
+        grfx::VertexBinding                 vertexBinding;
+        grfx::DescriptorSetLayoutPtr        descriptorSetLayout;
+        std::vector<grfx::DescriptorSetPtr> descriptorSets;
     };
 
     struct LOD
@@ -176,11 +192,12 @@ private:
     bool                              mEnableMouseMovement = true;
     uint64_t                          mGpuWorkDuration;
     grfx::SamplerPtr                  mLinearSampler;
+    grfx::DescriptorPoolPtr           mDescriptorPool;
 
-    // Skybox resources
+    // SkyBox resources
     Entity                mSkyBox;
-    grfx::ShaderModulePtr mVSSkybox;
-    grfx::ShaderModulePtr mPSSkybox;
+    grfx::ShaderModulePtr mVSSkyBox;
+    grfx::ShaderModulePtr mPSSkyBox;
     grfx::TexturePtr      mSkyBoxTexture;
 
     // Spheres resources
@@ -191,7 +208,6 @@ private:
     grfx::TexturePtr                                              mNormalMapTexture;
     grfx::TexturePtr                                              mMetalRoughnessTexture;
     grfx::TexturePtr                                              mWhitePixelTexture;
-    std::vector<grfx::BufferPtr>                                  mDrawCallUniformBuffers;
     std::array<grfx::GraphicsPipelinePtr, kPipelineCount>         mPipelines;
     std::array<grfx::MeshPtr, kMeshCount>                         mSphereMeshes;
     std::vector<LOD>                                              mSphereLODs;
@@ -233,21 +249,27 @@ private:
     // - Uniform buffers
     // - Descriptor set layouts
     // - Shaders
-    void SetupSkyboxResources();
+    void SetupSkyBoxResources();
     void SetupSphereResources();
     void SetupFullscreenQuadsResources();
 
     // Setup vertex data:
     // - Geometries (or raw vertices & bindings), meshes
-    void SetupSkyboxMeshes();
+    void SetupSkyBoxMeshes();
     void SetupSphereMeshes();
     void SetupFullscreenQuadsMeshes();
 
     // Setup pipelines:
     // Note: Pipeline creation can be re-triggered within rendering loop
-    void SetupSkyboxPipelines();
+    void SetupSkyBoxPipelines();
     void SetupSpheresPipelines();
     void SetupFullscreenQuadsPipelines();
+
+    // Update descriptors
+    // Note: Descriptors can be updated within rendering loop
+    void UpdateSkyBoxDescriptors();
+    void UpdateSphereDescriptors();
+    void UpdateFullscreenQuadsDescriptors();
 
     // =====================================================================
     // RENDERING LOOP (Called every frame)
@@ -266,7 +288,7 @@ private:
     void RecordCommandBuffer(PerFrame& frame, grfx::SwapchainPtr swapchain, uint32_t imageIndex);
 
     // Records commands to render * in this frame's command buffer, with the current renderpass
-    void RecordCommandBufferSkybox(PerFrame& frame);
+    void RecordCommandBufferSkyBox(PerFrame& frame);
     void RecordCommandBufferSpheres(PerFrame& frame);
     void RecordCommandBufferFullscreenQuad(PerFrame& frame, size_t seed);
 

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -36,20 +36,6 @@ static constexpr uint32_t kMaxSphereInstanceCount  = 3000;
 static constexpr uint32_t kSeed                    = 89977;
 static constexpr uint32_t kMaxFullscreenQuadsCount = 1000;
 
-static constexpr size_t SKYBOX_UNIFORM_BUFFER_REGISTER = 0;
-static constexpr size_t SKYBOX_SAMPLED_IMAGE_REGISTER  = 1;
-static constexpr size_t SKYBOX_SAMPLER_REGISTER        = 2;
-
-static constexpr size_t SPHERE_UNIFORM_BUFFER_REGISTER                = 0;
-static constexpr size_t SPHERE_ALBEDO_SAMPLED_IMAGE_REGISTER          = 1;
-static constexpr size_t SPHERE_ALBEDO_SAMPLER_REGISTER                = 2;
-static constexpr size_t SPHERE_NORMAL_SAMPLED_IMAGE_REGISTER          = 3;
-static constexpr size_t SPHERE_NORMAL_SAMPLER_REGISTER                = 4;
-static constexpr size_t SPHERE_METAL_ROUGHNESS_SAMPLED_IMAGE_REGISTER = 5;
-static constexpr size_t SPHERE_METAL_ROUGHNESS_SAMPLER_REGISTER       = 6;
-
-static constexpr size_t QUADS_SAMPLED_IMAGE_REGISTER = 0;
-
 static constexpr const char* kShaderBaseDir = "benchmarks/shaders";
 
 static constexpr std::array<const char*, 2> kAvailableVsShaders = {

--- a/include/ppx/grfx/grfx_command.h
+++ b/include/ppx/grfx/grfx_command.h
@@ -30,7 +30,7 @@
 // We're going to favor the second case - command buffers do not
 // have affinity for tasks. This means that for D3D12 we'll copy
 // descriptors from the set's CPU heaps to the command buffer's
-// GPU visible heaps when the indGraphicsDescriptorSets or
+// GPU visible heaps when the BindGraphicsDescriptorSets or
 // BindComputeDescriptorSets is called. This may not be the most
 // efficient way to do this but it does give us the flexiblity
 // to shape D3D12 to look like Vulkan.

--- a/include/ppx/grfx/grfx_descriptor.h
+++ b/include/ppx/grfx/grfx_descriptor.h
@@ -98,7 +98,7 @@ public:
 
 namespace internal {
 
-//! @struct DescriptorPoolCreateInfo
+//! @struct DescriptorSetCreateInfo
 //!
 //!
 struct DescriptorSetCreateInfo

--- a/src/ppx/grfx/vk/vk_descriptor.cpp
+++ b/src/ppx/grfx/vk/vk_descriptor.cpp
@@ -37,7 +37,7 @@ Result DescriptorPool::CreateApiObjects(const grfx::DescriptorPoolCreateInfo* pC
     if (pCreateInfo->uniformTexelBuffer   > 0) poolSizes.push_back({VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER  , pCreateInfo->uniformTexelBuffer  });
     if (pCreateInfo->storageTexelBuffer   > 0) poolSizes.push_back({VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER  , pCreateInfo->storageTexelBuffer  });
     if (pCreateInfo->uniformBuffer        > 0) poolSizes.push_back({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER        , pCreateInfo->uniformBuffer       });
-    if (pCreateInfo->rawStorageBuffer        > 0) poolSizes.push_back({VK_DESCRIPTOR_TYPE_STORAGE_BUFFER        , pCreateInfo->rawStorageBuffer       });
+    if (pCreateInfo->rawStorageBuffer     > 0) poolSizes.push_back({VK_DESCRIPTOR_TYPE_STORAGE_BUFFER        , pCreateInfo->rawStorageBuffer    });
     if (pCreateInfo->uniformBufferDynamic > 0) poolSizes.push_back({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, pCreateInfo->uniformBufferDynamic});
     if (pCreateInfo->storageBufferDynamic > 0) poolSizes.push_back({VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, pCreateInfo->storageBufferDynamic});
     if (pCreateInfo->inputAttachment      > 0) poolSizes.push_back({VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT      , pCreateInfo->inputAttachment     });


### PR DESCRIPTION
* Replace push descriptors with traditional descriptors
* Rename variables with `Skybox` -> `SkyBox` for consistency
* Some comment/spacing corrections for bigwheels (not functional)
* Minor adjustments to knob appearance in UI (indent, ordering)