### PR TITLE
Remove cmake_minimum_required from dynamic rendering sample

### DIFF
--- a/projects/29_dynamic_rendering/CMakeLists.txt
+++ b/projects/29_dynamic_rendering/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(29_dynamic_rendering)
 
 add_samples_for_all_apis(


### PR DESCRIPTION
It was removed everywhere else in https://github.com/google/bigwheels/pull/374