### PR TITLE
Not for submission, some thought experiments

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -41,8 +41,11 @@ const grfx::Api kApi = grfx::API_DX_12_0;
 const grfx::Api kApi = grfx::API_VK_1_1;
 #endif
 
-void GraphicsBenchmarkApp::InitKnobs()
+void GraphicsBenchmarkApp::InitKnobs(ppx::StandardKnobsDefaultValues& defaultValues)
 {
+    defaultValues.enableMetrics        = true;
+    defaultValues.overwriteMetricsFile = true;
+
     const auto& cl_options = GetExtraOptions();
     PPX_ASSERT_MSG(!cl_options.HasExtraOption("vs-shader-index"), "--vs-shader-index flag has been replaced, instead use --vs and specify the name of the vertex shader");
     PPX_ASSERT_MSG(!cl_options.HasExtraOption("ps-shader-index"), "--ps-shader-index flag has been replaced, instead use --ps and specify the name of the pixel shader");
@@ -185,8 +188,6 @@ void GraphicsBenchmarkApp::Config(ppx::ApplicationSettings& settings)
     settings.xr.enable             = false; // Change this to true to enable the XR mode
     settings.xr.enableDebugCapture = false;
 #endif
-    settings.standardKnobsDefaultValue.enableMetrics        = true;
-    settings.standardKnobsDefaultValue.overwriteMetricsFile = true;
 }
 
 void GraphicsBenchmarkApp::Setup()

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -197,7 +197,7 @@ class GraphicsBenchmarkApp
 public:
     GraphicsBenchmarkApp()
         : mCamera(float3(0, 0, -5), pi<float>() / 2.0f, pi<float>() / 2.0f) {}
-    virtual void InitKnobs() override;
+    virtual void InitKnobs(ppx::StandardKnobsDefaultValues& defaultValues) override;
     virtual void Config(ppx::ApplicationSettings& settings) override;
     virtual void Setup() override;
     virtual void MouseMove(int32_t x, int32_t y, int32_t dx, int32_t dy, uint32_t buttons) override;

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -323,33 +323,33 @@ struct ApplicationSettings
             uint32_t     imageCount  = 2;
         } swapchain;
     } grfx;
+};
 
-    // Default values for standard knobs
-    struct StandardKnobsDefaultValue
-    {
-        std::vector<std::string> assetsPaths     = {};
-        std::vector<std::string> configJsonPaths = {};
-        bool                     deterministic   = false;
-        bool                     enableMetrics   = false;
-        uint64_t                 frameCount      = UINT64_MAX;
-        int                      gpuIndex        = INT_MAX;
+// Default values for standard knobs
+struct StandardKnobsDefaultValues
+{
+    std::vector<std::string> assetsPaths     = {};
+    std::vector<std::string> configJsonPaths = {};
+    bool                     deterministic   = false;
+    bool                     enableMetrics   = false;
+    uint64_t                 frameCount      = UINT64_MAX;
+    int                      gpuIndex        = INT_MAX;
 #if !defined(PPX_LINUX_HEADLESS)
-        bool headless = false;
+    bool headless = false;
 #endif
-        bool                listGpus              = false;
-        std::string         metricsFilename       = std::filesystem::current_path().u8string();
-        bool                overwriteMetricsFile  = false;
-        std::pair<int, int> resolution            = std::make_pair(0, 0);
-        int                 runTimeMs             = INT_MAX;
-        int                 screenshotFrameNumber = INT_MAX;
-        std::string         screenshotPath        = "";
-        int                 statsFrameWindow      = INT_MAX;
-        bool                useSoftwareRenderer   = false;
+    bool                listGpus              = false;
+    std::string         metricsFilename       = std::filesystem::current_path().u8string();
+    bool                overwriteMetricsFile  = false;
+    std::pair<int, int> resolution            = std::make_pair(0, 0);
+    int                 runTimeMs             = INT_MAX;
+    int                 screenshotFrameNumber = INT_MAX;
+    std::string         screenshotPath        = "";
+    int                 statsFrameWindow      = INT_MAX;
+    bool                useSoftwareRenderer   = false;
 #if defined(PPX_BUILD_XR)
-        std::pair<int, int>      xrUiResolution       = std::make_pair(0, 0);
-        std::vector<std::string> xrRequiredExtensions = {};
+    std::pair<int, int>      xrUiResolution       = std::make_pair(0, 0);
+    std::vector<std::string> xrRequiredExtensions = {};
 #endif
-    } standardKnobsDefaultValue;
 };
 
 //! @class Application
@@ -380,7 +380,7 @@ public:
     virtual void Scroll(float dx, float dy) {}                                                // Mouse wheel or touchpad scroll event
     virtual void Render() {}
     // Init knobs (adjustable parameters in the GUI that can be set at startup with commandline flags)
-    virtual void InitKnobs() {}
+    virtual void InitKnobs(ppx::StandardKnobsDefaultValues& defaults) {}
 
 protected:
     virtual void DispatchConfig();
@@ -397,6 +397,8 @@ protected:
     virtual void DispatchMouseUp(int32_t x, int32_t y, uint32_t buttons);
     virtual void DispatchScroll(float dx, float dy);
     virtual void DispatchRender();
+    // Is there even value in having protected DispatchInitKnobs
+    // if InitStandardKnobs is private?
     virtual void DispatchInitKnobs();
     virtual void DispatchUpdateMetrics();
     virtual void DrawGui(){}; // Draw additional project-related information to ImGui.
@@ -557,7 +559,12 @@ private:
     void SaveMetricsReportToDisk();
 
     // Initializes standard knobs
-    void InitStandardKnobs();
+    void InitStandardKnobs(const StandardKnobsDefaultValues& defaultValues);
+
+    void PrintHelpMessage() const;
+
+    // After this function mSettings has all values initialized and updated.
+    void InitializeAllSettings();
 
 private:
     friend struct WindowEvents;

--- a/include/ppx/command_line_parser.h
+++ b/include/ppx/command_line_parser.h
@@ -148,24 +148,10 @@ public:
 
     std::string       GetJsonConfigFlagName() const { return mJsonConfigFlagName; }
     const CliOptions& GetOptions() const { return mOpts; }
-    std::string       GetUsageMsg() const { return mUsageMsg; }
-
-    void AppendUsageMsg(const std::string& additionalMsg) { mUsageMsg += additionalMsg; }
 
 private:
     CliOptions  mOpts;
     std::string mJsonConfigFlagName = "config-json-path";
-    std::string mUsageMsg           = R"(
-USAGE
-==============================
-Boolean options can be turned on with:
-  --flag-name true, --flag-name 1, --flag-name
-And turned off with:
-  --flag-name false, --flag-name 0, --no-flag-name
-
---help : Prints this help message and exits.
-==============================
-)";
 };
 
 } // namespace ppx

--- a/include/ppx/knob.h
+++ b/include/ppx/knob.h
@@ -456,7 +456,6 @@ private:
     std::unordered_set<std::string> mFlagNames;
 
 public:
-    bool IsEmpty() { return mKnobs.empty(); }
     void ResetAllToDefault(); // The knobs can be reset to default by a button in the UI
 
     // Examples of available knobs:
@@ -483,7 +482,7 @@ public:
     }
 
     void        DrawAllKnobs(bool inExistingWindow = false);
-    std::string GetUsageMsg();
+    void        PrintFlags() const;
     void        UpdateFromFlags(const CliOptions& opts);
 
 private:

--- a/projects/01_triangle/Triangle.cpp
+++ b/projects/01_triangle/Triangle.cpp
@@ -29,6 +29,14 @@ void TriangleApp::Config(ApplicationSettings& settings)
     settings.grfx.api         = kApi;
     settings.grfx.enableDebug = false;
     settings.window.resizable = true;
+
+#if 0
+    // Same thing
+    settings.window.width = 512;
+    settings.window.height = 512;
+    // The following will always take precedence
+    settings.standardKnobsDefaultValue.resolution = std::make_pair(1024, 1024);
+#endif
 }
 
 void TriangleApp::Setup()

--- a/projects/04_cube_xr/CubeXr.cpp
+++ b/projects/04_cube_xr/CubeXr.cpp
@@ -33,6 +33,14 @@ void CubeXrApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.pacedFrameRate        = 0;
     settings.xr.enable                  = true;
     settings.xr.enableDebugCapture      = false;
+
+#if 0
+    // Same thing
+    settings.xr.uiWidth = 256;
+    settings.xr.uiHeight = 256;
+    // The following will always take precedence.
+    settings.standardKnobsDefaultValue.xrUiResolution = std::make_pair(512, 1024);
+#endif
 }
 
 void CubeXrApp::Setup()

--- a/projects/fluid_simulation/main.cpp
+++ b/projects/fluid_simulation/main.cpp
@@ -48,7 +48,7 @@
 
 namespace FluidSim {
 
-void ProjApp::InitKnobs()
+void ProjApp::InitKnobs(ppx::StandardKnobsDefaultValues&)
 {
     size_t indent = 2;
 

--- a/projects/fluid_simulation/sim.h
+++ b/projects/fluid_simulation/sim.h
@@ -249,7 +249,7 @@ private:
 class ProjApp : public ppx::Application
 {
 public:
-    virtual void            InitKnobs() override;
+    virtual void            InitKnobs(ppx::StandardKnobsDefaultValues&) override;
     virtual void            Config(ppx::ApplicationSettings& settings) override;
     virtual void            Setup() override;
     virtual void            Render() override;

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -645,8 +645,9 @@ void Application::DestroyPlatformWindow()
 
 void Application::DispatchInitKnobs()
 {
-    InitStandardKnobs();
-    InitKnobs();
+    StandardKnobsDefaultValues defaults;
+    InitKnobs(defaults);
+    InitStandardKnobs(defaults);
 }
 
 void Application::DispatchConfig()
@@ -787,16 +788,16 @@ void Application::SaveMetricsReportToDisk()
     report.WriteToDisk(mStandardOpts.pOverwriteMetricsFile->GetValue());
 }
 
-void Application::InitStandardKnobs()
+void Application::InitStandardKnobs(const StandardKnobsDefaultValues& defaultValues)
 {
     // Flag names in alphabetical order
     mStandardOpts.pAssetsPaths =
-        mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>("assets-path", mSettings.standardKnobsDefaultValue.assetsPaths);
+        mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>("assets-path", defaultValues.assetsPaths);
     mStandardOpts.pAssetsPaths->SetFlagDescription(
         "Add a path before the default assets folder in the search list.");
     mStandardOpts.pAssetsPaths->SetFlagParameters("<path>");
 
-    mStandardOpts.pConfigJsonPaths = mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>(mCommandLineParser.GetJsonConfigFlagName(), mSettings.standardKnobsDefaultValue.configJsonPaths);
+    mStandardOpts.pConfigJsonPaths = mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>(mCommandLineParser.GetJsonConfigFlagName(), defaultValues.configJsonPaths);
     mStandardOpts.pConfigJsonPaths->SetFlagDescription(
         "Additional commandline flags specified in a JSON file. Values specified in JSON files are "
         "always overwritten by those specified on the command line. Between different files, the "
@@ -804,42 +805,42 @@ void Application::InitStandardKnobs()
     mStandardOpts.pConfigJsonPaths->SetFlagParameters("<path>");
 
     mStandardOpts.pDeterministic =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("deterministic", mSettings.standardKnobsDefaultValue.deterministic);
+        mKnobManager.CreateKnob<KnobFlag<bool>>("deterministic", defaultValues.deterministic);
     mStandardOpts.pDeterministic->SetFlagDescription(
         "Disable non-deterministic behaviors, like clocks.");
 
     mStandardOpts.pEnableMetrics =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("enable-metrics", mSettings.standardKnobsDefaultValue.enableMetrics);
+        mKnobManager.CreateKnob<KnobFlag<bool>>("enable-metrics", defaultValues.enableMetrics);
     mStandardOpts.pEnableMetrics->SetFlagDescription(
         "Enable metrics report output. See also: `--metrics-filename` and `--overwrite-metrics-file`.");
 
     mStandardOpts.pFrameCount =
-        mKnobManager.CreateKnob<KnobFlag<uint64_t>>("frame-count", 0, 0, mSettings.standardKnobsDefaultValue.frameCount);
+        mKnobManager.CreateKnob<KnobFlag<uint64_t>>("frame-count", 0, 0, defaultValues.frameCount);
     mStandardOpts.pFrameCount->SetFlagDescription(
         "Shutdown the application after successfully rendering N frames. "
         "Default: 0 (infinite)");
 
     mStandardOpts.pGpuIndex =
-        mKnobManager.CreateKnob<KnobFlag<int>>("gpu", 0, 0, mSettings.standardKnobsDefaultValue.gpuIndex);
+        mKnobManager.CreateKnob<KnobFlag<int>>("gpu", 0, 0, defaultValues.gpuIndex);
     mStandardOpts.pGpuIndex->SetFlagDescription(
         "Select the gpu with the given index. To determine the set of valid "
         "indices use --list-gpus.");
 
 #if !defined(PPX_LINUX_HEADLESS)
     mStandardOpts.pHeadless =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("headless", mSettings.standardKnobsDefaultValue.headless);
+        mKnobManager.CreateKnob<KnobFlag<bool>>("headless", defaultValues.headless);
     mStandardOpts.pHeadless->SetFlagDescription(
         "Run the sample without creating windows.");
 #endif
 
     mStandardOpts.pListGpus =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("list-gpus", mSettings.standardKnobsDefaultValue.listGpus);
+        mKnobManager.CreateKnob<KnobFlag<bool>>("list-gpus", defaultValues.listGpus);
     mStandardOpts.pListGpus->SetFlagDescription(
         "Prints a list of the available GPUs on the current system with their "
         "index and exits (see --gpu).");
 
     mStandardOpts.pMetricsFilename =
-        mKnobManager.CreateKnob<KnobFlag<std::string>>("metrics-filename", mSettings.standardKnobsDefaultValue.metricsFilename);
+        mKnobManager.CreateKnob<KnobFlag<std::string>>("metrics-filename", defaultValues.metricsFilename);
     mStandardOpts.pMetricsFilename->SetFlagDescription(
         "If metrics are enabled, save the metrics report to the "
         "provided filename (including path). If used, any `@` "
@@ -849,7 +850,7 @@ void Application::InitStandardKnobs()
         "`--enable-metrics` and `--overwrite-metrics-file`.");
 
     mStandardOpts.pOverwriteMetricsFile =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("overwrite-metrics-file", mSettings.standardKnobsDefaultValue.overwriteMetricsFile);
+        mKnobManager.CreateKnob<KnobFlag<bool>>("overwrite-metrics-file", defaultValues.overwriteMetricsFile);
     mStandardOpts.pOverwriteMetricsFile->SetFlagDescription(
         "Only applies if metrics are enabled with `--enable-metrics`. "
         "If an existing file at the path set with `--metrics-filename` is found, it will be overwritten. "
@@ -857,7 +858,7 @@ void Application::InitStandardKnobs()
 
     mStandardOpts.pResolution =
         mKnobManager.CreateKnob<KnobFlag<std::pair<int, int>>>(
-            "resolution", mSettings.standardKnobsDefaultValue.resolution);
+            "resolution", defaultValues.resolution);
     mStandardOpts.pResolution->SetFlagDescription(
         "Specify the main window resolution in pixels. Width and Height must be "
         "two positive integers greater or equal to 1. (Default: Window dimensions)");
@@ -872,31 +873,31 @@ void Application::InitStandardKnobs()
     });
 
     mStandardOpts.pRunTimeMs =
-        mKnobManager.CreateKnob<KnobFlag<int>>("run-time-ms", 0, 0, mSettings.standardKnobsDefaultValue.runTimeMs);
+        mKnobManager.CreateKnob<KnobFlag<int>>("run-time-ms", 0, 0, defaultValues.runTimeMs);
     mStandardOpts.pRunTimeMs->SetFlagDescription(
         "Shutdown the application after N milliseconds. Default: 0 (infinite).");
 
     mStandardOpts.pScreenshotFrameNumber =
-        mKnobManager.CreateKnob<KnobFlag<int>>("screenshot-frame-number", -1, -1, mSettings.standardKnobsDefaultValue.screenshotFrameNumber);
+        mKnobManager.CreateKnob<KnobFlag<int>>("screenshot-frame-number", -1, -1, defaultValues.screenshotFrameNumber);
     mStandardOpts.pScreenshotFrameNumber->SetFlagDescription(
         "Take a screenshot of frame number N and save it in PPM format. See also "
         "`--screenshot-path`.");
 
     mStandardOpts.pScreenshotPath =
-        mKnobManager.CreateKnob<KnobFlag<std::string>>("screenshot-path", mSettings.standardKnobsDefaultValue.screenshotPath);
+        mKnobManager.CreateKnob<KnobFlag<std::string>>("screenshot-path", defaultValues.screenshotPath);
     mStandardOpts.pScreenshotPath->SetFlagDescription(
         "Save the screenshot to this path. Default: \"screenshot_frame<N>.ppm\" "
         "in the current working directory.");
     mStandardOpts.pScreenshotPath->SetFlagParameters("<path>");
 
     mStandardOpts.pStatsFrameWindow = mKnobManager.CreateKnob<KnobFlag<int>>(
-        "stats-frame-window", -1, -1, mSettings.standardKnobsDefaultValue.statsFrameWindow);
+        "stats-frame-window", -1, -1, defaultValues.statsFrameWindow);
     mStandardOpts.pStatsFrameWindow->SetFlagDescription(
         "Calculate frame statistics over the last N frames only. Set to 0 to use "
         "all frames since the beginning of the application.");
 
     mStandardOpts.pUseSoftwareRenderer =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("use-software-renderer", mSettings.standardKnobsDefaultValue.useSoftwareRenderer);
+        mKnobManager.CreateKnob<KnobFlag<bool>>("use-software-renderer", defaultValues.useSoftwareRenderer);
     mStandardOpts.pUseSoftwareRenderer->SetFlagDescription(
         "Use a software renderer instead of a hardware device, if available.");
     mStandardOpts.pUseSoftwareRenderer->SetValidator([gpuIndex{mStandardOpts.pGpuIndex->GetValue()}](bool useSoftwareRenderer) {
@@ -907,7 +908,7 @@ void Application::InitStandardKnobs()
 #if defined(PPX_BUILD_XR)
     mStandardOpts.pXrUiResolution =
         mKnobManager.CreateKnob<KnobFlag<std::pair<int, int>>>(
-            "xr-ui-resolution", mSettings.standardKnobsDefaultValue.xrUiResolution);
+            "xr-ui-resolution", defaultValues.xrUiResolution);
     mStandardOpts.pXrUiResolution->SetFlagDescription(
         "Specify the UI quad resolution in pixels. Width and Height must be two "
         "positive integers greater or equal to 1.");
@@ -918,7 +919,7 @@ void Application::InitStandardKnobs()
 
     mStandardOpts.pXrRequiredExtensions =
         mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>(
-            "xr-required-extension", mSettings.standardKnobsDefaultValue.xrRequiredExtensions);
+            "xr-required-extension", defaultValues.xrRequiredExtensions);
     mStandardOpts.pXrRequiredExtensions->SetFlagDescription(
         "Specify any additional OpenXR extensions that need to be loaded in addition "
         "to the base extensions. Any required extensions that are not supported by the "
@@ -1142,47 +1143,28 @@ bool Application::IsRunning() const
     return mWindow->IsRunning();
 }
 
-int Application::Run(int argc, char** argv)
+void Application::PrintHelpMessage() const
 {
-    // Only allow one instance of Application. Since we can't stop
-    // the app in the ctor - stop it here.
-    //
-    if (this != sApplicationInstance) {
-        return false;
-    }
+    std::string mUsageMsg = R"(
+USAGE
+==============================
+Boolean options can be turned on with:
+  --flag-name true, --flag-name 1, --flag-name
+And turned off with:
+  --flag-name false, --flag-name 0, --no-flag-name
 
-    // Parse args.
-    if (Failed(mCommandLineParser.Parse(argc, const_cast<const char**>(argv)))) {
-        PPX_ASSERT_MSG(false, "Unable to parse command line arguments");
-        return EXIT_FAILURE;
-    }
+--help : Prints this help message and exits.
+==============================
+)";
+    PPX_LOG_INFO(mUsageMsg);
+    mKnobManager.PrintFlags();
+}
 
+void Application::InitializeAllSettings()
+{
     // Call config.
     // Put this early because it might disable the display.
     DispatchConfig();
-
-    // Knobs need to be set up before commandline parsing.
-    // This has dependency on DispatchConfig() where standard knob default values are set
-    DispatchInitKnobs();
-
-    if (!mKnobManager.IsEmpty()) {
-        mCommandLineParser.AppendUsageMsg(mKnobManager.GetUsageMsg());
-    }
-
-    if (mCommandLineParser.GetOptions().GetOptionValueOrDefault("help", false)) {
-        PPX_LOG_INFO(mCommandLineParser.GetUsageMsg());
-        return EXIT_SUCCESS;
-    }
-
-    // Command line will overwrite the knob settings from the application
-    if (!mKnobManager.IsEmpty()) {
-        auto options = mCommandLineParser.GetOptions();
-        mKnobManager.UpdateFromFlags(options);
-    }
-
-    // Asset directories based on settings in mSettings, mCommandLineParser and mKnobManager
-    // note that mKnobManager needs to be updated by options from mCommandLineParser before this call
-    UpdateAssetDirs();
 
     if (mSettings.appName.empty()) {
         mSettings.appName = "PPX Application";
@@ -1190,7 +1172,6 @@ int Application::Run(int argc, char** argv)
     if (mSettings.window.title.empty()) {
         mSettings.window.title = mSettings.appName;
     }
-    mDecoratedApiName = ToString(mSettings.grfx.api);
 
 #if defined(PPX_LINUX_HEADLESS)
     // Force headless if BigWheels was built without surface support.
@@ -1198,19 +1179,6 @@ int Application::Run(int argc, char** argv)
 #else
     mSettings.headless = mStandardOpts.pHeadless->GetValue();
 #endif
-
-    if (!mWindow) {
-        if (mSettings.headless) {
-            mWindow = Window::GetImplHeadless(this);
-        }
-        else {
-            mWindow = Window::GetImplNative(this);
-        }
-        if (!mWindow) {
-            PPX_ASSERT_MSG(false, "out of memory");
-            return EXIT_FAILURE;
-        }
-    }
 
     // If command line argument provided width and height
     auto resolution        = mStandardOpts.pResolution->GetValue();
@@ -1228,16 +1196,65 @@ int Application::Run(int argc, char** argv)
     }
 #endif
 
-    mRunTimeSeconds = mStandardOpts.pRunTimeMs->GetValue() / 1000.f;
-    if (mRunTimeSeconds == 0) {
-        mRunTimeSeconds = std::numeric_limits<float>::max();
-    }
-
     // Disable ImGui in headless or deterministic mode.
     // ImGUI is not non-deterministic, but the visible informations (stats, timers) are.
     if ((mSettings.headless || mStandardOpts.pDeterministic->GetValue()) && mSettings.enableImGui) {
         mSettings.enableImGui = false;
         PPX_LOG_WARN("Headless or deterministic mode: disabling ImGui");
+    }
+}
+
+int Application::Run(int argc, char** argv)
+{
+    // Only allow one instance of Application. Since we can't stop
+    // the app in the ctor - stop it here.
+    //
+    if (this != sApplicationInstance) {
+        return false;
+    }
+
+    // Parse args.
+    if (Failed(mCommandLineParser.Parse(argc, const_cast<const char**>(argv)))) {
+        PPX_ASSERT_MSG(false, "Unable to parse command line arguments");
+        return EXIT_FAILURE;
+    }
+
+    // Knobs need to be set up before commandline parsing.
+    DispatchInitKnobs();
+
+    if (mCommandLineParser.GetOptions().GetOptionValueOrDefault("help", false)) {
+        PrintHelpMessage();
+        return EXIT_SUCCESS;
+    }
+
+    // Command line will overwrite the knob settings from the application
+    auto options = mCommandLineParser.GetOptions();
+    mKnobManager.UpdateFromFlags(options);
+
+    InitializeAllSettings();
+
+    // Asset directories based on settings in mSettings, mCommandLineParser and mKnobManager
+    // note that mKnobManager needs to be updated by options from mCommandLineParser before this call
+    UpdateAssetDirs();
+
+    mDecoratedApiName = ToString(mSettings.grfx.api);
+
+    mRunTimeSeconds = mStandardOpts.pRunTimeMs->GetValue() / 1000.f;
+    if (mRunTimeSeconds == 0) {
+        mRunTimeSeconds = std::numeric_limits<float>::max();
+    }
+
+    if (!mWindow) {
+        if (mSettings.headless) {
+            mWindow = Window::GetImplHeadless(this);
+        }
+        else {
+            mWindow = Window::GetImplNative(this);
+        }
+        if (!mWindow) {
+            PPX_ASSERT_MSG(false, "out of memory");
+            return EXIT_FAILURE;
+        }
     }
 
     // Initialize the platform
@@ -1263,6 +1280,10 @@ int Application::Run(int argc, char** argv)
         createInfo.enableDebug          = mSettings.grfx.enableDebug;
         createInfo.enableQuadLayer      = mSettings.enableImGui;
         createInfo.enableDepthSwapchain = mSettings.xr.enableDepthSwapchain;
+
+        // Note: adding a default value will make hasResolutionFlag true.
+        auto resolution        = mStandardOpts.pResolution->GetValue();
+        bool hasResolutionFlag = (resolution.first > 0 && resolution.second > 0);
         if (hasResolutionFlag) {
             createInfo.resolution.width  = mSettings.window.width;
             createInfo.resolution.height = mSettings.window.height;

--- a/src/ppx/knob.cpp
+++ b/src/ppx/knob.cpp
@@ -124,7 +124,7 @@ void KnobManager::DrawAllKnobs(bool inExistingWindow)
     }
 }
 
-std::string KnobManager::GetUsageMsg()
+void KnobManager::PrintFlags() const
 {
     std::string usageMsg = "\nFlags:\n";
     for (const auto& knobPtr : mKnobs) {
@@ -138,7 +138,7 @@ std::string KnobManager::GetUsageMsg()
         }
         usageMsg += knobMsg + "\n";
     }
-    return usageMsg;
+    PPX_LOG_INFO(usageMsg);
 }
 
 void KnobManager::UpdateFromFlags(const CliOptions& opts)

--- a/src/test/knob_test.cpp
+++ b/src/test/knob_test.cpp
@@ -465,11 +465,6 @@ TEST_F(KnobTestFixture, KnobFlag_CreateListInts)
 // KnobManager
 // -------------------------------------------------------------------------------------------------
 
-TEST_F(KnobManagerTestFixture, KnobManager_Create)
-{
-    EXPECT_TRUE(km.IsEmpty());
-}
-
 TEST_F(KnobManagerTestFixture, KnobManager_CreateBoolCheckbox)
 {
     std::shared_ptr<KnobCheckbox> boolKnobPtr(km.CreateKnob<KnobCheckbox>("flag_name1", true));
@@ -570,6 +565,7 @@ TEST_F(KnobManagerTestFixture, KnobManager_CreateUniqueName)
 }
 #endif
 
+#if 0
 TEST_F(KnobManagerWithKnobsTestFixture, KnobManager_GetBasicUsageMsg)
 {
     std::string usageMsg = R"(
@@ -628,6 +624,7 @@ Flags:
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);
 }
+#endif
 
 TEST_F(KnobManagerWithKnobsTestFixture, KnobManager_ResetAllToDefault)
 {


### PR DESCRIPTION
- There is a bit of a weird relationship between settings and default values for things that repeat: resolution and XR UI resolution. If the defaults for those are provided then the values in the settings will be overwritten. Might not be a problem, but might not be immediately obvious.

- There is an ordering dependencies between some functions in the beginning of Run(). They seem to be documented, but comments don't seem to be the best way for this, as some comments already might cause confusion. This explores the option of providing defaults in the InitKnobs instead of as part of the settings.

- Removing the storage for the flags in command line parser, this seems to be only needed for `--help`, so it shouldn't be necessary to store that.