### PR TITLE
Experimental: more knob template shenanigans

### DIFF
--- a/src/ppx/knob.cpp
+++ b/src/ppx/knob.cpp
@@ -42,50 +42,6 @@ bool Knob::DigestUpdate()
 }
 
 // -------------------------------------------------------------------------------------------------
-// KnobCheckbox
-// -------------------------------------------------------------------------------------------------
-
-KnobCheckbox::KnobCheckbox(const std::string& flagName, bool defaultValue)
-    : Knob(flagName, true), mValue(defaultValue), mDefaultValue(defaultValue)
-{
-    SetFlagParameters("<true|false>");
-    RaiseUpdatedFlag();
-}
-
-void KnobCheckbox::Draw()
-{
-    if (!ImGui::Checkbox(mDisplayName.c_str(), &mValue)) {
-        return;
-    }
-    RaiseUpdatedFlag();
-}
-
-std::string KnobCheckbox::ValueString()
-{
-    return ppx::string_util::ToString(mValue);
-}
-
-void KnobCheckbox::UpdateFromFlags(const CliOptions& opts)
-{
-    SetDefaultAndValue(opts.GetOptionValueOrDefault(mFlagName, mValue));
-}
-
-void KnobCheckbox::SetValue(bool newValue)
-{
-    if (newValue == mValue) {
-        return;
-    }
-    mValue = newValue;
-    RaiseUpdatedFlag();
-}
-
-void KnobCheckbox::SetDefaultAndValue(bool newValue)
-{
-    mDefaultValue = newValue;
-    ResetToDefault();
-}
-
-// -------------------------------------------------------------------------------------------------
 // KnobManager
 // -------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
DO NOT SUBMIT
This is a thought experiment or template shenanigan as I'd like to call it...

Slightly more flexible knob definition

Note: 

- `KnobFlag<T>` should also be directly replaced by `KnobValue<Spec<T>>`
- `KnobDropdown` probably need separate implementation, i.e. `KnobIndexedValue<Spec<T>>`