### PR TITLE
Experimental: Prototyping a few changes to XR handling

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -107,6 +107,7 @@ public:
     virtual void MouseMove(int32_t x, int32_t y, int32_t dx, int32_t dy, uint32_t buttons) override;
     virtual void KeyDown(ppx::KeyCode key) override;
     virtual void KeyUp(ppx::KeyCode key) override;
+    virtual void DispatchRender() override;
     virtual void Render() override;
 
 private:
@@ -207,6 +208,8 @@ private:
     std::array<grfx::GraphicsPipelinePtr, kFullscreenQuadsTypes.size()>  mQuadsPipelines;
     std::array<grfx::PipelineInterfacePtr, kFullscreenQuadsTypes.size()> mQuadsPipelineInterfaces;
     std::array<grfx::ShaderModulePtr, kFullscreenQuadsTypes.size()>      mQuadsPs;
+
+    uint32_t mViewIndex;
 
 private:
     std::shared_ptr<KnobDropdown<std::string>> pKnobVs;

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -565,7 +565,6 @@ private:
     KnobManager                     mKnobManager;
 
     uint64_t          mFrameCount        = 0;
-    uint32_t          mSwapchainIndex    = 0;
     float             mAverageFPS        = 0;
     float             mFrameStartTime    = 0;
     float             mFrameEndTime      = 0;

--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -146,6 +146,8 @@ public:
         grfx::Fence*     pFence,     // Wait fence
         uint32_t*        pImageIndex);
 
+    Result Wait(uint32_t imageIndex);
+
     Result Present(
         uint32_t                      imageIndex,
         uint32_t                      waitSemaphoreCount,

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -166,16 +166,14 @@ public:
     XrInstance GetInstance() const { return mInstance; }
     XrSystemId GetSystemId() const { return mSystemId; }
     XrSession  GetSession() const { return mSession; }
-    void       SetCurrentViewIndex(uint32_t index) { mCurrentViewIndex = index; }
-    uint32_t   GetCurrentViewIndex() const { return mCurrentViewIndex; }
 
     // Computes the projection matrix for the current view given the near and
     // far frustum planes. The values for the frustum planes will be sent to
     // the OpenXR runtime as part of the frame depth info submission, and the
     // caller must ensure that the values do not change within a frame.
-    glm::mat4 GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(float nearZ, float farZ);
-    glm::mat4 GetViewMatrixForCurrentView() const;
-    XrPosef   GetPoseForCurrentView() const;
+    glm::mat4 GetProjectionMatrixForViewAndSetFrustumPlanes(uint32_t viewIndex, float nearZ, float farZ);
+    glm::mat4 GetViewMatrixForView(uint32_t viewIndex) const;
+    XrPosef   GetPoseForView(uint32_t viewIndex) const;
 
     bool IsSessionRunning() const { return mIsSessionRunning; }
     bool ShouldRender() const { return mShouldRender; }
@@ -214,7 +212,6 @@ private:
     std::vector<XrViewConfigurationView> mConfigViews;
     std::vector<XrView>                  mViews;
     std::vector<XrEnvironmentBlendMode>  mBlendModes;
-    uint32_t                             mCurrentViewIndex = 0;
 
     std::unordered_map<LayerRef, std::unique_ptr<XrLayerBase>> mLayers;
     LayerRef                                                   mNextLayerRef = 0;

--- a/projects/04_cube_xr/CubeXr.cpp
+++ b/projects/04_cube_xr/CubeXr.cpp
@@ -31,12 +31,20 @@ void CubeXrApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
     settings.grfx.enableDebug           = false;
     settings.grfx.pacedFrameRate        = 0;
+#if defined(PPX_BUILD_XR)
     settings.xr.enable                  = true;
     settings.xr.enableDebugCapture      = false;
+#else
+    settings.xr.enable = false;
+#endif
 }
 
 void CubeXrApp::Setup()
 {
+    PerView pv;
+    mPerView.push_back(pv);
+    mPerView.push_back(pv);
+
     // Uniform buffer
     {
         grfx::BufferCreateInfo bufferCreateInfo        = {};
@@ -44,28 +52,38 @@ void CubeXrApp::Setup()
         bufferCreateInfo.usageFlags.bits.uniformBuffer = true;
         bufferCreateInfo.memoryUsage                   = grfx::MEMORY_USAGE_CPU_TO_GPU;
 
-        PPX_CHECKED_CALL(GetDevice()->CreateBuffer(&bufferCreateInfo, &mUniformBuffer));
+        PPX_CHECKED_CALL(GetDevice()->CreateBuffer(&bufferCreateInfo, &mPerView[0].mUniformBuffer));
+        if (IsXrEnabled()) {
+            PPX_CHECKED_CALL(GetDevice()->CreateBuffer(&bufferCreateInfo, &mPerView[1].mUniformBuffer));
+        }
     }
 
     // Descriptor
     {
         grfx::DescriptorPoolCreateInfo poolCreateInfo = {};
-        poolCreateInfo.uniformBuffer                  = 1;
+        poolCreateInfo.uniformBuffer                  = IsXrEnabled() ? 2 : 1;
         PPX_CHECKED_CALL(GetDevice()->CreateDescriptorPool(&poolCreateInfo, &mDescriptorPool));
 
         grfx::DescriptorSetLayoutCreateInfo layoutCreateInfo = {};
         layoutCreateInfo.bindings.push_back(grfx::DescriptorBinding{0, grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, grfx::SHADER_STAGE_ALL_GRAPHICS});
         PPX_CHECKED_CALL(GetDevice()->CreateDescriptorSetLayout(&layoutCreateInfo, &mDescriptorSetLayout));
 
-        PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mDescriptorSetLayout, &mDescriptorSet));
+        PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mDescriptorSetLayout, &mPerView[0].mDescriptorSet));
+        if (IsXrEnabled()) {
+            PPX_CHECKED_CALL(GetDevice()->AllocateDescriptorSet(mDescriptorPool, mDescriptorSetLayout, &mPerView[1].mDescriptorSet));
+        }
 
         grfx::WriteDescriptor write = {};
         write.binding               = 0;
         write.type                  = grfx::DESCRIPTOR_TYPE_UNIFORM_BUFFER;
         write.bufferOffset          = 0;
         write.bufferRange           = PPX_WHOLE_SIZE;
-        write.pBuffer               = mUniformBuffer;
-        PPX_CHECKED_CALL(mDescriptorSet->UpdateDescriptors(1, &write));
+        write.pBuffer               = mPerView[0].mUniformBuffer;
+        PPX_CHECKED_CALL(mPerView[0].mDescriptorSet->UpdateDescriptors(1, &write));
+        if (IsXrEnabled()) {
+            write.pBuffer = mPerView[1].mUniformBuffer;
+            PPX_CHECKED_CALL(mPerView[1].mDescriptorSet->UpdateDescriptors(1, &write));
+        }
     }
 
     // Pipeline
@@ -201,17 +219,33 @@ void CubeXrApp::Setup()
     mScissorRect = {0, 0, GetWindowWidth(), GetWindowHeight()};
 }
 
+void CubeXrApp::DispatchRender()
+{
+    bool useOld = false;
+    if (useOld) {
+        // This is default behaviour
+        if (IsXrEnabled()) {
+            mViewIndex = 0;
+            Render();
+            mViewIndex = 1;
+            Render();
+        }
+        else {
+            Render();
+        }
+    }
+    else {
+        RenderSingleCommandBuffer();
+    }
+}
+
 void CubeXrApp::Render()
 {
     PerFrame& frame            = mPerFrame[0];
     uint32_t  imageIndex       = UINT32_MAX;
-    uint32_t  currentViewIndex = 0;
-    if (IsXrEnabled()) {
-        currentViewIndex = GetXrComponent().GetCurrentViewIndex();
-    }
 
     // Render UI into a different composition layer.
-    if (IsXrEnabled() && (currentViewIndex == 0) && GetSettings()->enableImGui) {
+    if (IsXrEnabled() && (mViewIndex == 0) && GetSettings()->enableImGui) {
         grfx::SwapchainPtr uiSwapchain = GetUISwapchain();
         PPX_CHECKED_CALL(uiSwapchain->AcquireNextImage(UINT64_MAX, nullptr, nullptr, &imageIndex));
         PPX_CHECKED_CALL(frame.uiRenderCompleteFence->WaitAndReset());
@@ -245,16 +279,17 @@ void CubeXrApp::Render()
         submitInfo.ppSignalSemaphores   = nullptr;
 
         submitInfo.pFence = frame.uiRenderCompleteFence;
+        uiSwapchain->Wait(imageIndex);
 
         PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
+        uiSwapchain->Present(imageIndex, 0, nullptr);
     }
 
-    grfx::SwapchainPtr swapchain = GetSwapchain(currentViewIndex);
+    grfx::SwapchainPtr swapchain = GetSwapchain(mViewIndex);
 
     if (swapchain->ShouldSkipExternalSynchronization()) {
         // No need to
         // - Signal imageAcquiredSemaphore & imageAcquiredFence.
-        // - Wait for imageAcquiredFence since xrWaitSwapchainImage is called in AcquireNextImage.
         PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, nullptr, nullptr, &imageIndex));
     }
     else {
@@ -274,17 +309,19 @@ void CubeXrApp::Render()
         float4x4 P = glm::perspective(glm::radians(60.0f), GetWindowAspect(), 0.001f, 10000.0f);
         float4x4 V = glm::lookAt(float3(0, 0, 0), float3(0, 0, 1), float3(0, 1, 0));
 
+#if defined(PPX_BUILD_XR)
         if (IsXrEnabled()) {
-            P = GetXrComponent().GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(0.001f, 10000.0f);
-            V = GetXrComponent().GetViewMatrixForCurrentView();
+            P = GetXrComponent().GetProjectionMatrixForViewAndSetFrustumPlanes(mViewIndex, 0.001f, 10000.0f);
+            V = GetXrComponent().GetViewMatrixForView(mViewIndex);
         }
+#endif
         float4x4 M   = glm::translate(float3(0, 0, -3)) * glm::rotate(t, float3(0, 0, 1)) * glm::rotate(t, float3(0, 1, 0)) * glm::rotate(t, float3(1, 0, 0));
         float4x4 mat = P * V * M;
 
         void* pData = nullptr;
-        PPX_CHECKED_CALL(mUniformBuffer->MapMemory(0, &pData));
+        PPX_CHECKED_CALL(mPerView[0].mUniformBuffer->MapMemory(0, &pData));
         memcpy(pData, &mat, sizeof(mat));
-        mUniformBuffer->UnmapMemory();
+        mPerView[0].mUniformBuffer->UnmapMemory();
     }
 
     // Build command buffer.
@@ -308,7 +345,7 @@ void CubeXrApp::Render()
         {
             frame.cmd->SetScissors(1, &mScissorRect);
             frame.cmd->SetViewports(1, &mViewport);
-            frame.cmd->BindGraphicsDescriptorSets(mPipelineInterface, 1, &mDescriptorSet);
+            frame.cmd->BindGraphicsDescriptorSets(mPipelineInterface, 1, &mPerView[0].mDescriptorSet);
             frame.cmd->BindGraphicsPipeline(mPipeline);
             frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());
             frame.cmd->Draw(36, 1, 0, 0);
@@ -343,23 +380,222 @@ void CubeXrApp::Render()
         submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     }
     submitInfo.pFence = frame.renderCompleteFence;
-
+    swapchain->Wait(imageIndex);
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
     // No need to present when XR is enabled.
+    uint32_t         semaphoreCount = 0;
+    grfx::Semaphore* pPresentSemaphores;
+    if (IsXrEnabled()) {
+        semaphoreCount = 1;
+    }
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, semaphoreCount, IsXrEnabled() ? nullptr : &frame.renderCompleteSemaphore));
+
+#if defined(PPX_BUILD_XR)
+    if (GetSettings()->xr.enableDebugCapture && (mViewIndex == 1)) {
+        // We could use semaphore to sync to have better performance,
+        // but this requires modifying the submission code.
+        // For debug capture we don't care about the performance,
+        // so use existing fence to sync for simplicity.
+        grfx::SwapchainPtr debugSwapchain = GetDebugCaptureSwapchain();
+        PPX_CHECKED_CALL(debugSwapchain->AcquireNextImage(UINT64_MAX, nullptr, frame.imageAcquiredFence, &imageIndex));
+        frame.imageAcquiredFence->WaitAndReset();
+        PPX_CHECKED_CALL(debugSwapchain->Present(imageIndex, 0, nullptr));
+    }
+#endif
+}
+
+void CubeXrApp::RenderSingleCommandBuffer()
+{
+    PerFrame& frame = mPerFrame[0];
+
+    //=========================================================================================
+    // PrepareFrame
+    // Does image acquisition
+    //=========================================================================================
+    std::vector<uint32_t> viewImageIndices(mPerView.size());
+    uint32_t              uiImageIndex = UINT32_MAX;
+
     if (!IsXrEnabled()) {
-        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+        PPX_CHECKED_CALL(GetSwapchain()->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &viewImageIndices[0]));
+
+        // Wait for and reset image acquired fence.
+        // Why?
+        PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
     }
     else {
-        if (GetSettings()->xr.enableDebugCapture && (currentViewIndex == 1)) {
-            // We could use semaphore to sync to have better performance,
-            // but this requires modifying the submission code.
-            // For debug capture we don't care about the performance,
-            // so use existing fence to sync for simplicity.
-            grfx::SwapchainPtr debugSwapchain = GetDebugCaptureSwapchain();
-            PPX_CHECKED_CALL(debugSwapchain->AcquireNextImage(UINT64_MAX, nullptr, frame.imageAcquiredFence, &imageIndex));
-            frame.imageAcquiredFence->WaitAndReset();
-            PPX_CHECKED_CALL(debugSwapchain->Present(imageIndex, 0, nullptr));
+        for (uint32_t viewIndex = 0; viewIndex < viewImageIndices.size(); viewIndex++) {
+            grfx::SwapchainPtr swapchain = GetSwapchain(viewIndex);
+            PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, nullptr, nullptr, &viewImageIndices[viewIndex]));
+        }
+
+        if (GetSettings()->enableImGui) {
+            grfx::SwapchainPtr uiSwapchain = GetUISwapchain();
+            PPX_CHECKED_CALL(uiSwapchain->AcquireNextImage(UINT64_MAX, nullptr, nullptr, &uiImageIndex));
         }
     }
+
+    //=========================================================================================
+    // RecordFrame
+    // Records command buffers
+    //=========================================================================================
+
+    // Wait for and reset render complete fence before recording the command buffer.
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
+    // Update uniform buffers.
+    {
+        float    t = GetElapsedSeconds();
+        float4x4 P = glm::perspective(glm::radians(60.0f), GetWindowAspect(), 0.001f, 10000.0f);
+        float4x4 V = glm::lookAt(float3(0, 0, 0), float3(0, 0, 1), float3(0, 1, 0));
+
+        uint32_t viewIndex = 0;
+#if defined(PPX_BUILD_XR)
+        if (IsXrEnabled()) {
+            P = GetXrComponent().GetProjectionMatrixForViewAndSetFrustumPlanes(viewIndex, 0.001f, 10000.0f);
+            V = GetXrComponent().GetViewMatrixForView(viewIndex);
+        }
+#endif
+        float4x4 M   = glm::translate(float3(0, 0, -3)) * glm::rotate(t, float3(0, 0, 1)) * glm::rotate(t, float3(0, 1, 0)) * glm::rotate(t, float3(1, 0, 0));
+        float4x4 mat = P * V * M;
+
+        void* pData = nullptr;
+        PPX_CHECKED_CALL(mPerView[viewIndex].mUniformBuffer->MapMemory(0, &pData));
+        memcpy(pData, &mat, sizeof(mat));
+        mPerView[viewIndex].mUniformBuffer->UnmapMemory();
+
+        if (IsXrEnabled()) {
+            viewIndex    = 1;
+            P            = GetXrComponent().GetProjectionMatrixForViewAndSetFrustumPlanes(viewIndex, 0.001f, 10000.0f);
+            V            = GetXrComponent().GetViewMatrixForView(viewIndex);
+            float4x4 M   = glm::translate(float3(0, 0, -3)) * glm::rotate(t, float3(0, 0, 1)) * glm::rotate(t, float3(0, 1, 0)) * glm::rotate(t, float3(1, 0, 0));
+            float4x4 mat = P * V * M;
+
+            void* pData = nullptr;
+            PPX_CHECKED_CALL(mPerView[viewIndex].mUniformBuffer->MapMemory(0, &pData));
+            memcpy(pData, &mat, sizeof(mat));
+            mPerView[viewIndex].mUniformBuffer->UnmapMemory();
+        }
+    }
+
+    // Build command buffer.
+    PPX_CHECKED_CALL(frame.cmd->Begin());
+    {
+        if (IsXrEnabled() && GetSettings()->enableImGui) {
+            grfx::RenderPassPtr renderPass = GetUISwapchain()->GetRenderPass(uiImageIndex);
+            PPX_ASSERT_MSG(!renderPass.IsNull(), "render pass object is null");
+            grfx::RenderPassBeginInfo beginInfo = {};
+            beginInfo.pRenderPass               = renderPass;
+            beginInfo.renderArea                = renderPass->GetRenderArea();
+            beginInfo.RTVClearCount             = 1;
+            beginInfo.RTVClearValues[0]         = {{0, 0, 0, 0}};
+            beginInfo.DSVClearValue             = {1.0f, 0xFF};
+
+            frame.cmd->BeginRenderPass(&beginInfo);
+            // Draw ImGui
+            DrawDebugInfo();
+            DrawImGui(frame.cmd);
+            frame.cmd->EndRenderPass();
+        }
+
+        for (size_t view = 0; view < mPerView.size(); view++) {
+            grfx::SwapchainPtr  swapchain  = GetSwapchain(view);
+            grfx::RenderPassPtr renderPass = swapchain->GetRenderPass(viewImageIndices[view]);
+            PPX_ASSERT_MSG(!renderPass.IsNull(), "render pass object is null");
+
+            grfx::RenderPassBeginInfo beginInfo = {};
+            beginInfo.pRenderPass               = renderPass;
+            beginInfo.renderArea                = renderPass->GetRenderArea();
+            beginInfo.RTVClearCount             = 1;
+            beginInfo.RTVClearValues[0]         = {{0, 0, 0, 0}};
+            beginInfo.DSVClearValue             = {1.0f, 0xFF};
+
+            if (!IsXrEnabled()) {
+                frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
+            }
+
+            frame.cmd->BeginRenderPass(&beginInfo);
+            {
+                frame.cmd->SetScissors(1, &mScissorRect);
+                frame.cmd->SetViewports(1, &mViewport);
+                frame.cmd->BindGraphicsDescriptorSets(mPipelineInterface, 1, &mPerView[view].mDescriptorSet);
+                frame.cmd->BindGraphicsPipeline(mPipeline);
+                frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());
+                frame.cmd->Draw(36, 1, 0, 0);
+
+                if (!IsXrEnabled()) {
+                    // Draw ImGui
+                    DrawDebugInfo();
+                    DrawImGui(frame.cmd);
+                }
+            }
+            frame.cmd->EndRenderPass();
+            if (!IsXrEnabled()) {
+                frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_RENDER_TARGET, grfx::RESOURCE_STATE_PRESENT);
+            }
+        }
+    }
+    PPX_CHECKED_CALL(frame.cmd->End());
+
+    //=========================================================================================
+    // SubmitFrame
+    // Submit GPU work
+    //=========================================================================================
+    for (size_t view = 0; view < mPerView.size(); view++) {
+        grfx::SwapchainPtr swapchain = GetSwapchain(view);
+        swapchain->Wait(viewImageIndices[view]);
+    }
+
+    if (IsXrEnabled() && GetSettings()->enableImGui) {
+        GetUISwapchain()->Wait(uiImageIndex);
+    }
+
+    grfx::SubmitInfo submitInfo   = {};
+    submitInfo.commandBufferCount = 1;
+    submitInfo.ppCommandBuffers   = &frame.cmd;
+    // No need to use semaphore when XR is enabled.
+    if (IsXrEnabled()) {
+        submitInfo.waitSemaphoreCount   = 0;
+        submitInfo.ppWaitSemaphores     = nullptr;
+        submitInfo.signalSemaphoreCount = 0;
+        submitInfo.ppSignalSemaphores   = nullptr;
+    }
+    else {
+        submitInfo.waitSemaphoreCount   = 1;
+        submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
+        submitInfo.signalSemaphoreCount = 1;
+        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    }
+    submitInfo.pFence = frame.renderCompleteFence;
+
+    PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
+
+    //=========================================================================================
+    // PresentFrame
+    // Present frame
+    //=========================================================================================
+    if (!IsXrEnabled()) {
+        PPX_CHECKED_CALL(GetSwapchain()->Present(viewImageIndices[0], 1, &frame.renderCompleteSemaphore));
+    }
+    else {
+        PPX_CHECKED_CALL(GetSwapchain(0)->Present(viewImageIndices[0], 0, nullptr));
+        PPX_CHECKED_CALL(GetSwapchain(1)->Present(viewImageIndices[1], 0, nullptr));
+        if (GetSettings()->enableImGui) {
+            PPX_CHECKED_CALL(GetUISwapchain()->Present(uiImageIndex, 0, nullptr));
+        }
+    }
+
+#if defined(PPX_BUILD_XR)
+    if (GetSettings()->xr.enableDebugCapture && (mViewIndex == 1)) {
+        // We could use semaphore to sync to have better performance,
+        // but this requires modifying the submission code.
+        // For debug capture we don't care about the performance,
+        // so use existing fence to sync for simplicity.
+        uint32_t           imageIndex     = -1;
+        grfx::SwapchainPtr debugSwapchain = GetDebugCaptureSwapchain();
+        PPX_CHECKED_CALL(debugSwapchain->AcquireNextImage(UINT64_MAX, nullptr, frame.imageAcquiredFence, &imageIndex));
+        frame.imageAcquiredFence->WaitAndReset();
+        PPX_CHECKED_CALL(debugSwapchain->Present(imageIndex, 0, nullptr));
+    }
+#endif
 }

--- a/projects/04_cube_xr/CubeXr.h
+++ b/projects/04_cube_xr/CubeXr.h
@@ -26,6 +26,8 @@ public:
     virtual void Config(ApplicationSettings& settings) override;
     virtual void Setup() override;
     virtual void Render() override;
+    void         RenderSingleCommandBuffer();
+    virtual void DispatchRender() override;
 
 private:
     struct PerFrame
@@ -41,6 +43,14 @@ private:
         grfx::FencePtr         uiRenderCompleteFence;
     };
 
+    struct PerView
+    {
+        grfx::DescriptorSetPtr mDescriptorSet;
+        grfx::BufferPtr        mUniformBuffer;
+    };
+
+    std::vector<PerView> mPerView;
+
     std::vector<PerFrame>        mPerFrame;
     grfx::ShaderModulePtr        mVS;
     grfx::ShaderModulePtr        mPS;
@@ -49,11 +59,12 @@ private:
     grfx::BufferPtr              mVertexBuffer;
     grfx::DescriptorPoolPtr      mDescriptorPool;
     grfx::DescriptorSetLayoutPtr mDescriptorSetLayout;
-    grfx::DescriptorSetPtr       mDescriptorSet;
-    grfx::BufferPtr              mUniformBuffer;
+
     grfx::Viewport               mViewport;
     grfx::Rect                   mScissorRect;
     grfx::VertexBinding          mVertexBinding;
+
+    uint32_t mViewIndex;
 };
 
 #endif // CUBEXR_H

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -49,7 +49,8 @@ add_subdirectory(fishtornado)
 add_subdirectory(fluid_simulation)
 add_subdirectory(oit_demo)
 
-if (PPX_BUILD_XR)
+
 add_subdirectory(04_cube_xr)
+if (PPX_BUILD_XR)
 add_subdirectory(fishtornado_xr)
 endif()

--- a/projects/fishtornado_xr/FishTornado.h
+++ b/projects/fishtornado_xr/FishTornado.h
@@ -88,6 +88,7 @@ public:
     virtual void Setup() override;
     virtual void Shutdown() override;
     virtual void Scroll(float dx, float dy) override;
+    virtual void DispatchRender() override;
     virtual void Render() override;
 
     bool WasLastFrameAsync() { return mLastFrameWasAsyncCompute; }
@@ -168,6 +169,7 @@ private:
     std::vector<uint64_t>                 mViewGpuFrameTime         = {};
     std::vector<grfx::PipelineStatistics> mViewPipelineStatistics   = {};
     MetricsData                           mMetricsData;
+    uint32_t                              mViewIndex;
 
 private:
     void SetupDescriptorPool();

--- a/projects/fishtornado_xr/Flocking.cpp
+++ b/projects/fishtornado_xr/Flocking.cpp
@@ -318,7 +318,7 @@ void Flocking::Shutdown()
     mMaterialConstants.Destroy();
 }
 
-void Flocking::Update(uint32_t frameIndex)
+void Flocking::Update(uint32_t frameIndex, uint32_t viewIndex = 0)
 {
     FishTornadoApp* pApp  = FishTornadoApp::GetThisApp();
     const float     t     = pApp->GetTime();
@@ -346,7 +346,7 @@ void Flocking::Update(uint32_t frameIndex)
         pFlockingData->predPos            = pApp->GetShark()->GetPosition();
         pFlockingData->camPos             = pApp->GetCamera()->GetEyePosition();
         if (pApp->IsXrEnabled() && (pUseTracking != nullptr && *pUseTracking)) {
-            const XrVector3f& pos = pApp->GetXrComponent().GetPoseForCurrentView().position;
+            const XrVector3f& pos = pApp->GetXrComponent().GetPoseForView(viewIndex).position;
             pFlockingData->camPos = {pos.x, pos.y, pos.z};
         }
     }

--- a/projects/fishtornado_xr/Flocking.h
+++ b/projects/fishtornado_xr/Flocking.h
@@ -36,7 +36,7 @@ public:
 
     void Setup(uint32_t numFramesInFlight, const FishTornadoSettings& settings);
     void Shutdown();
-    void Update(uint32_t frameIndex);
+    void Update(uint32_t frameIndex, uint32_t viewIndex);
     void CopyConstantsToGpu(uint32_t frameIndex, grfx::CommandBuffer* pCmd);
 
     void BeginCompute(uint32_t frameIndex, grfx::CommandBuffer* pCmd, bool asyncCompute);

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1368,32 +1368,16 @@ int Application::Run(int argc, char** argv)
 
             if (mXrComponent.IsSessionRunning()) {
                 mXrComponent.BeginFrame();
+
                 if (mXrComponent.ShouldRender()) {
-                    XrSwapchainImageReleaseInfo releaseInfo = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
                     uint32_t                    viewCount   = static_cast<uint32_t>(mXrComponent.GetViewCount());
                     // Start new Imgui frame
                     if (mImGui) {
                         mImGui->NewFrame();
                     }
-                    for (uint32_t k = 0; k < viewCount; ++k) {
-                        mSwapchainIndex = k;
-                        mXrComponent.SetCurrentViewIndex(k);
-                        DispatchRender();
-                        grfx::SwapchainPtr swapchain = GetSwapchain(k + mStereoscopicSwapchainIndex);
-                        CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrColorSwapchain(), &releaseInfo));
-                        if (swapchain->GetXrDepthSwapchain() != XR_NULL_HANDLE) {
-                            CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrDepthSwapchain(), &releaseInfo));
-                        }
-                    }
-
-                    if (GetSettings()->enableImGui) {
-                        grfx::SwapchainPtr swapchain = GetSwapchain(mUISwapchainIndex);
-                        CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrColorSwapchain(), &releaseInfo));
-                        if (swapchain->GetXrDepthSwapchain() != XR_NULL_HANDLE) {
-                            CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrDepthSwapchain(), &releaseInfo));
-                        }
-                    }
+                    DispatchRender();
                 }
+
                 mXrComponent.EndFrame(mSwapchains, 0, mUISwapchainIndex);
             }
         }

--- a/src/ppx/xr_component.cpp
+++ b/src/ppx/xr_component.cpp
@@ -581,7 +581,7 @@ void XrComponent::ConditionallyPopulateProjectionLayer(const std::vector<grfx::S
 
         if (mShouldSubmitDepthInfo && (swapchains[startIndex + i]->GetXrDepthSwapchain() != XR_NULL_HANDLE)) {
             PPX_ASSERT_MSG(mNearPlaneForFrame.has_value() && mFarPlaneForFrame.has_value(), "Depth info layer cannot be submitted because near and far plane values are not set. "
-                                                                                            "Call GetProjectionMatrixForCurrentViewAndSetFrustumPlanes to set per-frame values.");
+                                                                                            "Call GetProjectionMatrixForViewAndSetFrustumPlanes to set per-frame values.");
             XrCompositionLayerDepthInfoKHR depthInfo = {XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR};
             depthInfo.minDepth                       = 0.0f;
             depthInfo.maxDepth                       = 1.0f;
@@ -663,10 +663,10 @@ bool XrComponent::RemoveLayer(LayerRef layerRef)
     return mLayers.erase(layerRef);
 }
 
-glm::mat4 XrComponent::GetViewMatrixForCurrentView() const
+glm::mat4 XrComponent::GetViewMatrixForView(uint32_t viewIndex) const
 {
-    PPX_ASSERT_MSG((mCurrentViewIndex < mViews.size()), "Invalid view index!");
-    const XrView&  view = mViews[mCurrentViewIndex];
+    PPX_ASSERT_MSG((viewIndex < mViews.size()), "Invalid view index!");
+    const XrView&  view = mViews[viewIndex];
     const XrPosef& pose = view.pose;
     // OpenXR is using right handed system which is the same as Vulkan
     glm::quat quat         = glm::quat(pose.orientation.w, pose.orientation.x, pose.orientation.y, pose.orientation.z);
@@ -678,10 +678,10 @@ glm::mat4 XrComponent::GetViewMatrixForCurrentView() const
     return view_glm_inv;
 }
 
-glm::mat4 XrComponent::GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(float nearZ, float farZ)
+glm::mat4 XrComponent::GetProjectionMatrixForViewAndSetFrustumPlanes(uint32_t viewIndex, float nearZ, float farZ)
 {
-    PPX_ASSERT_MSG((mCurrentViewIndex < mViews.size()), "Invalid view index!");
-    const XrView& view = mViews[mCurrentViewIndex];
+    PPX_ASSERT_MSG((viewIndex < mViews.size()), "Invalid view index!");
+    const XrView& view = mViews[viewIndex];
     const XrFovf& fov  = view.fov;
 
     // Save near and far plane values so that they can be referenced
@@ -722,10 +722,10 @@ glm::mat4 XrComponent::GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(floa
     return glm::make_mat4(mat);
 }
 
-XrPosef XrComponent::GetPoseForCurrentView() const
+XrPosef XrComponent::GetPoseForView(uint32_t viewIndex) const
 {
-    PPX_ASSERT_MSG((mCurrentViewIndex < mViews.size()), "Invalid view index!");
-    return mViews[mCurrentViewIndex].pose;
+    PPX_ASSERT_MSG((viewIndex < mViews.size()), "Invalid view index!");
+    return mViews[viewIndex].pose;
 }
 
 } // namespace ppx


### PR DESCRIPTION
Swapchain:
- Add Wait() method to swapchain, it is a no-op for non-XR. For XR it calls xrWaitSwapchainImage. Since the command buffer can be recorded between xrAcquireSwapchainImage and xrWaitSwapchainImage, putting xrWaitSwapchainImage in AcquireNextImage is unnecessarily restrictive.
- Add xrReleaseSwapchainImage to Present(). It is weird not to have a function for this and to do this in the main application loop, since the application already calls Acquire.

Remove calling Render() twice for XR and the viewIndex logic. It is very much application/project specific logic of how it decides to render two views, and can be easily handled in the application level. It also becomes more restrictive where application decides to render differently (for example, using a single command buffer for UI and both views, or with multiview in the future)

Also adds a method to cube to show rendering within a single command buffer using two uniform buffers for two views.

Change other samples