### PR TITLE
Add startup only flag for texture path for fullscreen quad

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -118,6 +118,9 @@ void GraphicsBenchmarkApp::InitKnobs()
     pFullscreenQuadsColor->SetFlagDescription("Select the hue for the solid color fullscreen quads (see --fullscreen-quads-count).");
     pFullscreenQuadsColor->SetIndent(2);
 
+    GetKnobManager().InitKnob(&pQuadTextureFile, "fullscreen-quads-texture-path", kQuadTextureFile);
+    pQuadTextureFile->SetFlagDescription("Texture used in fullscreen quads (see --fullscreen-quads-count) texture mode (see --fullscreen-quads-type).");
+
     GetKnobManager().InitKnob(&pFullscreenQuadsSingleRenderpass, "fullscreen-quads-single-renderpass", true);
     pFullscreenQuadsSingleRenderpass->SetDisplayName("Single Renderpass");
     pFullscreenQuadsSingleRenderpass->SetFlagDescription("Render all fullscreen quads (see --fullscreen-quads-count) in a single renderpass.");
@@ -404,7 +407,7 @@ void GraphicsBenchmarkApp::SetupFullscreenQuadsResources()
     {
         // Large resolution image
         grfx_util::TextureOptions options = grfx_util::TextureOptions().MipLevelCount(1);
-        PPX_CHECKED_CALL(CreateTextureFromFile(GetDevice()->GetGraphicsQueue(), GetAssetPath("benchmarks/textures/resolution.jpg"), &mQuadsTexture, options));
+        PPX_CHECKED_CALL(CreateTextureFromFile(GetDevice()->GetGraphicsQueue(), GetAssetPath(pQuadTextureFile->GetValue()), &mQuadsTexture, options));
     }
 
     // Descriptor set layout for texture shader

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -32,7 +32,8 @@ static constexpr uint32_t kMaxSphereInstanceCount  = 3000;
 static constexpr uint32_t kSeed                    = 89977;
 static constexpr uint32_t kMaxFullscreenQuadsCount = 1000;
 
-static constexpr const char* kShaderBaseDir = "benchmarks/shaders";
+static constexpr const char* kShaderBaseDir   = "benchmarks/shaders";
+static constexpr const char* kQuadTextureFile = "benchmarks/textures/resolution.jpg";
 
 static constexpr std::array<const char*, 2> kAvailableVsShaders = {
     "Benchmark_VsSimple",
@@ -415,6 +416,8 @@ private:
     BlitContext mBlit;
 
 private:
+    std::shared_ptr<KnobCheckbox>              pEnableSkyBox;
+    std::shared_ptr<KnobCheckbox>              pEnableSpheres;
     std::shared_ptr<KnobDropdown<std::string>> pKnobVs;
     std::shared_ptr<KnobDropdown<std::string>> pKnobPs;
     std::shared_ptr<KnobDropdown<std::string>> pKnobLOD;
@@ -422,15 +425,15 @@ private:
     std::shared_ptr<KnobDropdown<std::string>> pKnobVertexAttrLayout;
     std::shared_ptr<KnobSlider<int>>           pSphereInstanceCount;
     std::shared_ptr<KnobSlider<int>>           pDrawCallCount;
+    std::shared_ptr<KnobCheckbox>              pAlphaBlend;
+    std::shared_ptr<KnobCheckbox>              pDepthTestWrite;
+    std::shared_ptr<KnobCheckbox>              pAllTexturesTo1x1;
+
     std::shared_ptr<KnobSlider<int>>           pFullscreenQuadsCount;
     std::shared_ptr<KnobDropdown<std::string>> pFullscreenQuadsType;
     std::shared_ptr<KnobDropdown<std::string>> pFullscreenQuadsColor;
     std::shared_ptr<KnobCheckbox>              pFullscreenQuadsSingleRenderpass;
-    std::shared_ptr<KnobCheckbox>              pAlphaBlend;
-    std::shared_ptr<KnobCheckbox>              pDepthTestWrite;
-    std::shared_ptr<KnobCheckbox>              pEnableSkyBox;
-    std::shared_ptr<KnobCheckbox>              pEnableSpheres;
-    std::shared_ptr<KnobCheckbox>              pAllTexturesTo1x1;
+    std::shared_ptr<KnobFlag<std::string>>     pQuadTextureFile;
 
     std::shared_ptr<KnobCheckbox>              pRenderOffscreen;
     std::shared_ptr<KnobCheckbox>              pBlitOffscreen;


### PR DESCRIPTION
Usage example:
vk_graphics_pipeline.exe --fullscreen-quads-texture-path benchmarks/textures/bricks_1080p.png