### PR TITLE
Fix invalid timestamp computation for single-pass rendering

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -1508,7 +1508,7 @@ void GraphicsBenchmarkApp::RecordCommandBuffer(PerFrame& frame, const RenderPass
 
     // Write end timestamp
     // Note the framebuffer is still in RENDER_TARGET state, although it should not really be a problem.
-    frame.cmd->WriteTimestamp(frame.timestampQuery, grfx::PIPELINE_STAGE_TOP_OF_PIPE_BIT, /* queryIndex = */ 1);
+    frame.cmd->WriteTimestamp(frame.timestampQuery, grfx::PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, /* queryIndex = */ 1);
 
     if (renderpasses.blitRenderPass) {
         currentRenderPass = renderpasses.blitRenderPass;


### PR DESCRIPTION
The time computation for multi-pass rendering was incorrect. For both `Timestamp Queries` to the GPU, the PIPELINE_STAGE_TOP_OF_PIPE_BIT stage was erroneously used. To correct this, the first timestamp should use the PIPELINE_STAGE_TOP_BIT stage to record the timestamp as soon as all previous commands are processed by the command processor. The second timestamp should employ the PIPELINE_STAGE_BOTTOM_BIT stage to record the timestamp as soon as all previous commands retire.