### PR TITLE
[do not submit, breaking into smaller pieces] Fixes and better usage message for StandardOptions default values

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -85,14 +85,14 @@ void GraphicsBenchmarkApp::InitKnobs()
     pKnobVertexAttrLayout->SetFlagDescription("Select the Vertex Attribute Layout for the graphics pipeline.");
     pKnobVertexAttrLayout->SetIndent(1);
 
-    GetKnobManager().InitKnob(&pSphereInstanceCount, "sphere-count", /* defaultValue = */ 50, /* minValue = */ 1, kMaxSphereInstanceCount);
+    GetKnobManager().InitKnob(&pSphereInstanceCount, "sphere-count", 50, 1, kMaxSphereInstanceCount);
     pSphereInstanceCount->SetDisplayName("Sphere Count");
     pSphereInstanceCount->SetFlagDescription("Select the number of spheres to draw on the screen.");
     pSphereInstanceCount->SetIndent(1);
 
-    GetKnobManager().InitKnob(&pDrawCallCount, "drawcall-count", /* defaultValue = */ 1, /* minValue = */ 1, kMaxSphereInstanceCount);
+    GetKnobManager().InitKnob(&pDrawCallCount, "drawcall-count", 1, 1, kMaxSphereInstanceCount);
     pDrawCallCount->SetDisplayName("DrawCall Count");
-    pDrawCallCount->SetFlagDescription("Select the number of draw calls to be used to draw the `sphere-count` spheres.");
+    pDrawCallCount->SetFlagDescription("Select the number of draw calls to be used to draw the `--sphere-count` spheres.");
     pDrawCallCount->SetIndent(1);
 
     GetKnobManager().InitKnob(&pAlphaBlend, "alpha-blend", false);
@@ -102,29 +102,29 @@ void GraphicsBenchmarkApp::InitKnobs()
 
     GetKnobManager().InitKnob(&pDepthTestWrite, "depth-test-write", true);
     pDepthTestWrite->SetDisplayName("Depth Test & Write");
-    pDepthTestWrite->SetFlagDescription("Enable depth test and depth write for spheres (Default: enabled).");
+    pDepthTestWrite->SetFlagDescription("Enable depth test and depth write for spheres.");
     pDepthTestWrite->SetIndent(1);
 
-    GetKnobManager().InitKnob(&pFullscreenQuadsCount, "fullscreen-quads-count", /* defaultValue = */ 0, /* minValue = */ 0, kMaxFullscreenQuadsCount);
+    GetKnobManager().InitKnob(&pFullscreenQuadsCount, "fullscreen-quads-count", 0, 0, kMaxFullscreenQuadsCount);
     pFullscreenQuadsCount->SetDisplayName("Number of Fullscreen Quads");
     pFullscreenQuadsCount->SetFlagDescription("Select the number of fullscreen quads to render.");
 
     GetKnobManager().InitKnob(&pFullscreenQuadsType, "fullscreen-quads-type", 0, kFullscreenQuadsTypes);
     pFullscreenQuadsType->SetDisplayName("Type");
-    pFullscreenQuadsType->SetFlagDescription("Select the type of the fullscreen quads (see --fullscreen-quads-count).");
+    pFullscreenQuadsType->SetFlagDescription("Select the type of the fullscreen quads. See `--fullscreen-quads-count`.");
     pFullscreenQuadsType->SetIndent(1);
 
     GetKnobManager().InitKnob(&pFullscreenQuadsColor, "fullscreen-quads-color", 0, kFullscreenQuadsColors);
     pFullscreenQuadsColor->SetDisplayName("Color");
-    pFullscreenQuadsColor->SetFlagDescription("Select the hue for the solid color fullscreen quads (see --fullscreen-quads-count).");
+    pFullscreenQuadsColor->SetFlagDescription("Select the hue for the solid color fullscreen quads. See `--fullscreen-quads-count`.");
     pFullscreenQuadsColor->SetIndent(2);
 
     GetKnobManager().InitKnob(&pQuadTextureFile, "fullscreen-quads-texture-path", kQuadTextureFile);
-    pQuadTextureFile->SetFlagDescription("Texture used in fullscreen quads (see --fullscreen-quads-count) texture mode (see --fullscreen-quads-type).");
+    pQuadTextureFile->SetFlagDescription("Texture used in fullscreen quads texture mode. See `--fullscreen-quads-count` and `--fullscreen-quads-type`.");
 
     GetKnobManager().InitKnob(&pFullscreenQuadsSingleRenderpass, "fullscreen-quads-single-renderpass", true);
     pFullscreenQuadsSingleRenderpass->SetDisplayName("Single Renderpass");
-    pFullscreenQuadsSingleRenderpass->SetFlagDescription("Render all fullscreen quads (see --fullscreen-quads-count) in a single renderpass.");
+    pFullscreenQuadsSingleRenderpass->SetFlagDescription("Render all fullscreen quads in a single renderpass. See `--fullscreen-quads-count`");
     pFullscreenQuadsSingleRenderpass->SetIndent(1);
 
     // Offscreen rendering knobs:

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -327,23 +327,23 @@ struct ApplicationSettings
     // Default values for standard knobs
     struct StandardKnobsDefaultValue
     {
-        std::vector<std::string> assetsPaths     = {};
-        std::vector<std::string> configJsonPaths = {};
-        bool                     deterministic   = false;
-        bool                     enableMetrics   = false;
-        uint64_t                 frameCount      = UINT64_MAX;
-        int                      gpuIndex        = INT_MAX;
+        const std::vector<std::string> assetsPaths     = {};
+        const std::vector<std::string> configJsonPaths = {};
+        bool                           deterministic   = false;
+        bool                           enableMetrics   = false;
+        uint64_t                       frameCount      = 0;
+        int                            gpuIndex        = 0;
 #if !defined(PPX_LINUX_HEADLESS)
         bool headless = false;
 #endif
         bool                listGpus              = false;
-        std::string         metricsFilename       = std::filesystem::current_path().u8string();
+        std::string         metricsFilename       = "report_@.json";
         bool                overwriteMetricsFile  = false;
         std::pair<int, int> resolution            = std::make_pair(0, 0);
-        int                 runTimeMs             = INT_MAX;
-        int                 screenshotFrameNumber = INT_MAX;
-        std::string         screenshotPath        = "";
-        int                 statsFrameWindow      = INT_MAX;
+        int                 runTimeMs             = 0;
+        int                 screenshotFrameNumber = -1;
+        std::string         screenshotPath        = "screenshot_frame#.ppm";
+        int                 statsFrameWindow      = -1;
         bool                useSoftwareRenderer   = false;
 #if defined(PPX_BUILD_XR)
         std::pair<int, int>      xrUiResolution       = std::make_pair(0, 0);
@@ -534,7 +534,6 @@ public:
 #endif
 private:
     void   InternalCtor();
-    void   InitializeAssetDirs();
     Result InitializePlatform();
     Result InitializeGrfxDevice();
     Result InitializeGrfxSurface();

--- a/include/ppx/fs.h
+++ b/include/ppx/fs.h
@@ -143,6 +143,10 @@ std::filesystem::path GetInternalDataPath();
 std::filesystem::path GetExternalDataPath();
 #endif
 
+// Constructs the full path from a possibly partial path
+// If `regexToReplace` is specified, replace all instances of that symbol in the filename with `replaceString`
+std::filesystem::path GetFullPath(const std::filesystem::path& partialPath, const std::filesystem::path& defaultFolder, const std::filesystem::path& ext, const std::string& regexToReplace = "", const std::string& replaceString = "");
+
 } // namespace ppx::fs
 
 #endif // ppx_fs_h

--- a/include/ppx/metrics.h
+++ b/include/ppx/metrics.h
@@ -265,8 +265,7 @@ public:
     std::string GetContentString() const;
 
 private:
-    static constexpr const char* kFileExtension     = ".json";
-    static constexpr const char* kDefaultReportPath = "report_@";
+    static constexpr const char* kFileExtension = ".json";
 
 private:
     void SetReportPath(const std::string& reportPath);

--- a/src/ppx/fs.cpp
+++ b/src/ppx/fs.cpp
@@ -16,8 +16,9 @@
 #include "ppx/config.h"
 
 #include <filesystem>
-#include <vector>
+#include <regex>
 #include <optional>
+#include <vector>
 
 #if defined(PPX_ANDROID)
 #include <android_native_app_glue.h>
@@ -189,5 +190,29 @@ std::filesystem::path GetExternalDataPath()
     return std::filesystem::path(gAndroidContext->activity->externalDataPath);
 }
 #endif
+
+std::filesystem::path GetFullPath(const std::filesystem::path& partialPath, const std::filesystem::path& defaultFolder, const std::filesystem::path& ext, const std::string& regexToReplace, const std::string& replaceString)
+{
+    PPX_ASSERT_MSG(partialPath.u8string() != "", "Partial path cannot be empty string");
+    PPX_ASSERT_MSG(partialPath.has_filename(), "Partial path cannot be a folder");
+
+    std::filesystem::path fullPath = partialPath;
+
+    if (regexToReplace != "") {
+        std::string fileName    = fullPath.filename().string();
+        std::string newfileName = std::regex_replace(fileName, std::regex(regexToReplace), replaceString);
+        fullPath.replace_filename(std::filesystem::path(newfileName));
+    }
+
+    if (!fullPath.has_parent_path()) {
+        fullPath = defaultFolder / fullPath;
+    }
+
+    if (fullPath.extension() != ext) {
+        fullPath.replace_extension(ext);
+    }
+
+    return fullPath;
+}
 
 } // namespace ppx::fs

--- a/src/ppx/knob.cpp
+++ b/src/ppx/knob.cpp
@@ -132,8 +132,10 @@ std::string KnobManager::GetUsageMsg()
         if (knobPtr->mFlagParameters != "") {
             knobMsg += " " + knobPtr->mFlagParameters;
         }
+        knobMsg += "\n";
+        std::string knobDefault = "(Default: " + knobPtr->ValueString() + ")";
+        knobMsg += ppx::string_util::WrapText(knobDefault, kUsageMsgTotalWidth, kUsageMsgIndentWidth);
         if (knobPtr->mFlagDescription != "") {
-            knobMsg += "\n";
             knobMsg += ppx::string_util::WrapText(knobPtr->mFlagDescription, kUsageMsgTotalWidth, kUsageMsgIndentWidth);
         }
         usageMsg += knobMsg + "\n";

--- a/src/ppx/ppm_export.cpp
+++ b/src/ppx/ppm_export.cpp
@@ -14,6 +14,8 @@
 
 #include "ppx/ppm_export.h"
 
+#include <filesystem>
+
 namespace ppx {
 
 unsigned char ConvertToUint(const char* value, grfx::FormatDataType dataType)
@@ -44,6 +46,7 @@ bool IsOptimalFormat(const grfx::FormatDesc* desc, uint32_t width, uint32_t rowS
 
 Result ExportToPPM(const std::string& outputFilename, grfx::Format inputFormat, const void* texels, uint32_t width, uint32_t height, uint32_t rowStride)
 {
+    std::filesystem::create_directories(std::filesystem::path(outputFilename).parent_path());
     std::ofstream file(outputFilename, std::ios::out | std::ios::binary | std::ios::trunc);
     ppx::Result   result = ExportToPPM(file, inputFormat, texels, width, height, rowStride);
     file.close();

--- a/src/test/knob_test.cpp
+++ b/src/test/knob_test.cpp
@@ -575,15 +575,35 @@ TEST_F(KnobManagerWithKnobsTestFixture, KnobManager_GetBasicUsageMsg)
     std::string usageMsg = R"(
 Flags:
 --flag_name1 <true|false>
+                    (Default: true)
+
 --flag_name2 <true|false>
+                    (Default: true)
+
 --flag_name3 <0~10>
+                    (Default: 5)
+
 --flag_name4 <c1|c2|"c3 and more">
+                    (Default: c2)
+
 --flag_name5
+                    (Default: true)
+
 --flag_name6
+                    (Default: 6.6)
+
 --flag_name7
+                    (Default: 8)
+
 --flag_name8 <0.0~10.0>
+                    (Default: 5)
+
 --flag_name9
+                    (Default: 1, 2)
+
 --flag_name10
+                    (Default: a, b, c, d and more)
+
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);
 }
@@ -606,25 +626,40 @@ TEST_F(KnobManagerWithKnobsTestFixture, KnobManager_GetCustomizedUsageMsg)
     std::string usageMsg = R"(
 Flags:
 --flag_name1 <bool>
+                    (Default: true)
                     description1
 
 --flag_name2 <true|false>
+                    (Default: true)
+
 --flag_name3 <N>
+                    (Default: 5)
                     description3
 
 --flag_name4 <c1|c2|"c3 and more">
+                    (Default: c2)
                     description4
 
 --flag_name5 <0|1>
+                    (Default: true)
+
 --flag_name6 <0.0~10.0>
+                    (Default: 6.6)
                     description6
 
 --flag_name7 <0~INT_MAX>
+                    (Default: 8)
+
 --flag_name8 <0.000~10.000>
+                    (Default: 5)
+
 --flag_name9
+                    (Default: 1, 2)
                     description9
 
 --flag_name10 <string>
+                    (Default: a, b, c, d and more)
+
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);
 }


### PR DESCRIPTION
Fixes:
* For ranged knobs, the max value was erroneously being used as default value
* Default metrics path was not working as described in the help message

New:
* Usage message will now show default values

Changes:
* `--assets-path` renamed to `--extra-assets-path` for clarity
* `--metrics-filename` renamed to `--metrics-path`
* Logic for `--metrics-path` and `--screenshot-path` is made similar for ease of use & helper function `ppx::fs::GetFullPath` is added
* Removed `InitializeAssetDirs()` and shifted what it does into `UpdateAssetDirs()` instead
* Using more concise `InitKnob()` syntax for creating standard options knobs