### PR TITLE
build: remove mismatching cmake minimum version

### DIFF
--- a/benchmarks/compute_operations/CMakeLists.txt
+++ b/benchmarks/compute_operations/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(compute_operations)
 
 add_samples_for_all_apis(

--- a/benchmarks/draw_call/CMakeLists.txt
+++ b/benchmarks/draw_call/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(draw_call)
 
 add_samples_for_all_apis(

--- a/benchmarks/graphics_pipeline/CMakeLists.txt
+++ b/benchmarks/graphics_pipeline/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(graphics_pipeline)
 
 add_samples_for_all_apis(

--- a/benchmarks/headless_compute/CMakeLists.txt
+++ b/benchmarks/headless_compute/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(headless_compute)
 
 add_samples_for_all_apis(

--- a/benchmarks/overdraw/CMakeLists.txt
+++ b/benchmarks/overdraw/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(overdraw)
 
 add_samples_for_all_apis(

--- a/benchmarks/primitive_assembly/CMakeLists.txt
+++ b/benchmarks/primitive_assembly/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(primitive_assembly)
 
 add_samples_for_all_apis(

--- a/benchmarks/render_target/CMakeLists.txt
+++ b/benchmarks/render_target/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(render_target)
 
 add_samples_for_all_apis(

--- a/benchmarks/texture_load/CMakeLists.txt
+++ b/benchmarks/texture_load/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(texture_load)
 
 add_samples_for_all_apis(

--- a/benchmarks/texture_sample/CMakeLists.txt
+++ b/benchmarks/texture_sample/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(texture_sample)
 
 add_samples_for_all_apis(

--- a/benchmarks/texture_transfer_cpu_to_gpu/CMakeLists.txt
+++ b/benchmarks/texture_transfer_cpu_to_gpu/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(texture_transfer_cpu_to_gpu)
 
 add_samples_for_all_apis(

--- a/cmake/GraphicsSample.cmake
+++ b/cmake/GraphicsSample.cmake
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 include(Utils)
 include(CMakeParseArguments)
 

--- a/cmake/ShaderCompile.cmake
+++ b/cmake/ShaderCompile.cmake
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 include(Utils)
 include(CMakeParseArguments)
 

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 include(CMakeParseArguments)
 
 function(prefix_all OUTPUT)

--- a/projects/00_ppx_info/CMakeLists.txt
+++ b/projects/00_ppx_info/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(00_ppx_info)
 
 add_samples_for_all_apis(

--- a/projects/01_triangle/CMakeLists.txt
+++ b/projects/01_triangle/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(01_triangle)
 
 add_samples_for_all_apis(

--- a/projects/02_triangle_spinning/CMakeLists.txt
+++ b/projects/02_triangle_spinning/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(02_triangle_spinning)
 
 add_samples_for_all_apis(

--- a/projects/03_square_textured/CMakeLists.txt
+++ b/projects/03_square_textured/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(03_square_textured)
 
 add_samples_for_all_apis(

--- a/projects/04_cube/CMakeLists.txt
+++ b/projects/04_cube/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(04_cube)
 
 add_samples_for_all_apis(

--- a/projects/04_cube_xr/CMakeLists.txt
+++ b/projects/04_cube_xr/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(04_cube_xr)
 
 add_samples_for_all_apis(

--- a/projects/05_cube_textured/CMakeLists.txt
+++ b/projects/05_cube_textured/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(05_cube_textured)
 
 add_samples_for_all_apis(

--- a/projects/06_compute_fill/CMakeLists.txt
+++ b/projects/06_compute_fill/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(06_compute_fill)
 
 add_samples_for_all_apis(

--- a/projects/07_draw_indexed/CMakeLists.txt
+++ b/projects/07_draw_indexed/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(07_draw_indexed)
 
 add_samples_for_all_apis(

--- a/projects/08_basic_geometry/CMakeLists.txt
+++ b/projects/08_basic_geometry/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(08_basic_geometry)
 
 add_samples_for_all_apis(

--- a/projects/09_obj_geometry/CMakeLists.txt
+++ b/projects/09_obj_geometry/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(09_obj_geometry)
 
 add_samples_for_all_apis(

--- a/projects/10_cube_map/CMakeLists.txt
+++ b/projects/10_cube_map/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(10_cube_map)
 
 add_samples_for_all_apis(

--- a/projects/11_compressed_texture/CMakeLists.txt
+++ b/projects/11_compressed_texture/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(11_compressed_texture)
 
 add_samples_for_all_apis(

--- a/projects/12_shadows/CMakeLists.txt
+++ b/projects/12_shadows/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(12_shadows)
 
 add_samples_for_all_apis(

--- a/projects/13_normal_map/CMakeLists.txt
+++ b/projects/13_normal_map/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(13_normal_map)
 
 add_samples_for_all_apis(

--- a/projects/14_input/CMakeLists.txt
+++ b/projects/14_input/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(14_input)
 
 add_samples_for_all_apis(

--- a/projects/15_basic_material/CMakeLists.txt
+++ b/projects/15_basic_material/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(15_basic_material)
 
 add_samples_for_all_apis(

--- a/projects/16_gbuffer/CMakeLists.txt
+++ b/projects/16_gbuffer/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(16_gbuffer)
 
 add_samples_for_all_apis(

--- a/projects/17_primitives/CMakeLists.txt
+++ b/projects/17_primitives/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(17_primitives)
 
 add_samples_for_all_apis(

--- a/projects/18_arcball_camera/CMakeLists.txt
+++ b/projects/18_arcball_camera/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(18_arcball_camera)
 
 add_samples_for_all_apis(

--- a/projects/19_camera_fit_scene/CMakeLists.txt
+++ b/projects/19_camera_fit_scene/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(19_camera_fit_scene)
 
 add_samples_for_all_apis(

--- a/projects/20_camera_motion/CMakeLists.txt
+++ b/projects/20_camera_motion/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(20_camera_motion)
 
 add_samples_for_all_apis(

--- a/projects/21_text_draw/CMakeLists.txt
+++ b/projects/21_text_draw/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(21_text_draw)
 
 add_samples_for_all_apis(

--- a/projects/22_image_filter/CMakeLists.txt
+++ b/projects/22_image_filter/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(22_image_filter)
 
 add_samples_for_all_apis(

--- a/projects/23_async_compute/CMakeLists.txt
+++ b/projects/23_async_compute/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(23_async_compute)
 
 add_samples_for_all_apis(

--- a/projects/24_push_constants/CMakeLists.txt
+++ b/projects/24_push_constants/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(24_push_constants)
 
 add_samples_for_all_apis(

--- a/projects/25_push_descriptors_buffers/CMakeLists.txt
+++ b/projects/25_push_descriptors_buffers/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(25_push_descriptors_buffers)
 
 add_samples_for_all_apis(

--- a/projects/26_push_descriptors/CMakeLists.txt
+++ b/projects/26_push_descriptors/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(26_push_descriptors)
 
 add_vk_sample(

--- a/projects/27_mipmap_demo/CMakeLists.txt
+++ b/projects/27_mipmap_demo/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(27_mipmap_demo)
 
 add_samples_for_all_apis(

--- a/projects/28_gltf/CMakeLists.txt
+++ b/projects/28_gltf/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(28_gltf)
 
 add_samples_for_all_apis(

--- a/projects/alloc/CMakeLists.txt
+++ b/projects/alloc/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(alloc)
 
 add_samples_for_all_apis(

--- a/projects/fishtornado/CMakeLists.txt
+++ b/projects/fishtornado/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(fishtornado)
 
 add_samples_for_all_apis(

--- a/projects/fishtornado_xr/CMakeLists.txt
+++ b/projects/fishtornado_xr/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(fishtornado_xr)
 
 add_samples_for_all_apis(

--- a/projects/fluid_simulation/CMakeLists.txt
+++ b/projects/fluid_simulation/CMakeLists.txt
@@ -4,8 +4,6 @@
 # Use of this source code is governed by an MIT-style
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(fluid_simulation)
 
 add_samples_for_all_apis(

--- a/projects/oit_demo/CMakeLists.txt
+++ b/projects/oit_demo/CMakeLists.txt
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(oit_demo)
 
 add_samples_for_all_apis(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(ppx)
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Projects & benchmarks are not standalone, they build using this project's main CMakeLists.
The main file sets the min version to 3.2, while others only required 3, which makes the min requirement to be 3.2.

In addition, there is now a warning as 3.0 support will drop. This commit silence this warning by removing useless cmake_minimum_required statements.