### PR TITLE
Fix standard knob default values for sliders

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -336,18 +336,18 @@ struct ApplicationSettings
 #if !defined(PPX_LINUX_HEADLESS)
         bool headless = false;
 #endif
-        bool                          listGpus              = false;
-        std::string                   metricsFilename       = std::filesystem::current_path().string();
-        bool                          overwriteMetricsFile  = false;
-        std::pair<uint32_t, uint32_t> resolution            = std::make_pair(0, 0);
-        uint32_t                      runTimeMs             = 0;
-        int                           screenshotFrameNumber = -1;
-        std::string                   screenshotPath        = "";
-        int                           statsFrameWindow      = -1;
-        bool                          useSoftwareRenderer   = false;
+        bool                listGpus              = false;
+        std::string         metricsFilename       = std::filesystem::current_path().string();
+        bool                overwriteMetricsFile  = false;
+        std::pair<int, int> resolution            = std::make_pair(0, 0);
+        uint32_t            runTimeMs             = 0;
+        int                 screenshotFrameNumber = -1;
+        std::string         screenshotPath        = "";
+        int                 statsFrameWindow      = -1;
+        bool                useSoftwareRenderer   = false;
 #if defined(PPX_BUILD_XR)
-        std::pair<uint32_t, uint32_t> xrUiResolution       = std::make_pair(0, 0);
-        std::vector<std::string>      xrRequiredExtensions = {};
+        std::pair<int, int>      xrUiResolution       = std::make_pair(0, 0);
+        std::vector<std::string> xrRequiredExtensions = {};
 #endif
     } standardKnobsDefaultValue;
 };

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -332,22 +332,22 @@ struct ApplicationSettings
         bool                     deterministic   = false;
         bool                     enableMetrics   = false;
         uint64_t                 frameCount      = 0;
-        int                      gpuIndex        = 0;
+        uint32_t                 gpuIndex        = 0;
 #if !defined(PPX_LINUX_HEADLESS)
         bool headless = false;
 #endif
-        bool                listGpus              = false;
-        std::string         metricsFilename       = std::filesystem::current_path().string();
-        bool                overwriteMetricsFile  = false;
-        std::pair<int, int> resolution            = std::make_pair(0, 0);
-        int                 runTimeMs             = 0;
-        int                 screenshotFrameNumber = -1;
-        std::string         screenshotPath        = "";
-        int                 statsFrameWindow      = -1;
-        bool                useSoftwareRenderer   = false;
+        bool                          listGpus              = false;
+        std::string                   metricsFilename       = std::filesystem::current_path().string();
+        bool                          overwriteMetricsFile  = false;
+        std::pair<uint32_t, uint32_t> resolution            = std::make_pair(0, 0);
+        uint32_t                      runTimeMs             = 0;
+        int                           screenshotFrameNumber = -1;
+        std::string                   screenshotPath        = "";
+        int                           statsFrameWindow      = -1;
+        bool                          useSoftwareRenderer   = false;
 #if defined(PPX_BUILD_XR)
-        std::pair<int, int>      xrUiResolution       = std::make_pair(0, 0);
-        std::vector<std::string> xrRequiredExtensions = {};
+        std::pair<uint32_t, uint32_t> xrUiResolution       = std::make_pair(0, 0);
+        std::vector<std::string>      xrRequiredExtensions = {};
 #endif
     } standardKnobsDefaultValue;
 };

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -331,8 +331,8 @@ struct ApplicationSettings
         std::vector<std::string> configJsonPaths = {};
         bool                     deterministic   = false;
         bool                     enableMetrics   = false;
-        uint64_t                 frameCount      = UINT64_MAX;
-        int                      gpuIndex        = INT_MAX;
+        uint64_t                 frameCount      = 0;
+        int                      gpuIndex        = 0;
 #if !defined(PPX_LINUX_HEADLESS)
         bool headless = false;
 #endif
@@ -340,10 +340,10 @@ struct ApplicationSettings
         std::string         metricsFilename       = std::filesystem::current_path().string();
         bool                overwriteMetricsFile  = false;
         std::pair<int, int> resolution            = std::make_pair(0, 0);
-        int                 runTimeMs             = INT_MAX;
-        int                 screenshotFrameNumber = INT_MAX;
+        int                 runTimeMs             = 0;
+        int                 screenshotFrameNumber = -1;
         std::string         screenshotPath        = "";
-        int                 statsFrameWindow      = INT_MAX;
+        int                 statsFrameWindow      = -1;
         bool                useSoftwareRenderer   = false;
 #if defined(PPX_BUILD_XR)
         std::pair<int, int>      xrUiResolution       = std::make_pair(0, 0);

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -237,9 +237,9 @@ struct StandardOptions
     std::shared_ptr<KnobFlag<bool>> pOverwriteMetricsFile;
 
     // Options
-    std::shared_ptr<KnobFlag<int>>      pGpuIndex;
+    std::shared_ptr<KnobFlag<uint32_t>> pGpuIndex;
     std::shared_ptr<KnobFlag<uint64_t>> pFrameCount;
-    std::shared_ptr<KnobFlag<int>>      pRunTimeMs;
+    std::shared_ptr<KnobFlag<uint32_t>> pRunTimeMs;
     std::shared_ptr<KnobFlag<int>>      pStatsFrameWindow;
     std::shared_ptr<KnobFlag<int>>      pScreenshotFrameNumber;
 

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -800,7 +800,7 @@ void Application::InitStandardKnobs()
         "If 0, this is disabled.");
 
     mStandardOpts.pGpuIndex =
-        mKnobManager.CreateKnob<KnobFlag<int>>("gpu", mSettings.standardKnobsDefaultValue.gpuIndex, 0, INT_MAX);
+        mKnobManager.CreateKnob<KnobFlag<uint32_t>>("gpu", mSettings.standardKnobsDefaultValue.gpuIndex, 0, UINT_MAX);
     mStandardOpts.pGpuIndex->SetFlagDescription(
         "Select the gpu with the given index. To determine the set of valid "
         "indices use `--list-gpus`.");
@@ -852,7 +852,7 @@ void Application::InitStandardKnobs()
     });
 
     mStandardOpts.pRunTimeMs =
-        mKnobManager.CreateKnob<KnobFlag<int>>("run-time-ms", mSettings.standardKnobsDefaultValue.runTimeMs, 0, INT_MAX);
+        mKnobManager.CreateKnob<KnobFlag<uint32_t>>("run-time-ms", mSettings.standardKnobsDefaultValue.runTimeMs, 0, UINT_MAX);
     mStandardOpts.pRunTimeMs->SetFlagDescription(
         "Shutdown the application after N milliseconds. If 0, this is disabled.");
 

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -794,13 +794,13 @@ void Application::InitStandardKnobs()
         "Enable metrics report output. See also: `--metrics-filename` and `--overwrite-metrics-file`.");
 
     mStandardOpts.pFrameCount =
-        mKnobManager.CreateKnob<KnobFlag<uint64_t>>("frame-count", 0, 0, mSettings.standardKnobsDefaultValue.frameCount);
+        mKnobManager.CreateKnob<KnobFlag<uint64_t>>("frame-count", mSettings.standardKnobsDefaultValue.frameCount, 0, UINT64_MAX);
     mStandardOpts.pFrameCount->SetFlagDescription(
         "Shutdown the application after successfully rendering N frames. "
         "If 0, this is disabled.");
 
     mStandardOpts.pGpuIndex =
-        mKnobManager.CreateKnob<KnobFlag<int>>("gpu", 0, 0, mSettings.standardKnobsDefaultValue.gpuIndex);
+        mKnobManager.CreateKnob<KnobFlag<int>>("gpu", mSettings.standardKnobsDefaultValue.gpuIndex, 0, INT_MAX);
     mStandardOpts.pGpuIndex->SetFlagDescription(
         "Select the gpu with the given index. To determine the set of valid "
         "indices use `--list-gpus`.");
@@ -852,12 +852,12 @@ void Application::InitStandardKnobs()
     });
 
     mStandardOpts.pRunTimeMs =
-        mKnobManager.CreateKnob<KnobFlag<int>>("run-time-ms", 0, 0, mSettings.standardKnobsDefaultValue.runTimeMs);
+        mKnobManager.CreateKnob<KnobFlag<int>>("run-time-ms", mSettings.standardKnobsDefaultValue.runTimeMs, 0, INT_MAX);
     mStandardOpts.pRunTimeMs->SetFlagDescription(
         "Shutdown the application after N milliseconds. If 0, this is disabled.");
 
     mStandardOpts.pScreenshotFrameNumber =
-        mKnobManager.CreateKnob<KnobFlag<int>>("screenshot-frame-number", -1, -1, mSettings.standardKnobsDefaultValue.screenshotFrameNumber);
+        mKnobManager.CreateKnob<KnobFlag<int>>("screenshot-frame-number", mSettings.standardKnobsDefaultValue.screenshotFrameNumber, -1, INT_MAX);
     mStandardOpts.pScreenshotFrameNumber->SetFlagDescription(
         "Take a screenshot of frame number N and save it in PPM format. See also "
         "`--screenshot-path`.");
@@ -870,7 +870,7 @@ void Application::InitStandardKnobs()
     mStandardOpts.pScreenshotPath->SetFlagParameters("<path>");
 
     mStandardOpts.pStatsFrameWindow = mKnobManager.CreateKnob<KnobFlag<int>>(
-        "stats-frame-window", -1, -1, mSettings.standardKnobsDefaultValue.statsFrameWindow);
+        "stats-frame-window", mSettings.standardKnobsDefaultValue.statsFrameWindow, -1, INT_MAX);
     mStandardOpts.pStatsFrameWindow->SetFlagDescription(
         "Calculate frame statistics over the last N frames only. If 0, "
         "all frames since the beginning of the application will be used.");


### PR DESCRIPTION
For sliders, currently the max values are being used rather than the default values.
Also changing some `int` -> `uint32_t` since those flags cannot be negative