### PR TITLE
A few changes to XR handling

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -755,6 +755,7 @@ void GraphicsBenchmarkApp::RecordAndSubmitCommandBufferGUIXR(PerFrame& frame)
         frame.uiCmd->EndRenderPass();
     }
     PPX_CHECKED_CALL(frame.uiCmd->End());
+    uiSwapchain->Wait(imageIndex);
 
     grfx::SubmitInfo submitInfo     = {};
     submitInfo.commandBufferCount   = 1;
@@ -767,29 +768,42 @@ void GraphicsBenchmarkApp::RecordAndSubmitCommandBufferGUIXR(PerFrame& frame)
     submitInfo.pFence = frame.uiRenderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
+    uiSwapchain->Present(imageIndex, 0, nullptr);
 }
 #endif
+
+void GraphicsBenchmarkApp::DispatchRender()
+{
+    if (IsXrEnabled()) {
+        size_t viewCount = static_cast<uint32_t>(GetXrComponent().GetViewCount());
+        for (size_t view = 0; view < viewCount; view++) {
+            mViewIndex = view;
+            Render();
+        }
+    }
+    else {
+        Render();
+    }
+}
 
 void GraphicsBenchmarkApp::Render()
 {
     ProcessInput();
     ProcessKnobs();
 
-    PerFrame& frame            = mPerFrame[0];
-    uint32_t  currentViewIndex = 0;
+    PerFrame& frame = mPerFrame[0];
 
 #if defined(PPX_BUILD_XR)
     // Render UI into a different composition layer.
     if (IsXrEnabled()) {
-        currentViewIndex = GetXrComponent().GetCurrentViewIndex();
-        if ((currentViewIndex == 0) && GetSettings()->enableImGui) {
+        if ((mViewIndex == 0) && GetSettings()->enableImGui) {
             RecordAndSubmitCommandBufferGUIXR(frame);
         }
     }
 #endif
 
     uint32_t           imageIndex = UINT32_MAX;
-    grfx::SwapchainPtr swapchain  = GetSwapchain(currentViewIndex);
+    grfx::SwapchainPtr swapchain  = GetSwapchain(mViewIndex);
 
 #if defined(PPX_BUILD_XR)
     if (IsXrEnabled()) {
@@ -825,13 +839,15 @@ void GraphicsBenchmarkApp::Render()
     frame.sceneData.viewProjectionMatrix = mCamera.GetViewProjectionMatrix();
 #if defined(PPX_BUILD_XR)
     if (IsXrEnabled()) {
-        const glm::mat4 v                    = GetXrComponent().GetViewMatrixForCurrentView();
-        const glm::mat4 p                    = GetXrComponent().GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(PPX_CAMERA_DEFAULT_NEAR_CLIP, PPX_CAMERA_DEFAULT_FAR_CLIP);
+        const glm::mat4 v                    = GetXrComponent().GetViewMatrixForView(mViewIndex);
+        const glm::mat4 p                    = GetXrComponent().GetProjectionMatrixForViewAndSetFrustumPlanes(mViewIndex, PPX_CAMERA_DEFAULT_NEAR_CLIP, PPX_CAMERA_DEFAULT_FAR_CLIP);
         frame.sceneData.viewProjectionMatrix = p * v;
     }
 #endif
 
     RecordCommandBuffer(frame, swapchain, imageIndex);
+
+    swapchain->Wait(imageIndex);
 
     grfx::SubmitInfo submitInfo   = {};
     submitInfo.commandBufferCount = 1;
@@ -857,9 +873,10 @@ void GraphicsBenchmarkApp::Render()
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
 #if defined(PPX_BUILD_XR)
-    // No need to present when XR is enabled.
     if (IsXrEnabled()) {
-        if (GetSettings()->xr.enableDebugCapture && (currentViewIndex == 1)) {
+        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 0, nullptr));
+
+        if (GetSettings()->xr.enableDebugCapture && (mViewIndex == 1)) {
             // We could use semaphore to sync to have better performance,
             // but this requires modifying the submission code.
             // For debug capture we don't care about the performance,

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -107,6 +107,7 @@ public:
     virtual void MouseMove(int32_t x, int32_t y, int32_t dx, int32_t dy, uint32_t buttons) override;
     virtual void KeyDown(ppx::KeyCode key) override;
     virtual void KeyUp(ppx::KeyCode key) override;
+    virtual void DispatchRender() override;
     virtual void Render() override;
 
 private:
@@ -207,6 +208,8 @@ private:
     std::array<grfx::GraphicsPipelinePtr, kFullscreenQuadsTypes.size()>  mQuadsPipelines;
     std::array<grfx::PipelineInterfacePtr, kFullscreenQuadsTypes.size()> mQuadsPipelineInterfaces;
     std::array<grfx::ShaderModulePtr, kFullscreenQuadsTypes.size()>      mQuadsPs;
+
+    uint32_t mViewIndex;
 
 private:
     std::shared_ptr<KnobDropdown<std::string>> pKnobVs;

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -565,7 +565,6 @@ private:
     KnobManager                     mKnobManager;
 
     uint64_t          mFrameCount        = 0;
-    uint32_t          mSwapchainIndex    = 0;
     float             mAverageFPS        = 0;
     float             mFrameStartTime    = 0;
     float             mFrameEndTime      = 0;

--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -146,6 +146,8 @@ public:
         grfx::Fence*     pFence,     // Wait fence
         uint32_t*        pImageIndex);
 
+    Result Wait(uint32_t);
+
     Result Present(
         uint32_t                      imageIndex,
         uint32_t                      waitSemaphoreCount,

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -166,16 +166,14 @@ public:
     XrInstance GetInstance() const { return mInstance; }
     XrSystemId GetSystemId() const { return mSystemId; }
     XrSession  GetSession() const { return mSession; }
-    void       SetCurrentViewIndex(uint32_t index) { mCurrentViewIndex = index; }
-    uint32_t   GetCurrentViewIndex() const { return mCurrentViewIndex; }
 
     // Computes the projection matrix for the current view given the near and
     // far frustum planes. The values for the frustum planes will be sent to
     // the OpenXR runtime as part of the frame depth info submission, and the
     // caller must ensure that the values do not change within a frame.
-    glm::mat4 GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(float nearZ, float farZ);
-    glm::mat4 GetViewMatrixForCurrentView() const;
-    XrPosef   GetPoseForCurrentView() const;
+    glm::mat4 GetProjectionMatrixForViewAndSetFrustumPlanes(uint32_t viewIndex, float nearZ, float farZ);
+    glm::mat4 GetViewMatrixForView(uint32_t viewIndex) const;
+    XrPosef   GetPoseForView(uint32_t viewIndex) const;
 
     bool IsSessionRunning() const { return mIsSessionRunning; }
     bool ShouldRender() const { return mShouldRender; }
@@ -214,7 +212,6 @@ private:
     std::vector<XrViewConfigurationView> mConfigViews;
     std::vector<XrView>                  mViews;
     std::vector<XrEnvironmentBlendMode>  mBlendModes;
-    uint32_t                             mCurrentViewIndex = 0;
 
     std::unordered_map<LayerRef, std::unique_ptr<XrLayerBase>> mLayers;
     LayerRef                                                   mNextLayerRef = 0;

--- a/projects/04_cube_xr/CubeXr.h
+++ b/projects/04_cube_xr/CubeXr.h
@@ -26,6 +26,7 @@ public:
     virtual void Config(ApplicationSettings& settings) override;
     virtual void Setup() override;
     virtual void Render() override;
+    virtual void DispatchRender() override;
 
 private:
     struct PerFrame
@@ -54,6 +55,8 @@ private:
     grfx::Viewport               mViewport;
     grfx::Rect                   mScissorRect;
     grfx::VertexBinding          mVertexBinding;
+
+    uint32_t mViewIndex;
 };
 
 #endif // CUBEXR_H

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -505,10 +505,10 @@ void FishTornadoApp::UpdateScene(uint32_t frameIndex)
     pSceneData->usePCF                     = static_cast<uint32_t>(mSettings.usePCF);
 
     if (IsXrEnabled() && mSettings.useTracking) {
-        const XrVector3f& pos            = GetXrComponent().GetPoseForCurrentView().position;
+        const XrVector3f& pos            = GetXrComponent().GetPoseForView(mViewIndex).position;
         pSceneData->eyePosition          = {pos.x, pos.y, pos.z};
-        const glm::mat4 v                = GetXrComponent().GetViewMatrixForCurrentView();
-        const glm::mat4 p                = GetXrComponent().GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(PPX_CAMERA_DEFAULT_NEAR_CLIP, PPX_CAMERA_DEFAULT_FAR_CLIP);
+        const glm::mat4 v                = GetXrComponent().GetViewMatrixForView(mViewIndex);
+        const glm::mat4 p                = GetXrComponent().GetProjectionMatrixForViewAndSetFrustumPlanes(mViewIndex, PPX_CAMERA_DEFAULT_NEAR_CLIP, PPX_CAMERA_DEFAULT_FAR_CLIP);
         pSceneData->viewMatrix           = v;
         pSceneData->projectionMatrix     = p;
         pSceneData->viewProjectionMatrix = p * v;
@@ -566,7 +566,7 @@ void FishTornadoApp::RenderSceneUsingSingleCommandBuffer(
         bool updateFlocking = true;
         // only need to update flocking once per frame
         if (IsXrEnabled()) {
-            if (GetXrComponent().GetCurrentViewIndex() != 0) {
+            if (mViewIndex != 0) {
                 updateFlocking = false;
             }
         }
@@ -674,6 +674,8 @@ void FishTornadoApp::RenderSceneUsingSingleCommandBuffer(
 
     PPX_CHECKED_CALL(frame.cmd->End());
 
+    swapchain->Wait(imageIndex);
+
     grfx::SubmitInfo submitInfo   = {};
     submitInfo.commandBufferCount = 1;
     submitInfo.ppCommandBuffers   = &frame.cmd;
@@ -778,7 +780,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
     bool updateFlocking = true;
     // only need to update flocking once per frame
     if (IsXrEnabled()) {
-        if (GetXrComponent().GetCurrentViewIndex() != 0) {
+        if (mViewIndex != 0) {
             updateFlocking = false;
         }
     }
@@ -921,6 +923,8 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
     }
     PPX_CHECKED_CALL(frame.cmd->End());
 
+    swapchain->Wait(imageIndex);
+
     // Submit render work
     // no need to use semaphore when XR is enabled
     if (IsXrEnabled()) {
@@ -1007,6 +1011,20 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
 #endif
 }
 
+void FishTornadoApp::DispatchRender()
+{
+    if (IsXrEnabled()) {
+        size_t viewCount = static_cast<uint32_t>(GetXrComponent().GetViewCount());
+        for (size_t view = 0; view < viewCount; view++) {
+            mViewIndex = view;
+            Render();
+        }
+    }
+    else {
+        Render();
+    }
+}
+
 void FishTornadoApp::Render()
 {
     uint32_t  frameIndex     = GetInFlightFrameIndex();
@@ -1014,21 +1032,18 @@ void FishTornadoApp::Render()
     uint32_t  prevFrameIndex = GetPreviousInFlightFrameIndex();
     PerFrame& prevFrame      = mPerFrame[prevFrameIndex];
 
-    uint32_t imageIndex       = UINT32_MAX;
-    uint32_t currentViewIndex = 0;
-    if (IsXrEnabled()) {
-        currentViewIndex = GetXrComponent().GetCurrentViewIndex();
-    }
+    uint32_t imageIndex = UINT32_MAX;
 
     // Render UI into a different composition layer.
-    if (IsXrEnabled() && (currentViewIndex == 0) && GetSettings()->enableImGui) {
+    if (IsXrEnabled() && (mViewIndex == 0) && GetSettings()->enableImGui) {
+        uint32_t           uiImageIndex = UINT32_MAX;
         grfx::SwapchainPtr uiSwapchain = GetUISwapchain();
-        PPX_CHECKED_CALL(uiSwapchain->AcquireNextImage(UINT64_MAX, nullptr, nullptr, &imageIndex));
+        PPX_CHECKED_CALL(uiSwapchain->AcquireNextImage(UINT64_MAX, nullptr, nullptr, &uiImageIndex));
         PPX_CHECKED_CALL(frame.uiRenderCompleteFence->WaitAndReset());
 
         PPX_CHECKED_CALL(frame.uiCmd->Begin());
         {
-            grfx::RenderPassPtr renderPass = uiSwapchain->GetRenderPass(imageIndex);
+            grfx::RenderPassPtr renderPass = uiSwapchain->GetRenderPass(uiImageIndex);
             PPX_ASSERT_MSG(!renderPass.IsNull(), "render pass object is null");
 
             grfx::RenderPassBeginInfo beginInfo = {};
@@ -1046,6 +1061,8 @@ void FishTornadoApp::Render()
         }
         PPX_CHECKED_CALL(frame.uiCmd->End());
 
+        PPX_CHECKED_CALL(uiSwapchain->Wait(uiImageIndex));
+
         grfx::SubmitInfo submitInfo     = {};
         submitInfo.commandBufferCount   = 1;
         submitInfo.ppCommandBuffers     = &frame.uiCmd;
@@ -1057,9 +1074,10 @@ void FishTornadoApp::Render()
         submitInfo.pFence = frame.uiRenderCompleteFence;
 
         PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
+        PPX_CHECKED_CALL(uiSwapchain->Present(uiImageIndex, 0, nullptr));
     }
 
-    grfx::SwapchainPtr swapchain = GetSwapchain(currentViewIndex);
+    grfx::SwapchainPtr swapchain = GetSwapchain(mViewIndex);
 
     UpdateTime();
 
@@ -1086,7 +1104,7 @@ void FishTornadoApp::Render()
         mShark.Update(frameIndex);
     }
     if (mSettings.renderFish) {
-        mFlocking.Update(frameIndex);
+        mFlocking.Update(frameIndex, mViewIndex);
     }
     if (mSettings.renderOcean) {
         mOcean.Update(frameIndex);
@@ -1098,9 +1116,9 @@ void FishTornadoApp::Render()
         uint64_t data[2] = {0, 0};
         PPX_CHECKED_CALL(prevFrame.startTimestampQuery->GetData(&data[0], 1 * sizeof(uint64_t)));
         PPX_CHECKED_CALL(prevFrame.endTimestampQuery->GetData(&data[1], 1 * sizeof(uint64_t)));
-        mViewGpuFrameTime[currentViewIndex] = (data[1] - data[0]);
+        mViewGpuFrameTime[mViewIndex] = (data[1] - data[0]);
         if (GetDevice()->PipelineStatsAvailable()) {
-            PPX_CHECKED_CALL(prevFrame.pipelineStatsQuery->GetData(&(mViewPipelineStatistics[currentViewIndex]), sizeof(grfx::PipelineStatistics)));
+            PPX_CHECKED_CALL(prevFrame.pipelineStatsQuery->GetData(&(mViewPipelineStatistics[mViewIndex]), sizeof(grfx::PipelineStatistics)));
         }
 #endif
     }
@@ -1114,12 +1132,13 @@ void FishTornadoApp::Render()
 
     mLastFrameWasAsyncCompute = mSettings.useAsyncCompute;
 
-    // No need to present when XR is enabled.
     if (!IsXrEnabled()) {
         PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.frameCompleteSemaphore));
     }
     else {
-        if (GetSettings()->xr.enableDebugCapture && (currentViewIndex == 1)) {
+        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 0, nullptr));
+
+        if (GetSettings()->xr.enableDebugCapture && (mViewIndex == 1)) {
             // We could use semaphore to sync to have better performance,
             // but this requires modifying the submission code.
             // For debug capture we don't care about the performance,

--- a/projects/fishtornado_xr/FishTornado.h
+++ b/projects/fishtornado_xr/FishTornado.h
@@ -88,6 +88,7 @@ public:
     virtual void Setup() override;
     virtual void Shutdown() override;
     virtual void Scroll(float dx, float dy) override;
+    virtual void DispatchRender() override;
     virtual void Render() override;
 
     bool WasLastFrameAsync() { return mLastFrameWasAsyncCompute; }
@@ -168,6 +169,7 @@ private:
     std::vector<uint64_t>                 mViewGpuFrameTime         = {};
     std::vector<grfx::PipelineStatistics> mViewPipelineStatistics   = {};
     MetricsData                           mMetricsData;
+    uint32_t                              mViewIndex;
 
 private:
     void SetupDescriptorPool();

--- a/projects/fishtornado_xr/Flocking.cpp
+++ b/projects/fishtornado_xr/Flocking.cpp
@@ -318,7 +318,7 @@ void Flocking::Shutdown()
     mMaterialConstants.Destroy();
 }
 
-void Flocking::Update(uint32_t frameIndex)
+void Flocking::Update(uint32_t frameIndex, uint32_t viewIndex = 0)
 {
     FishTornadoApp* pApp  = FishTornadoApp::GetThisApp();
     const float     t     = pApp->GetTime();
@@ -346,7 +346,7 @@ void Flocking::Update(uint32_t frameIndex)
         pFlockingData->predPos            = pApp->GetShark()->GetPosition();
         pFlockingData->camPos             = pApp->GetCamera()->GetEyePosition();
         if (pApp->IsXrEnabled() && (pUseTracking != nullptr && *pUseTracking)) {
-            const XrVector3f& pos = pApp->GetXrComponent().GetPoseForCurrentView().position;
+            const XrVector3f& pos = pApp->GetXrComponent().GetPoseForView(viewIndex).position;
             pFlockingData->camPos = {pos.x, pos.y, pos.z};
         }
     }

--- a/projects/fishtornado_xr/Flocking.h
+++ b/projects/fishtornado_xr/Flocking.h
@@ -36,7 +36,7 @@ public:
 
     void Setup(uint32_t numFramesInFlight, const FishTornadoSettings& settings);
     void Shutdown();
-    void Update(uint32_t frameIndex);
+    void Update(uint32_t frameIndex, uint32_t viewIndex);
     void CopyConstantsToGpu(uint32_t frameIndex, grfx::CommandBuffer* pCmd);
 
     void BeginCompute(uint32_t frameIndex, grfx::CommandBuffer* pCmd, bool asyncCompute);

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1368,32 +1368,15 @@ int Application::Run(int argc, char** argv)
 
             if (mXrComponent.IsSessionRunning()) {
                 mXrComponent.BeginFrame();
+
                 if (mXrComponent.ShouldRender()) {
-                    XrSwapchainImageReleaseInfo releaseInfo = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
-                    uint32_t                    viewCount   = static_cast<uint32_t>(mXrComponent.GetViewCount());
                     // Start new Imgui frame
                     if (mImGui) {
                         mImGui->NewFrame();
                     }
-                    for (uint32_t k = 0; k < viewCount; ++k) {
-                        mSwapchainIndex = k;
-                        mXrComponent.SetCurrentViewIndex(k);
-                        DispatchRender();
-                        grfx::SwapchainPtr swapchain = GetSwapchain(k + mStereoscopicSwapchainIndex);
-                        CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrColorSwapchain(), &releaseInfo));
-                        if (swapchain->GetXrDepthSwapchain() != XR_NULL_HANDLE) {
-                            CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrDepthSwapchain(), &releaseInfo));
-                        }
-                    }
-
-                    if (GetSettings()->enableImGui) {
-                        grfx::SwapchainPtr swapchain = GetSwapchain(mUISwapchainIndex);
-                        CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrColorSwapchain(), &releaseInfo));
-                        if (swapchain->GetXrDepthSwapchain() != XR_NULL_HANDLE) {
-                            CHECK_XR_CALL(xrReleaseSwapchainImage(swapchain->GetXrDepthSwapchain(), &releaseInfo));
-                        }
-                    }
+                    DispatchRender();
                 }
+
                 mXrComponent.EndFrame(mSwapchains, 0, mUISwapchainIndex);
             }
         }

--- a/src/ppx/grfx/grfx_swapchain.cpp
+++ b/src/ppx/grfx/grfx_swapchain.cpp
@@ -426,21 +426,13 @@ Result Swapchain::AcquireNextImage(
         PPX_ASSERT_MSG(mXrColorSwapchain != XR_NULL_HANDLE, "Invalid color xrSwapchain handle!");
         PPX_ASSERT_MSG(pSemaphore == nullptr, "Should not use semaphore when XR is enabled!");
         PPX_ASSERT_MSG(pFence == nullptr, "Should not use fence when XR is enabled!");
+
         XrSwapchainImageAcquireInfo acquire_info = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
         CHECK_XR_CALL(xrAcquireSwapchainImage(mXrColorSwapchain, &acquire_info, pImageIndex));
 
-        XrSwapchainImageWaitInfo wait_info = {XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
-        wait_info.timeout                  = XR_INFINITE_DURATION;
-        CHECK_XR_CALL(xrWaitSwapchainImage(mXrColorSwapchain, &wait_info));
-
         if (mXrDepthSwapchain != XR_NULL_HANDLE) {
-            uint32_t                    colorImageIndex = *pImageIndex;
-            XrSwapchainImageAcquireInfo acquire_info    = {XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+            uint32_t colorImageIndex = *pImageIndex;
             CHECK_XR_CALL(xrAcquireSwapchainImage(mXrDepthSwapchain, &acquire_info, pImageIndex));
-
-            XrSwapchainImageWaitInfo wait_info = {XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
-            wait_info.timeout                  = XR_INFINITE_DURATION;
-            CHECK_XR_CALL(xrWaitSwapchainImage(mXrDepthSwapchain, &wait_info));
 
             PPX_ASSERT_MSG(colorImageIndex == *pImageIndex, "Color and depth swapchain image indices are different");
         }
@@ -455,6 +447,26 @@ Result Swapchain::AcquireNextImage(
     return AcquireNextImageInternal(timeout, pSemaphore, pFence, pImageIndex);
 }
 
+Result Swapchain::Wait(uint32_t)
+{
+#if defined(PPX_BUILD_XR)
+    // Wait index is ignored.
+    if (mCreateInfo.pXrComponent != nullptr) {
+        PPX_ASSERT_MSG(mXrColorSwapchain != XR_NULL_HANDLE, "Invalid color xrSwapchain handle!");
+
+        XrSwapchainImageWaitInfo wait_info = {XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+        wait_info.timeout                  = XR_INFINITE_DURATION;
+        // Since timeout is infinite, this needs to return XR_SUCCESS
+        CHECK_XR_CALL(xrWaitSwapchainImage(mXrColorSwapchain, &wait_info));
+        PPX_LOG_INFO("Waited on the image from swapchain " << mXrColorSwapchain);
+        if (mXrDepthSwapchain != XR_NULL_HANDLE) {
+            CHECK_XR_CALL(xrWaitSwapchainImage(mXrDepthSwapchain, &wait_info));
+        }
+    }
+#endif
+    return ppx::SUCCESS;
+}
+
 Result Swapchain::Present(
     uint32_t                      imageIndex,
     uint32_t                      waitSemaphoreCount,
@@ -463,7 +475,20 @@ Result Swapchain::Present(
     if (IsHeadless()) {
         return PresentHeadless(imageIndex, waitSemaphoreCount, ppWaitSemaphores);
     }
+#if defined(PPX_BUILD_XR)
+    else if (mCreateInfo.pXrComponent != nullptr) {
+        PPX_ASSERT_MSG(mXrColorSwapchain != XR_NULL_HANDLE, "Invalid color xrSwapchain handle!");
+        PPX_ASSERT_MSG(waitSemaphoreCount == 0, "Should not use semaphore when XR is enabled");
+        PPX_ASSERT_MSG(ppWaitSemaphores == nullptr, "Should not use semaphore when XR is enabled");
 
+        XrSwapchainImageReleaseInfo releaseInfo = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+        CHECK_XR_CALL(xrReleaseSwapchainImage(GetXrColorSwapchain(), &releaseInfo));
+        if (GetXrDepthSwapchain() != XR_NULL_HANDLE) {
+            CHECK_XR_CALL(xrReleaseSwapchainImage(GetXrDepthSwapchain(), &releaseInfo));
+        }
+        return ppx::SUCCESS;
+    }
+#endif
     return PresentInternal(imageIndex, waitSemaphoreCount, ppWaitSemaphores);
 }
 

--- a/src/ppx/xr_component.cpp
+++ b/src/ppx/xr_component.cpp
@@ -581,7 +581,7 @@ void XrComponent::ConditionallyPopulateProjectionLayer(const std::vector<grfx::S
 
         if (mShouldSubmitDepthInfo && (swapchains[startIndex + i]->GetXrDepthSwapchain() != XR_NULL_HANDLE)) {
             PPX_ASSERT_MSG(mNearPlaneForFrame.has_value() && mFarPlaneForFrame.has_value(), "Depth info layer cannot be submitted because near and far plane values are not set. "
-                                                                                            "Call GetProjectionMatrixForCurrentViewAndSetFrustumPlanes to set per-frame values.");
+                                                                                            "Call GetProjectionMatrixForViewAndSetFrustumPlanes to set per-frame values.");
             XrCompositionLayerDepthInfoKHR depthInfo = {XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR};
             depthInfo.minDepth                       = 0.0f;
             depthInfo.maxDepth                       = 1.0f;
@@ -663,10 +663,10 @@ bool XrComponent::RemoveLayer(LayerRef layerRef)
     return mLayers.erase(layerRef);
 }
 
-glm::mat4 XrComponent::GetViewMatrixForCurrentView() const
+glm::mat4 XrComponent::GetViewMatrixForView(uint32_t viewIndex) const
 {
-    PPX_ASSERT_MSG((mCurrentViewIndex < mViews.size()), "Invalid view index!");
-    const XrView&  view = mViews[mCurrentViewIndex];
+    PPX_ASSERT_MSG((viewIndex < mViews.size()), "Invalid view index!");
+    const XrView&  view = mViews[viewIndex];
     const XrPosef& pose = view.pose;
     // OpenXR is using right handed system which is the same as Vulkan
     glm::quat quat         = glm::quat(pose.orientation.w, pose.orientation.x, pose.orientation.y, pose.orientation.z);
@@ -678,10 +678,10 @@ glm::mat4 XrComponent::GetViewMatrixForCurrentView() const
     return view_glm_inv;
 }
 
-glm::mat4 XrComponent::GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(float nearZ, float farZ)
+glm::mat4 XrComponent::GetProjectionMatrixForViewAndSetFrustumPlanes(uint32_t viewIndex, float nearZ, float farZ)
 {
-    PPX_ASSERT_MSG((mCurrentViewIndex < mViews.size()), "Invalid view index!");
-    const XrView& view = mViews[mCurrentViewIndex];
+    PPX_ASSERT_MSG((viewIndex < mViews.size()), "Invalid view index!");
+    const XrView& view = mViews[viewIndex];
     const XrFovf& fov  = view.fov;
 
     // Save near and far plane values so that they can be referenced
@@ -722,10 +722,10 @@ glm::mat4 XrComponent::GetProjectionMatrixForCurrentViewAndSetFrustumPlanes(floa
     return glm::make_mat4(mat);
 }
 
-XrPosef XrComponent::GetPoseForCurrentView() const
+XrPosef XrComponent::GetPoseForView(uint32_t viewIndex) const
 {
-    PPX_ASSERT_MSG((mCurrentViewIndex < mViews.size()), "Invalid view index!");
-    return mViews[mCurrentViewIndex].pose;
+    PPX_ASSERT_MSG((viewIndex < mViews.size()), "Invalid view index!");
+    return mViews[viewIndex].pose;
 }
 
 } // namespace ppx


### PR DESCRIPTION
Swapchain:
- Add Wait() method to swapchain, it is a no-op for non-XR. For XR it calls xrWaitSwapchainImage. Since the command buffer can be recorded between xrAcquireSwapchainImage and xrWaitSwapchainImage, putting xrWaitSwapchainImage in AcquireNextImage is unnecessarily restrictive.
- Add xrReleaseSwapchainImage to Present(). It is weird not to have a function for this and to do this in the main application loop, since the application already calls Acquire.

Remove calling Render() twice for XR and the viewIndex logic. It is very much application/project specific logic of how it decides to render two views, and can be easily handled in the application level. It also becomes more restrictive where application decides to render differently (for example, using a single command buffer for UI and both views, or with multiview