### PR TITLE
Benchmark: Initialize spheres on demand 

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -910,8 +910,7 @@ void GraphicsBenchmarkApp::ProcessKnobs()
 
     if (enableSpheres) {
         // Update sphere resources and mesh
-        const bool spheresAreSetUp = mSpheresAreSetUp;
-        if (!spheresAreSetUp) {
+        if (!mSpheresAreSetUp) {
             // This creates all resources.
             SetupSpheres();
         }
@@ -919,10 +918,6 @@ void GraphicsBenchmarkApp::ProcessKnobs()
             const bool requireMoreSpheres = sphereInstanceCountKnobChanged && (pSphereInstanceCount->GetValue() > mInitializedSpheres);
             if (requireMoreSpheres) {
                 SetupSphereMeshes();
-            }
-            // Rebuild pipelines
-            if (alphaBlendKnobChanged || depthTestWriteKnobChanged) {
-                SetupSpheresPipelines();
             }
             // Update descriptors
             if (allTexturesTo1x1KnobChanged) {

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -28,9 +28,10 @@
 #include <vector>
 #include <unordered_map>
 
-static constexpr uint32_t kMaxSphereInstanceCount  = 3000;
-static constexpr uint32_t kSeed                    = 89977;
-static constexpr uint32_t kMaxFullscreenQuadsCount = 1000;
+static constexpr uint32_t kMaxSphereInstanceCount     = 3000;
+static constexpr uint32_t kDefaultSphereInstanceCount = 50;
+static constexpr uint32_t kSeed                       = 89977;
+static constexpr uint32_t kMaxFullscreenQuadsCount    = 1000;
 
 static constexpr const char* kShaderBaseDir   = "benchmarks/shaders";
 static constexpr const char* kQuadTextureFile = "benchmarks/textures/resolution.jpg";
@@ -431,7 +432,8 @@ private:
     std::array<grfx::MeshPtr, kMeshCount>                         mSphereMeshes;
     std::vector<LOD>                                              mSphereLODs;
     MultiDimensionalIndexer                                       mMeshesIndexer;
-    bool                                                          mSpheresAreSetUp = false;
+    bool                                                          mSpheresAreSetUp    = false;
+    uint32_t                                                      mInitializedSpheres = 0;
 
     // Fullscreen quads resources
     Entity2D                                                             mFullscreenQuads;

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -511,6 +511,10 @@ private:
     void SetupSpheresPipelines();
     void SetupFullscreenQuadsPipelines();
 
+    // Setup everything:
+    // - Resources, vertex data and pipelines
+    void SetupSpheres();
+
     // Metrics related functions
     virtual void SetupMetrics() override;
     virtual void UpdateMetrics() override;


### PR DESCRIPTION
- It considerably reduces the startup time and memory by initializing only 100 spheres.