### PR TITLE
Call string() instead of u8string() for default metrics filepath

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -337,7 +337,7 @@ struct ApplicationSettings
         bool headless = false;
 #endif
         bool                listGpus              = false;
-        std::string         metricsFilename       = std::filesystem::current_path().u8string();
+        std::string         metricsFilename       = std::filesystem::current_path().string();
         bool                overwriteMetricsFile  = false;
         std::pair<int, int> resolution            = std::make_pair(0, 0);
         int                 runTimeMs             = INT_MAX;


### PR DESCRIPTION
Otherwise this triggers an error of
"no viable conversion from 'basic_string<char8_t>' to 'basic_string<char>'"