### PR TITLE
Refactor knob creation to use InitKnob

### DIFF
--- a/include/ppx/knob.h
+++ b/include/ppx/knob.h
@@ -459,27 +459,17 @@ public:
     bool IsEmpty() { return mKnobs.empty(); }
     void ResetAllToDefault(); // The knobs can be reset to default by a button in the UI
 
-    // Examples of available knobs:
-    //   CreateKnob<KnobCheckbox>("flag_name", bool defaultValue);
-    //   CreateKnob<KnobSlider<int>>("flag_name", int defaultValue, minValue, maxValue);
-    //   CreateKnob<KnobDropdown<std::string>>("flag_name", size_t defaultIndex, std::vector<std::string> choices);
-    template <typename T, typename... ArgsT>
-    std::shared_ptr<T> CreateKnob(const std::string& flagName, ArgsT... args)
-    {
-        PPX_ASSERT_MSG(mFlagNames.count(flagName) == 0, "knob with this name already exists: " + flagName);
-
-        std::shared_ptr<T> knobPtr(new T(flagName, std::forward<ArgsT>(args)...));
-        RegisterKnob(flagName, knobPtr);
-        return knobPtr;
-    }
-
-    // Initialize knob in-place, equivalent to
-    // *ppKnob = CreateKnob<std::remove_reference_t<decltype(*ppKnob)>>(name, ...)
+    // Initialize the knob in-place and register it with the knob manager
     template <typename T, typename... ArgsT>
     void InitKnob(std::shared_ptr<T>* ppKnob, const std::string& flagName, ArgsT&&... args)
     {
         PPX_ASSERT_MSG(ppKnob != nullptr, "output parameter is nullptr");
-        *ppKnob = CreateKnob<T>(flagName, std::forward<ArgsT>(args)...);
+        PPX_ASSERT_MSG(mFlagNames.count(flagName) == 0, "knob with this name already exists: " + flagName);
+
+        std::shared_ptr<T> knobPtr(new T(flagName, std::forward<ArgsT>(args)...));
+        RegisterKnob(flagName, knobPtr);
+
+        *ppKnob = knobPtr;
     }
 
     void        DrawAllKnobs(bool inExistingWindow = false);

--- a/projects/fluid_simulation/main.cpp
+++ b/projects/fluid_simulation/main.cpp
@@ -53,112 +53,112 @@ void ProjApp::InitKnobs()
     size_t indent = 2;
 
     // Fluid
-    mConfig.pCurl = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("curl", 30.0f, 0.0f, 100.0f);
+    GetKnobManager().InitKnob(&mConfig.pCurl, "curl", 30.0f, 0.0f, 100.0f);
     mConfig.pCurl->SetDisplayName("Curl");
     mConfig.pCurl->SetFlagDescription("Curl represents the rotational component of the fluid. It determines the spin (vorticity) of the fluid at each point of the simulation. Higher values indicate stronger vortices or swirling motions in the fluid.");
 
-    mConfig.pDensityDissipation = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("density-dissipation", 1.0f, 0.0f, 10.0f);
+    GetKnobManager().InitKnob(&mConfig.pDensityDissipation, "density-dissipation", 1.0f, 0.0f, 10.0f);
     mConfig.pDensityDissipation->SetDisplayName("Density Dissipation");
     mConfig.pDensityDissipation->SetFlagDescription("This controls the decay of the density field. It determines how quickly the density in the fluid diminshes over time. Higher values result in faster dissipation and smoother density fields.");
 
-    mConfig.pDyeResolution = GetKnobManager().CreateKnob<ppx::KnobSlider<int>>("dye-resolution", 1024, 1, 2048);
+    GetKnobManager().InitKnob(&mConfig.pDyeResolution, "dye-resolution", 1024, 1, 2048);
     mConfig.pDyeResolution->SetDisplayName("Dye Resolution");
     mConfig.pDyeResolution->SetFlagDescription("This determines the level of detail in which the dye is represented. This changes the clarity of the dye patterns in the simulation. Higher values provide finer details and sharper patterns.");
 
-    mConfig.pPressure = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("pressure", 0.8f, 0.0f, 1.0f);
+    GetKnobManager().InitKnob(&mConfig.pPressure, "pressure", 0.8f, 0.0f, 1.0f);
     mConfig.pPressure->SetDisplayName("Pressure");
     mConfig.pPressure->SetFlagDescription("Indicates the force exerted by the fluid on its surrounding boundaries. Higher values cause a greater force exerted on the boundaries. This can lead to denser regions in the fluid.");
 
-    mConfig.pPressureIterations = GetKnobManager().CreateKnob<ppx::KnobSlider<int>>("pressure-iterations", 20, 1, 100);
+    GetKnobManager().InitKnob(&mConfig.pPressureIterations, "pressure-iterations", 20, 1, 100);
     mConfig.pPressureIterations->SetDisplayName("Pressure Iterations");
     mConfig.pPressureIterations->SetFlagDescription("This is the number of iterations performed when solving the pressure field. Higher values produce a more accurate and detailed pressure computation.");
 
-    mConfig.pVelocityDissipation = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("velocity-dissipation", 0.2f, 0.0f, 1.0f);
+    GetKnobManager().InitKnob(&mConfig.pVelocityDissipation, "velocity-dissipation", 0.2f, 0.0f, 1.0f);
     mConfig.pVelocityDissipation->SetDisplayName("Velocity Dissipations");
     mConfig.pVelocityDissipation->SetFlagDescription("This simulates the loss of energy within the fluid system. Higher values result in faster velocity reduction.");
 
     // Bloom
-    mConfig.pEnableBloom = GetKnobManager().CreateKnob<ppx::KnobCheckbox>("enable-bloom", true);
+    GetKnobManager().InitKnob(&mConfig.pEnableBloom, "enable-bloom", true);
     mConfig.pEnableBloom->SetDisplayName("Enable Bloom");
     mConfig.pEnableBloom->SetFlagDescription("Enables bloom effects.");
 
-    mConfig.pBloomIntensity = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("bloom-intensity", 0.8f, 0.0f, 1.0f);
+    GetKnobManager().InitKnob(&mConfig.pBloomIntensity, "bloom-intensity", 0.8f, 0.0f, 1.0f);
     mConfig.pBloomIntensity->SetDisplayName("Intensity");
     mConfig.pBloomIntensity->SetFlagDescription("Strength of the bloom effect applied to the image. It determines how to enhance the bright areas and how pronounced the bloom effect is. Higher values result in a more pronounced effect that will make bright areas of the image appear brighter and more radiant. Lower values produce a more subdued glow.");
     mConfig.pBloomIntensity->SetIndent(indent);
 
-    mConfig.pBloomIterations = GetKnobManager().CreateKnob<ppx::KnobSlider<int>>("bloom-iterations", 8, 1, 20);
+    GetKnobManager().InitKnob(&mConfig.pBloomIterations, "bloom-iterations", 8, 1, 20);
     mConfig.pBloomIterations->SetDisplayName("Iterations");
     mConfig.pBloomIterations->SetFlagDescription("Number of iterations to use in the post-processing bloom pass. Each iteration blurs a downsampled version of the image with the original one. The number of iterations determines how intense the bloom effect is.");
     mConfig.pBloomIterations->SetIndent(indent);
 
-    mConfig.pBloomResolution = GetKnobManager().CreateKnob<ppx::KnobSlider<int>>("bloom-resolution", 256, 1, 2048);
+    GetKnobManager().InitKnob(&mConfig.pBloomResolution, "bloom-resolution", 256, 1, 2048);
     mConfig.pBloomResolution->SetDisplayName("Resolution");
     mConfig.pBloomResolution->SetFlagDescription("Sets the size at which the bloom effect is applied. Higher values provide a more precise bloom result at the expense of computation complexity.");
     mConfig.pBloomResolution->SetIndent(indent);
 
-    mConfig.pBloomSoftKnee = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("bloom-soft-knee", 0.7f, 0.0f, 1.0f);
+    GetKnobManager().InitKnob(&mConfig.pBloomSoftKnee, "bloom-soft-knee", 0.7f, 0.0f, 1.0f);
     mConfig.pBloomSoftKnee->SetDisplayName("Soft Knee");
     mConfig.pBloomSoftKnee->SetFlagDescription("This controls the transition between bloomed and non-bloomed regions of the image. It determines the smoothness of the blending between regions. Higher values result in smoother transitions.");
     mConfig.pBloomSoftKnee->SetIndent(indent);
 
-    mConfig.pBloomThreshold = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("bloom-threshold", 0.6f, 0.0f, 1.0f);
+    GetKnobManager().InitKnob(&mConfig.pBloomThreshold, "bloom-threshold", 0.6f, 0.0f, 1.0f);
     mConfig.pBloomThreshold->SetDisplayName("Threshold");
     mConfig.pBloomThreshold->SetFlagDescription("Minimum brightness for a pixel to be considered as a candidate for bloom. Pixels with intensities below this threshold are not included in the bloom effect. Higher values limit bloom to the brighter areas of the image.");
     mConfig.pBloomThreshold->SetIndent(indent);
 
     // Marble
-    mConfig.pEnableMarble = GetKnobManager().CreateKnob<ppx::KnobCheckbox>("enable-marble", true);
+    GetKnobManager().InitKnob(&mConfig.pEnableMarble, "enable-marble", true);
     mConfig.pEnableMarble->SetDisplayName("Enable Marble");
     mConfig.pEnableMarble->SetFlagDescription("When set, this instantiates a marble that bounces around the simulation field. The marble bounces above the fluid, but it splashes down with certain frequency (controlled by --marble-drop-frequency). This option is not available in the original WebGL implementation.");
 
-    mConfig.pColorUpdateFrequency = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("color-update-frequency", 0.9f, 0.0f, 1.0f);
+    GetKnobManager().InitKnob(&mConfig.pColorUpdateFrequency, "color-update-frequency", 0.9f, 0.0f, 1.0f);
     mConfig.pColorUpdateFrequency->SetDisplayName("Color Update Frequency");
     mConfig.pColorUpdateFrequency->SetFlagDescription("This takes effect only if the bouncing marble is enabled. This controls how often to change the bouncing marble color. This is the color used to produce the splash every time the marble drops.");
     mConfig.pColorUpdateFrequency->SetIndent(indent);
 
-    mConfig.pMarbleDropFrequency = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("marble-drop-frequency", 0.9f, 0.0f, 1.0f);
+    GetKnobManager().InitKnob(&mConfig.pMarbleDropFrequency, "marble-drop-frequency", 0.9f, 0.0f, 1.0f);
     mConfig.pMarbleDropFrequency->SetDisplayName("Drop Frequency");
     mConfig.pMarbleDropFrequency->SetFlagDescription("The probability that the marble will splash on the fluid as it bounces around the field.");
     mConfig.pMarbleDropFrequency->SetIndent(indent);
 
     // Splats
-    mConfig.pNumSplats = GetKnobManager().CreateKnob<ppx::KnobSlider<int>>("num-splats", 0, 0, 20);
+    GetKnobManager().InitKnob(&mConfig.pNumSplats, "num-splats", 0, 0, 20);
     mConfig.pNumSplats->SetDisplayName("Number of Splats");
     mConfig.pNumSplats->SetFlagDescription("This is the number of splashes of color to use at the start of the simulation. This is also used when --splat-frequency is given. A value of 0 means a random number of splats.");
 
-    mConfig.pSplatForce = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("splat-force", 6000.0f, 3000.0f, 10000.0f);
+    GetKnobManager().InitKnob(&mConfig.pSplatForce, "splat-force", 6000.0f, 3000.0f, 10000.0f);
     mConfig.pSplatForce->SetDisplayName("Force");
     mConfig.pSplatForce->SetFlagDescription("This represents the magnitude of the impact applied when an external force (e.g. marble drops) on the fluid.");
     mConfig.pSplatForce->SetIndent(indent);
 
-    mConfig.pSplatFrequency = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("splat-frequency", 0.4f, 0.0f, 1.0f);
+    GetKnobManager().InitKnob(&mConfig.pSplatFrequency, "splat-frequency", 0.4f, 0.0f, 1.0f);
     mConfig.pSplatFrequency->SetDisplayName("Frequency");
     mConfig.pSplatFrequency->SetFlagDescription("How frequent should new splats be generated at random.");
     mConfig.pSplatFrequency->SetIndent(indent);
 
-    mConfig.pSplatRadius = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("splat-radius", 0.25f, 0.0f, 1.0f);
+    GetKnobManager().InitKnob(&mConfig.pSplatRadius, "splat-radius", 0.25f, 0.0f, 1.0f);
     mConfig.pSplatRadius->SetDisplayName("Radius");
     mConfig.pSplatRadius->SetFlagDescription("This represents the extent of the influence region around a specific point where the splat force is applied.");
     mConfig.pSplatRadius->SetIndent(indent);
 
     // Sunrays
-    mConfig.pEnableSunrays = GetKnobManager().CreateKnob<ppx::KnobCheckbox>("enable-sunrays", true);
+    GetKnobManager().InitKnob(&mConfig.pEnableSunrays, "enable-sunrays", true);
     mConfig.pEnableSunrays->SetDisplayName("Enable Sunrays");
     mConfig.pEnableSunrays->SetFlagDescription("This enables the effect of rays of light shining through the fluid.");
 
-    mConfig.pSunraysResolution = GetKnobManager().CreateKnob<ppx::KnobSlider<int>>("sunrays-resolution", 196, 1, 500);
+    GetKnobManager().InitKnob(&mConfig.pSunraysResolution, "sunrays-resolution", 196, 1, 500);
     mConfig.pSunraysResolution->SetDisplayName("Resolution");
     mConfig.pSunraysResolution->SetFlagDescription("Indicates the level of detail for the light rays. Higher values produce a finer level of detail for the light.");
     mConfig.pSunraysResolution->SetIndent(indent);
 
-    mConfig.pSunraysWeight = GetKnobManager().CreateKnob<ppx::KnobSlider<float>>("sunrays-weight", 1.0f, 0.0f, 5.0f);
+    GetKnobManager().InitKnob(&mConfig.pSunraysWeight, "sunrays-weight", 1.0f, 0.0f, 5.0f);
     mConfig.pSunraysWeight->SetDisplayName("Weight");
     mConfig.pSunraysWeight->SetFlagDescription("Indicates the intensity of the light scattering effect. Higher values result in more prominent sun rays, making them appear brighter.");
     mConfig.pSunraysWeight->SetIndent(indent);
 
     // Misc
-    mConfig.pSimResolution = GetKnobManager().CreateKnob<ppx::KnobSlider<int>>("sim-resolution", 128, 1, 1000);
+    GetKnobManager().InitKnob(&mConfig.pSimResolution, "sim-resolution", 128, 1, 1000);
     mConfig.pSimResolution->SetDisplayName("Simulation Resolution");
     mConfig.pSimResolution->SetFlagDescription("This determines the grid size of the compute textures used during simulation. Higher values produce finer grids which produce a more accurate representation.");
 }

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -770,56 +770,48 @@ void Application::SaveMetricsReportToDisk()
 void Application::InitStandardKnobs()
 {
     // Flag names in alphabetical order
-    mStandardOpts.pAssetsPaths =
-        mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>("extra-assets-path", mSettings.standardKnobsDefaultValue.assetsPaths);
+    GetKnobManager().InitKnob(&mStandardOpts.pAssetsPaths, "extra-assets-path", mSettings.standardKnobsDefaultValue.assetsPaths);
     mStandardOpts.pAssetsPaths->SetFlagDescription(
         "Add a path before the default assets folder in the search list.");
     mStandardOpts.pAssetsPaths->SetFlagParameters("<path>");
 
-    mStandardOpts.pConfigJsonPaths = mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>(mCommandLineParser.GetJsonConfigFlagName(), mSettings.standardKnobsDefaultValue.configJsonPaths);
+    GetKnobManager().InitKnob(&mStandardOpts.pConfigJsonPaths, mCommandLineParser.GetJsonConfigFlagName(), mSettings.standardKnobsDefaultValue.configJsonPaths);
     mStandardOpts.pConfigJsonPaths->SetFlagDescription(
         "Additional commandline flags specified in a JSON file. Values specified in JSON files are "
         "always overwritten by those specified on the command line. Between different files, the "
         "later ones take priority.");
     mStandardOpts.pConfigJsonPaths->SetFlagParameters("<path>");
 
-    mStandardOpts.pDeterministic =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("deterministic", mSettings.standardKnobsDefaultValue.deterministic);
+    GetKnobManager().InitKnob(&mStandardOpts.pDeterministic, "deterministic", mSettings.standardKnobsDefaultValue.deterministic);
     mStandardOpts.pDeterministic->SetFlagDescription(
         "Disable non-deterministic behaviors, like clocks and ImGui.");
 
-    mStandardOpts.pEnableMetrics =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("enable-metrics", mSettings.standardKnobsDefaultValue.enableMetrics);
+    GetKnobManager().InitKnob(&mStandardOpts.pEnableMetrics, "enable-metrics", mSettings.standardKnobsDefaultValue.enableMetrics);
     mStandardOpts.pEnableMetrics->SetFlagDescription(
         "Enable metrics report output. See also: `--metrics-filename` and `--overwrite-metrics-file`.");
 
-    mStandardOpts.pFrameCount =
-        mKnobManager.CreateKnob<KnobFlag<uint64_t>>("frame-count", mSettings.standardKnobsDefaultValue.frameCount, 0, UINT64_MAX);
+    GetKnobManager().InitKnob(&mStandardOpts.pFrameCount, "frame-count", mSettings.standardKnobsDefaultValue.frameCount, 0, UINT64_MAX);
     mStandardOpts.pFrameCount->SetFlagDescription(
         "Shutdown the application after successfully rendering N frames. "
         "If 0, this is disabled.");
 
-    mStandardOpts.pGpuIndex =
-        mKnobManager.CreateKnob<KnobFlag<uint32_t>>("gpu", mSettings.standardKnobsDefaultValue.gpuIndex, 0, UINT_MAX);
+    GetKnobManager().InitKnob(&mStandardOpts.pGpuIndex, "gpu", mSettings.standardKnobsDefaultValue.gpuIndex, 0, UINT_MAX);
     mStandardOpts.pGpuIndex->SetFlagDescription(
         "Select the gpu with the given index. To determine the set of valid "
         "indices use `--list-gpus`.");
 
 #if !defined(PPX_LINUX_HEADLESS)
-    mStandardOpts.pHeadless =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("headless", mSettings.standardKnobsDefaultValue.headless);
+    GetKnobManager().InitKnob(&mStandardOpts.pHeadless, "headless", mSettings.standardKnobsDefaultValue.headless);
     mStandardOpts.pHeadless->SetFlagDescription(
         "Run the sample without creating windows.");
 #endif
 
-    mStandardOpts.pListGpus =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("list-gpus", mSettings.standardKnobsDefaultValue.listGpus);
+    GetKnobManager().InitKnob(&mStandardOpts.pListGpus, "list-gpus", mSettings.standardKnobsDefaultValue.listGpus);
     mStandardOpts.pListGpus->SetFlagDescription(
         "Prints a list of the available GPUs on the current system with their "
         "index and exits. See also `--gpu`.");
 
-    mStandardOpts.pMetricsFilename =
-        mKnobManager.CreateKnob<KnobFlag<std::string>>("metrics-filename", mSettings.standardKnobsDefaultValue.metricsFilename);
+    GetKnobManager().InitKnob(&mStandardOpts.pMetricsFilename, "metrics-filename", mSettings.standardKnobsDefaultValue.metricsFilename);
     mStandardOpts.pMetricsFilename->SetFlagDescription(
         "If metrics are enabled, save the metrics report to the "
         "provided filename (including path). If used, any `@` "
@@ -828,16 +820,13 @@ void Application::InitStandardKnobs()
         "`.json`, it will be appended. Default: `report_@`. See also: "
         "`--enable-metrics` and `--overwrite-metrics-file`.");
 
-    mStandardOpts.pOverwriteMetricsFile =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("overwrite-metrics-file", mSettings.standardKnobsDefaultValue.overwriteMetricsFile);
+    GetKnobManager().InitKnob(&mStandardOpts.pOverwriteMetricsFile, "overwrite-metrics-file", mSettings.standardKnobsDefaultValue.overwriteMetricsFile);
     mStandardOpts.pOverwriteMetricsFile->SetFlagDescription(
         "Only applies if metrics are enabled with `--enable-metrics`. "
         "If an existing file at the path set with `--metrics-filename` is found, it will be overwritten. "
         "See also: `--enable-metrics` and `--metrics-filename`.");
 
-    mStandardOpts.pResolution =
-        mKnobManager.CreateKnob<KnobFlag<std::pair<int, int>>>(
-            "resolution", mSettings.standardKnobsDefaultValue.resolution);
+    GetKnobManager().InitKnob(&mStandardOpts.pResolution, "resolution", mSettings.standardKnobsDefaultValue.resolution);
     mStandardOpts.pResolution->SetFlagDescription(
         "Specify the main window resolution in pixels. Width and Height must be "
         "two positive integers greater or equal to 1. If 0, window dimensions will be used.");
@@ -851,32 +840,27 @@ void Application::InitStandardKnobs()
         return res.first >= 0 && res.second >= 0;
     });
 
-    mStandardOpts.pRunTimeMs =
-        mKnobManager.CreateKnob<KnobFlag<uint32_t>>("run-time-ms", mSettings.standardKnobsDefaultValue.runTimeMs, 0, UINT_MAX);
+    GetKnobManager().InitKnob(&mStandardOpts.pRunTimeMs, "run-time-ms", mSettings.standardKnobsDefaultValue.runTimeMs, 0, UINT_MAX);
     mStandardOpts.pRunTimeMs->SetFlagDescription(
         "Shutdown the application after N milliseconds. If 0, this is disabled.");
 
-    mStandardOpts.pScreenshotFrameNumber =
-        mKnobManager.CreateKnob<KnobFlag<int>>("screenshot-frame-number", mSettings.standardKnobsDefaultValue.screenshotFrameNumber, -1, INT_MAX);
+    GetKnobManager().InitKnob(&mStandardOpts.pScreenshotFrameNumber, "screenshot-frame-number", mSettings.standardKnobsDefaultValue.screenshotFrameNumber, -1, INT_MAX);
     mStandardOpts.pScreenshotFrameNumber->SetFlagDescription(
         "Take a screenshot of frame number N and save it in PPM format. See also "
         "`--screenshot-path`.");
 
-    mStandardOpts.pScreenshotPath =
-        mKnobManager.CreateKnob<KnobFlag<std::string>>("screenshot-path", mSettings.standardKnobsDefaultValue.screenshotPath);
+    GetKnobManager().InitKnob(&mStandardOpts.pScreenshotPath, "screenshot-path", mSettings.standardKnobsDefaultValue.screenshotPath);
     mStandardOpts.pScreenshotPath->SetFlagDescription(
         "Save the screenshot to this path. Default: \"screenshot_frame<N>.ppm\" "
         "in the current working directory.");
     mStandardOpts.pScreenshotPath->SetFlagParameters("<path>");
 
-    mStandardOpts.pStatsFrameWindow = mKnobManager.CreateKnob<KnobFlag<int>>(
-        "stats-frame-window", mSettings.standardKnobsDefaultValue.statsFrameWindow, -1, INT_MAX);
+    GetKnobManager().InitKnob(&mStandardOpts.pStatsFrameWindow, "stats-frame-window", mSettings.standardKnobsDefaultValue.statsFrameWindow, -1, INT_MAX);
     mStandardOpts.pStatsFrameWindow->SetFlagDescription(
         "Calculate frame statistics over the last N frames only. If 0, "
         "all frames since the beginning of the application will be used.");
 
-    mStandardOpts.pUseSoftwareRenderer =
-        mKnobManager.CreateKnob<KnobFlag<bool>>("use-software-renderer", mSettings.standardKnobsDefaultValue.useSoftwareRenderer);
+    GetKnobManager().InitKnob(&mStandardOpts.pUseSoftwareRenderer, "use-software-renderer", mSettings.standardKnobsDefaultValue.useSoftwareRenderer);
     mStandardOpts.pUseSoftwareRenderer->SetFlagDescription(
         "Use a software renderer instead of a hardware device, if available.");
     mStandardOpts.pUseSoftwareRenderer->SetValidator([gpuIndex{mStandardOpts.pGpuIndex->GetValue()}](bool useSoftwareRenderer) {
@@ -885,9 +869,7 @@ void Application::InitStandardKnobs()
     });
 
 #if defined(PPX_BUILD_XR)
-    mStandardOpts.pXrUiResolution =
-        mKnobManager.CreateKnob<KnobFlag<std::pair<int, int>>>(
-            "xr-ui-resolution", mSettings.standardKnobsDefaultValue.xrUiResolution);
+    GetKnobManager().InitKnob(&mStandardOpts.pXrUiResolution, "xr-ui-resolution", mSettings.standardKnobsDefaultValue.xrUiResolution);
     mStandardOpts.pXrUiResolution->SetFlagDescription(
         "Specify the UI quad resolution in pixels. Width and Height must be two "
         "positive integers greater or equal to 1. If 0, window dimensions will be used.");
@@ -896,9 +878,7 @@ void Application::InitStandardKnobs()
         return res.first >= 0 && res.second >= 0;
     });
 
-    mStandardOpts.pXrRequiredExtensions =
-        mKnobManager.CreateKnob<KnobFlag<std::vector<std::string>>>(
-            "xr-required-extension", mSettings.standardKnobsDefaultValue.xrRequiredExtensions);
+    GetKnobManager().InitKnob(&mStandardOpts.pXrRequiredExtensions, "xr-required-extension", mSettings.standardKnobsDefaultValue.xrRequiredExtensions);
     mStandardOpts.pXrRequiredExtensions->SetFlagDescription(
         "Specify any additional OpenXR extensions that need to be loaded in addition "
         "to the base extensions. Any required extensions that are not supported by the "

--- a/src/test/knob_test.cpp
+++ b/src/test/knob_test.cpp
@@ -51,16 +51,16 @@ protected:
     {
         ppx::Log::Initialize(ppx::LOG_MODE_CONSOLE, nullptr);
 
-        k1  = km.CreateKnob<ppx::KnobCheckbox>("flag_name1", true);
-        k2  = km.CreateKnob<ppx::KnobCheckbox>("flag_name2", true);
-        k3  = km.CreateKnob<ppx::KnobSlider<int>>("flag_name3", 5, 0, 10);
-        k4  = km.CreateKnob<ppx::KnobDropdown<std::string>>("flag_name4", 1, choices4);
-        k5  = km.CreateKnob<ppx::KnobFlag<bool>>("flag_name5", true);
-        k6  = km.CreateKnob<ppx::KnobFlag<float>>("flag_name6", 6.6f, 0.0f, 10.0f);
-        k7  = km.CreateKnob<ppx::KnobFlag<int>>("flag_name7", 8, 0, INT_MAX);
-        k8  = km.CreateKnob<ppx::KnobSlider<float>>("flag_name8", 5.0f, 0.0f, 10.0f);
-        k9  = km.CreateKnob<ppx::KnobFlag<std::pair<int, int>>>("flag_name9", std::make_pair(1, 2));
-        k10 = km.CreateKnob<ppx::KnobFlag<std::vector<std::string>>>("flag_name10", defaultValues10);
+        km.InitKnob(&k1, "flag_name1", true);
+        km.InitKnob(&k2, "flag_name2", true);
+        km.InitKnob(&k3, "flag_name3", 5, 0, 10);
+        km.InitKnob(&k4, "flag_name4", 1, choices4);
+        km.InitKnob(&k5, "flag_name5", true);
+        km.InitKnob(&k6, "flag_name6", 6.6f, 0.0f, 10.0f);
+        km.InitKnob(&k7, "flag_name7", 8, 0, INT_MAX);
+        km.InitKnob(&k8, "flag_name8", 5.0f, 0.0f, 10.0f);
+        km.InitKnob(&k9, "flag_name9", std::make_pair(1, 2));
+        km.InitKnob(&k10, "flag_name10", defaultValues10);
     }
 
 protected:
@@ -472,99 +472,114 @@ TEST_F(KnobManagerTestFixture, KnobManager_Create)
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateBoolCheckbox)
 {
-    std::shared_ptr<KnobCheckbox> boolKnobPtr(km.CreateKnob<KnobCheckbox>("flag_name1", true));
-    EXPECT_TRUE(boolKnobPtr->GetValue());
+    std::shared_ptr<KnobCheckbox> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", true);
+    EXPECT_TRUE(pKnob->GetValue());
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateIntSlider)
 {
-    std::shared_ptr<KnobSlider<int>> k(km.CreateKnob<KnobSlider<int>>("flag_name1", 5, 0, 10));
-    EXPECT_EQ(k->GetValue(), 5);
+    std::shared_ptr<KnobSlider<int>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", 5, 0, 10);
+    EXPECT_EQ(pKnob->GetValue(), 5);
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateFloatSlider)
 {
-    std::shared_ptr<KnobSlider<float>> k(km.CreateKnob<KnobSlider<float>>("flag_name1", 5.0f, 0.0f, 10.0f));
-    EXPECT_EQ(k->GetValue(), 5.0f);
+    std::shared_ptr<KnobSlider<float>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", 5.0f, 0.0f, 10.0f);
+    EXPECT_EQ(pKnob->GetValue(), 5.0f);
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateStrDropdown)
 {
     std::vector<std::string>                   choices = {"c1", "c2", "c3"};
-    std::shared_ptr<KnobDropdown<std::string>> strKnobPtr(km.CreateKnob<KnobDropdown<std::string>>("flag_name1", 1, choices.cbegin(), choices.cend()));
-    EXPECT_EQ(strKnobPtr->GetIndex(), 1);
+    std::shared_ptr<KnobDropdown<std::string>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", 1, choices.cbegin(), choices.cend());
+    EXPECT_EQ(pKnob->GetIndex(), 1);
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagBool)
 {
-    std::shared_ptr<KnobFlag<bool>> knobPtr(km.CreateKnob<KnobFlag<bool>>("flag_name1", true));
-    EXPECT_EQ(knobPtr->GetValue(), true);
+    std::shared_ptr<KnobFlag<bool>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", true);
+    EXPECT_EQ(pKnob->GetValue(), true);
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagStr)
 {
-    std::shared_ptr<KnobFlag<std::string>> knobPtr(km.CreateKnob<KnobFlag<std::string>>("flag_name1", "placeholder"));
-    EXPECT_EQ(knobPtr->GetValue(), "placeholder");
+    std::shared_ptr<KnobFlag<std::string>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", "placeholder");
+    EXPECT_EQ(pKnob->GetValue(), "placeholder");
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagInt)
 {
-    std::shared_ptr<KnobFlag<int>> knobPtr(km.CreateKnob<KnobFlag<int>>("flag_name1", 5));
-    EXPECT_EQ(knobPtr->GetValue(), 5);
+    std::shared_ptr<KnobFlag<int>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", 5);
+    EXPECT_EQ(pKnob->GetValue(), 5);
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagFloat)
 {
-    std::shared_ptr<KnobFlag<float>> knobPtr(km.CreateKnob<KnobFlag<float>>("flag_name1", 5.5f));
-    EXPECT_EQ(knobPtr->GetValue(), 5.5f);
+    std::shared_ptr<KnobFlag<float>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", 5.5f);
+    EXPECT_EQ(pKnob->GetValue(), 5.5f);
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagIntWithRange)
 {
-    std::shared_ptr<KnobFlag<int>> knobPtr(km.CreateKnob<KnobFlag<int>>("flag_name1", 5, 0, 10));
-    EXPECT_EQ(knobPtr->GetValue(), 5);
+    std::shared_ptr<KnobFlag<int>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", 5, 0, 10);
+    EXPECT_EQ(pKnob->GetValue(), 5);
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagFloatWithRange)
 {
-    std::shared_ptr<KnobFlag<float>> knobPtr(km.CreateKnob<KnobFlag<float>>("flag_name1", 1.5f, 0.0f, 3.0f));
-    EXPECT_EQ(knobPtr->GetValue(), 1.5f);
+    std::shared_ptr<KnobFlag<float>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", 1.5f, 0.0f, 3.0f);
+    EXPECT_EQ(pKnob->GetValue(), 1.5f);
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagPairInts)
 {
-    std::shared_ptr<KnobFlag<std::pair<int, int>>> knobPtr(km.CreateKnob<KnobFlag<std::pair<int, int>>>("flag_name1", std::make_pair(1, 2)));
-    EXPECT_EQ(knobPtr->GetValue().first, 1);
-    EXPECT_EQ(knobPtr->GetValue().second, 2);
+    std::shared_ptr<KnobFlag<std::pair<int, int>>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", std::make_pair(1, 2));
+    EXPECT_EQ(pKnob->GetValue().first, 1);
+    EXPECT_EQ(pKnob->GetValue().second, 2);
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagListStrings)
 {
     std::vector<std::string>                            stringList = {"hi1", "hi2", "hi3"};
-    std::shared_ptr<KnobFlag<std::vector<std::string>>> knobPtr(km.CreateKnob<KnobFlag<std::vector<std::string>>>("flag_name1", stringList));
-    EXPECT_EQ(knobPtr->GetValue().size(), 3);
-    EXPECT_EQ(knobPtr->GetValue().at(0), "hi1");
-    EXPECT_EQ(knobPtr->GetValue().at(1), "hi2");
-    EXPECT_EQ(knobPtr->GetValue().at(2), "hi3");
+    std::shared_ptr<KnobFlag<std::vector<std::string>>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", stringList);
+    EXPECT_EQ(pKnob->GetValue().size(), 3);
+    EXPECT_EQ(pKnob->GetValue().at(0), "hi1");
+    EXPECT_EQ(pKnob->GetValue().at(1), "hi2");
+    EXPECT_EQ(pKnob->GetValue().at(2), "hi3");
 }
 
 TEST_F(KnobManagerTestFixture, KnobManager_CreateKnobFlagListInts)
 {
     std::vector<int>                            intList = {1, 2, 3};
-    std::shared_ptr<KnobFlag<std::vector<int>>> knobPtr(km.CreateKnob<KnobFlag<std::vector<int>>>("flag_name1", intList));
-    EXPECT_EQ(knobPtr->GetValue().size(), 3);
-    EXPECT_EQ(knobPtr->GetValue().at(0), 1);
-    EXPECT_EQ(knobPtr->GetValue().at(1), 2);
-    EXPECT_EQ(knobPtr->GetValue().at(2), 3);
+    std::shared_ptr<KnobFlag<std::vector<int>>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", intList);
+    EXPECT_EQ(pKnob->GetValue().size(), 3);
+    EXPECT_EQ(pKnob->GetValue().at(0), 1);
+    EXPECT_EQ(pKnob->GetValue().at(1), 2);
+    EXPECT_EQ(pKnob->GetValue().at(2), 3);
 }
 
 #if defined(PERFORM_DEATH_TESTS)
 TEST_F(KnobManagerTestFixture, KnobManager_CreateUniqueName)
 {
-    std::shared_ptr<KnobCheckbox> boolKnobPtr1(km.CreateKnob<KnobCheckbox>("flag_name1", true));
+    std::shared_ptr<KnobCheckbox> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", true);
     EXPECT_DEATH(
         {
-            std::shared_ptr<KnobCheckbox> boolKnobPtr2(km.CreateKnob<KnobCheckbox>("flag_name1", true));
+            std::shared_ptr<KnobCheckbox> pKnob;
+            km.InitKnob(&pKnob, "flag_name1", true);
         },
         "");
 }


### PR DESCRIPTION
Preferred for the shorter syntax, and it suits the usual split between knob declaration in header file and initialization in the cpp.