### PR TITLE
Add default value of knob to the usage message

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -92,7 +92,7 @@ void GraphicsBenchmarkApp::InitKnobs()
 
     GetKnobManager().InitKnob(&pDrawCallCount, "drawcall-count", /* defaultValue = */ 1, /* minValue = */ 1, kMaxSphereInstanceCount);
     pDrawCallCount->SetDisplayName("DrawCall Count");
-    pDrawCallCount->SetFlagDescription("Select the number of draw calls to be used to draw the `sphere-count` spheres.");
+    pDrawCallCount->SetFlagDescription("Select the number of draw calls to be used to draw the `--sphere-count` spheres.");
     pDrawCallCount->SetIndent(1);
 
     GetKnobManager().InitKnob(&pAlphaBlend, "alpha-blend", false);
@@ -102,7 +102,7 @@ void GraphicsBenchmarkApp::InitKnobs()
 
     GetKnobManager().InitKnob(&pDepthTestWrite, "depth-test-write", true);
     pDepthTestWrite->SetDisplayName("Depth Test & Write");
-    pDepthTestWrite->SetFlagDescription("Enable depth test and depth write for spheres (Default: enabled).");
+    pDepthTestWrite->SetFlagDescription("Enable depth test and depth write for spheres.");
     pDepthTestWrite->SetIndent(1);
 
     GetKnobManager().InitKnob(&pFullscreenQuadsCount, "fullscreen-quads-count", /* defaultValue = */ 0, /* minValue = */ 0, kMaxFullscreenQuadsCount);
@@ -111,20 +111,20 @@ void GraphicsBenchmarkApp::InitKnobs()
 
     GetKnobManager().InitKnob(&pFullscreenQuadsType, "fullscreen-quads-type", 0, kFullscreenQuadsTypes);
     pFullscreenQuadsType->SetDisplayName("Type");
-    pFullscreenQuadsType->SetFlagDescription("Select the type of the fullscreen quads (see --fullscreen-quads-count).");
+    pFullscreenQuadsType->SetFlagDescription("Select the type of the fullscreen quads. See also `--fullscreen-quads-count`.");
     pFullscreenQuadsType->SetIndent(1);
 
     GetKnobManager().InitKnob(&pFullscreenQuadsColor, "fullscreen-quads-color", 0, kFullscreenQuadsColors);
     pFullscreenQuadsColor->SetDisplayName("Color");
-    pFullscreenQuadsColor->SetFlagDescription("Select the hue for the solid color fullscreen quads (see --fullscreen-quads-count).");
+    pFullscreenQuadsColor->SetFlagDescription("Select the hue for the solid color fullscreen quads. See also `--fullscreen-quads-count`.");
     pFullscreenQuadsColor->SetIndent(2);
 
     GetKnobManager().InitKnob(&pQuadTextureFile, "fullscreen-quads-texture-path", kQuadTextureFile);
-    pQuadTextureFile->SetFlagDescription("Texture used in fullscreen quads (see --fullscreen-quads-count) texture mode (see --fullscreen-quads-type).");
+    pQuadTextureFile->SetFlagDescription("Texture used in fullscreen quads texture mode. See also `--fullscreen-quads-count` and `--fullscreen-quads-type`.");
 
     GetKnobManager().InitKnob(&pFullscreenQuadsSingleRenderpass, "fullscreen-quads-single-renderpass", true);
     pFullscreenQuadsSingleRenderpass->SetDisplayName("Single Renderpass");
-    pFullscreenQuadsSingleRenderpass->SetFlagDescription("Render all fullscreen quads (see --fullscreen-quads-count) in a single renderpass.");
+    pFullscreenQuadsSingleRenderpass->SetFlagDescription("Render all fullscreen quads in a single renderpass. See also `--fullscreen-quads-count`");
     pFullscreenQuadsSingleRenderpass->SetIndent(1);
 
     // Offscreen rendering knobs:

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -802,7 +802,7 @@ void Application::InitStandardKnobs()
     mStandardOpts.pDeterministic =
         mKnobManager.CreateKnob<KnobFlag<bool>>("deterministic", mSettings.standardKnobsDefaultValue.deterministic);
     mStandardOpts.pDeterministic->SetFlagDescription(
-        "Disable non-deterministic behaviors, like clocks.");
+        "Disable non-deterministic behaviors, like clocks and ImGui.");
 
     mStandardOpts.pEnableMetrics =
         mKnobManager.CreateKnob<KnobFlag<bool>>("enable-metrics", mSettings.standardKnobsDefaultValue.enableMetrics);
@@ -813,13 +813,13 @@ void Application::InitStandardKnobs()
         mKnobManager.CreateKnob<KnobFlag<uint64_t>>("frame-count", 0, 0, mSettings.standardKnobsDefaultValue.frameCount);
     mStandardOpts.pFrameCount->SetFlagDescription(
         "Shutdown the application after successfully rendering N frames. "
-        "Default: 0 (infinite)");
+        "If 0, this is disabled.");
 
     mStandardOpts.pGpuIndex =
         mKnobManager.CreateKnob<KnobFlag<int>>("gpu", 0, 0, mSettings.standardKnobsDefaultValue.gpuIndex);
     mStandardOpts.pGpuIndex->SetFlagDescription(
         "Select the gpu with the given index. To determine the set of valid "
-        "indices use --list-gpus.");
+        "indices use `--list-gpus`.");
 
 #if !defined(PPX_LINUX_HEADLESS)
     mStandardOpts.pHeadless =
@@ -832,7 +832,7 @@ void Application::InitStandardKnobs()
         mKnobManager.CreateKnob<KnobFlag<bool>>("list-gpus", mSettings.standardKnobsDefaultValue.listGpus);
     mStandardOpts.pListGpus->SetFlagDescription(
         "Prints a list of the available GPUs on the current system with their "
-        "index and exits (see --gpu).");
+        "index and exits. See also `--gpu`.");
 
     mStandardOpts.pMetricsFilename =
         mKnobManager.CreateKnob<KnobFlag<std::string>>("metrics-filename", mSettings.standardKnobsDefaultValue.metricsFilename);
@@ -849,18 +849,18 @@ void Application::InitStandardKnobs()
     mStandardOpts.pOverwriteMetricsFile->SetFlagDescription(
         "Only applies if metrics are enabled with `--enable-metrics`. "
         "If an existing file at the path set with `--metrics-filename` is found, it will be overwritten. "
-        "Default: false. See also: `--enable-metrics` and `--metrics-filename`.");
+        "See also: `--enable-metrics` and `--metrics-filename`.");
 
     mStandardOpts.pResolution =
         mKnobManager.CreateKnob<KnobFlag<std::pair<int, int>>>(
             "resolution", mSettings.standardKnobsDefaultValue.resolution);
     mStandardOpts.pResolution->SetFlagDescription(
         "Specify the main window resolution in pixels. Width and Height must be "
-        "two positive integers greater or equal to 1. (Default: Window dimensions)");
+        "two positive integers greater or equal to 1. If 0, window dimensions will be used.");
 #if defined(PPX_BUILD_XR)
     mStandardOpts.pResolution->SetFlagDescription(
         "Specify the per-eye resolution in pixels. Width and Height must be two "
-        "positive integers greater or equal to 1. (Default: Window dimensions)");
+        "positive integers greater or equal to 1. If 0, window dimensions will be used.");
 #endif
     mStandardOpts.pResolution->SetFlagParameters("<width>x<height>");
     mStandardOpts.pResolution->SetValidator([](std::pair<int, int> res) {
@@ -870,7 +870,7 @@ void Application::InitStandardKnobs()
     mStandardOpts.pRunTimeMs =
         mKnobManager.CreateKnob<KnobFlag<int>>("run-time-ms", 0, 0, mSettings.standardKnobsDefaultValue.runTimeMs);
     mStandardOpts.pRunTimeMs->SetFlagDescription(
-        "Shutdown the application after N milliseconds. Default: 0 (infinite).");
+        "Shutdown the application after N milliseconds. If 0, this is disabled.");
 
     mStandardOpts.pScreenshotFrameNumber =
         mKnobManager.CreateKnob<KnobFlag<int>>("screenshot-frame-number", -1, -1, mSettings.standardKnobsDefaultValue.screenshotFrameNumber);
@@ -888,8 +888,8 @@ void Application::InitStandardKnobs()
     mStandardOpts.pStatsFrameWindow = mKnobManager.CreateKnob<KnobFlag<int>>(
         "stats-frame-window", -1, -1, mSettings.standardKnobsDefaultValue.statsFrameWindow);
     mStandardOpts.pStatsFrameWindow->SetFlagDescription(
-        "Calculate frame statistics over the last N frames only. Set to 0 to use "
-        "all frames since the beginning of the application.");
+        "Calculate frame statistics over the last N frames only. If 0, "
+        "all frames since the beginning of the application will be used.");
 
     mStandardOpts.pUseSoftwareRenderer =
         mKnobManager.CreateKnob<KnobFlag<bool>>("use-software-renderer", mSettings.standardKnobsDefaultValue.useSoftwareRenderer);
@@ -906,7 +906,7 @@ void Application::InitStandardKnobs()
             "xr-ui-resolution", mSettings.standardKnobsDefaultValue.xrUiResolution);
     mStandardOpts.pXrUiResolution->SetFlagDescription(
         "Specify the UI quad resolution in pixels. Width and Height must be two "
-        "positive integers greater or equal to 1.");
+        "positive integers greater or equal to 1. If 0, window dimensions will be used.");
     mStandardOpts.pXrUiResolution->SetFlagParameters("<width>x<height>");
     mStandardOpts.pXrUiResolution->SetValidator([](std::pair<int, int> res) {
         return res.first >= 0 && res.second >= 0;

--- a/src/ppx/knob.cpp
+++ b/src/ppx/knob.cpp
@@ -132,8 +132,10 @@ std::string KnobManager::GetUsageMsg()
         if (knobPtr->mFlagParameters != "") {
             knobMsg += " " + knobPtr->mFlagParameters;
         }
+        knobMsg += "\n";
+        std::string knobDefault = "(Default: " + knobPtr->ValueString() + ")";
+        knobMsg += ppx::string_util::WrapText(knobDefault, kUsageMsgTotalWidth, kUsageMsgIndentWidth);
         if (knobPtr->mFlagDescription != "") {
-            knobMsg += "\n";
             knobMsg += ppx::string_util::WrapText(knobPtr->mFlagDescription, kUsageMsgTotalWidth, kUsageMsgIndentWidth);
         }
         usageMsg += knobMsg + "\n";

--- a/src/test/knob_test.cpp
+++ b/src/test/knob_test.cpp
@@ -575,15 +575,35 @@ TEST_F(KnobManagerWithKnobsTestFixture, KnobManager_GetBasicUsageMsg)
     std::string usageMsg = R"(
 Flags:
 --flag_name1 <true|false>
+                    (Default: true)
+
 --flag_name2 <true|false>
+                    (Default: true)
+
 --flag_name3 <0~10>
+                    (Default: 5)
+
 --flag_name4 <c1|c2|"c3 and more">
+                    (Default: c2)
+
 --flag_name5
+                    (Default: true)
+
 --flag_name6
+                    (Default: 6.6)
+
 --flag_name7
+                    (Default: 8)
+
 --flag_name8 <0.0~10.0>
+                    (Default: 5)
+
 --flag_name9
+                    (Default: 1, 2)
+
 --flag_name10
+                    (Default: a, b, c, d and more)
+
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);
 }
@@ -606,25 +626,40 @@ TEST_F(KnobManagerWithKnobsTestFixture, KnobManager_GetCustomizedUsageMsg)
     std::string usageMsg = R"(
 Flags:
 --flag_name1 <bool>
+                    (Default: true)
                     description1
 
 --flag_name2 <true|false>
+                    (Default: true)
+
 --flag_name3 <N>
+                    (Default: 5)
                     description3
 
 --flag_name4 <c1|c2|"c3 and more">
+                    (Default: c2)
                     description4
 
 --flag_name5 <0|1>
+                    (Default: true)
+
 --flag_name6 <0.0~10.0>
+                    (Default: 6.6)
                     description6
 
 --flag_name7 <0~INT_MAX>
+                    (Default: 8)
+
 --flag_name8 <0.000~10.000>
+                    (Default: 5)
+
 --flag_name9
+                    (Default: 1, 2)
                     description9
 
 --flag_name10 <string>
+                    (Default: a, b, c, d and more)
+
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);
 }


### PR DESCRIPTION
Add default value of the knob to the usage message as `(Default: <value>)` for standard knobs and graphics_pipeline

Also cleaned up usage messages
- remove defaults written in message
- standardize syntax for referring to other flags like `--other-flag`
- did not touch flags `--assets-path`, `--metrics-filename`, `--screenshot-path` as those will be changed in follow up PRs
- minor changes to description for some other knobs