### PR TITLE
XR simulated mouse input

### DIFF
--- a/include/ppx/imgui_impl.h
+++ b/include/ppx/imgui_impl.h
@@ -55,6 +55,9 @@ public:
     virtual void Shutdown(ppx::Application* pApp) override;
     virtual void Render(grfx::CommandBuffer* pCommandBuffer) override;
     virtual void ProcessEvent() override;
+#if defined(PPX_BUILD_XR)
+    void ProcessXrInput();
+#endif
 
 protected:
     virtual Result InitApiObjects(ppx::Application* pApp) override;

--- a/include/ppx/imgui_impl.h
+++ b/include/ppx/imgui_impl.h
@@ -37,7 +37,7 @@ public:
     virtual void   Shutdown(ppx::Application* pApp) = 0;
     virtual void   NewFrame();
     virtual void   Render(grfx::CommandBuffer* pCommandBuffer) = 0;
-    virtual void   ProcessEvent() {}
+    virtual void   ProcessEvents() {}
 
 protected:
     virtual Result InitApiObjects(ppx::Application* pApp) = 0;
@@ -54,7 +54,7 @@ public:
 
     virtual void Shutdown(ppx::Application* pApp) override;
     virtual void Render(grfx::CommandBuffer* pCommandBuffer) override;
-    virtual void ProcessEvent() override;
+    virtual void ProcessEvents() override;
 #if defined(PPX_BUILD_XR)
     void ProcessXrInput();
 #endif

--- a/include/ppx/imgui_impl.h
+++ b/include/ppx/imgui_impl.h
@@ -37,6 +37,7 @@ public:
     virtual void   Shutdown(ppx::Application* pApp) = 0;
     virtual void   NewFrame();
     virtual void   Render(grfx::CommandBuffer* pCommandBuffer) = 0;
+    virtual void   ProcessEvent() {}
 
 protected:
     virtual Result InitApiObjects(ppx::Application* pApp) = 0;
@@ -53,6 +54,7 @@ public:
 
     virtual void Shutdown(ppx::Application* pApp) override;
     virtual void Render(grfx::CommandBuffer* pCommandBuffer) override;
+    virtual void ProcessEvent() override;
 
 protected:
     virtual Result InitApiObjects(ppx::Application* pApp) override;
@@ -60,6 +62,9 @@ protected:
 
 private:
     grfx::DescriptorPoolPtr mPool;
+#if defined(PPX_BUILD_XR)
+    bool mSimulatedMouseDown = false;
+#endif
 };
 
 #if defined(PPX_D3D12)

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -177,6 +177,12 @@ public:
     glm::mat4 GetViewMatrixForCurrentView() const;
     XrPosef   GetPoseForCurrentView() const;
 
+    std::optional<XrPosef> GetUIPointingState() const { return mImguiPointingState; }
+    std::optional<bool>    GetUIClickState() const { return mImguiClickState; }
+    // Return cursor location on the UI plane, from center in unit of meters
+    // Note, the current UI swapchain covers a region of [-0.5, +0.5] x [-0.5, +0.5]
+    std::optional<XrVector2f> GetUICursor() const;
+
     bool IsSessionRunning() const { return mIsSessionRunning; }
     bool ShouldRender() const { return mShouldRender; }
 
@@ -226,6 +232,16 @@ private:
     XrDebugUtilsMessengerEXT mDebugUtilMessenger = XR_NULL_HANDLE;
     bool                     mIsSessionRunning   = false;
     bool                     mShouldRender       = false;
+
+    // KHR controller input profile
+    XrActionSet mImguiInput          = XR_NULL_HANDLE;
+    XrSpace     mImguiPointingSpace  = XR_NULL_HANDLE;
+    XrAction    mImguiClickAction    = XR_NULL_HANDLE;
+    XrAction    mImguiPointingAction = XR_NULL_HANDLE;
+    XrTime      mImguiActionTime     = {};
+
+    std::optional<XrPosef> mImguiPointingState = {};
+    std::optional<bool>    mImguiClickState    = {};
 
     std::optional<float> mNearPlaneForFrame     = std::nullopt;
     std::optional<float> mFarPlaneForFrame      = std::nullopt;

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -129,10 +129,16 @@ class XrComponent
 public:
     virtual ~XrComponent() = default;
 
-    void     InitializeBeforeGrfxDeviceInit(const XrComponentCreateInfo& createInfo);
-    void     InitializeAfterGrfxDeviceInit(const grfx::InstancePtr pGrfxInstance);
-    XrResult InitializeInteractionProfile();
-    void     Destroy();
+    void InitializeBeforeGrfxDeviceInit(const XrComponentCreateInfo& createInfo);
+    void InitializeAfterGrfxDeviceInit(const grfx::InstancePtr pGrfxInstance);
+    void Destroy();
+
+    // Initialize interaction profiles.
+    // Currently supported interaction profile:
+    //  - khr/simple_controller
+    //
+    // The error returned by this function can be safely ignored.
+    XrResult InitializeInteractionProfiles();
 
     void     PollEvents(bool& exitRenderLoop);
     XrResult PollActions();
@@ -190,7 +196,7 @@ public:
     glm::mat4 GetViewMatrixForCurrentView() const;
     XrPosef   GetPoseForCurrentView() const;
 
-    std::optional<XrPosef> GetUIPointingState() const { return mImguiPointingState; }
+    std::optional<XrPosef> GetUIAimState() const { return mImguiAimState; }
     std::optional<bool>    GetUIClickState() const { return mImguiClickState; }
     // Return cursor location on the UI plane, from center in unit of meters
     // Note, the current UI swapchain covers a region of [-0.5, +0.5] x [-0.5, +0.5]
@@ -246,16 +252,18 @@ private:
     bool                     mIsSessionRunning   = false;
     bool                     mShouldRender       = false;
 
-    // KHR controller input profile
-    bool        mInteractionProfileInitialized = false;
-    XrActionSet mImguiInput                    = XR_NULL_HANDLE;
-    XrSpace     mImguiPointingSpace            = XR_NULL_HANDLE;
-    XrAction    mImguiClickAction              = XR_NULL_HANDLE;
-    XrAction    mImguiPointingAction           = XR_NULL_HANDLE;
-    XrTime      mImguiActionTime               = {};
+    // Interaction Profiles
+    bool mInteractionProfileInitialized = false;
+    // Current controller pose and "select" button status.
+    std::optional<XrPosef> mImguiAimState   = {};
+    std::optional<bool>    mImguiClickState = {};
 
-    std::optional<XrPosef> mImguiPointingState = {};
-    std::optional<bool>    mImguiClickState    = {};
+    // XR Action Set, using KHR controller input profile.
+    XrActionSet mImguiInput       = XR_NULL_HANDLE;
+    XrSpace     mImguiAimSpace    = XR_NULL_HANDLE;
+    XrAction    mImguiClickAction = XR_NULL_HANDLE;
+    XrAction    mImguiAimAction   = XR_NULL_HANDLE;
+    XrTime      mImguiActionTime  = {};
 
     std::optional<float> mNearPlaneForFrame     = std::nullopt;
     std::optional<float> mFarPlaneForFrame      = std::nullopt;

--- a/include/ppx/xr_component.h
+++ b/include/ppx/xr_component.h
@@ -47,6 +47,17 @@
         PPX_ASSERT_MSG(RESULT__ == XR_SUCCESS, "XR call failed with result: " << RESULT__ << "!"); \
     }
 
+#define CHECK_XR_CALL_RETURN_ON_FAIL(CMD__)                                   \
+    {                                                                         \
+        auto RESULT__ = CMD__;                                                \
+        if (RESULT__ != XR_SUCCESS) {                                         \
+            PPX_LOG_WARN(                                                     \
+                "WARNING: XR call failed with result: "                       \
+                << RESULT__ << ", at " << __FILE__ << ":" << __LINE__ << ""); \
+            return RESULT__;                                                  \
+        }                                                                     \
+    }
+
 namespace ppx {
 namespace {
 
@@ -118,11 +129,13 @@ class XrComponent
 public:
     virtual ~XrComponent() = default;
 
-    void InitializeBeforeGrfxDeviceInit(const XrComponentCreateInfo& createInfo);
-    void InitializeAfterGrfxDeviceInit(const grfx::InstancePtr pGrfxInstance);
-    void Destroy();
+    void     InitializeBeforeGrfxDeviceInit(const XrComponentCreateInfo& createInfo);
+    void     InitializeAfterGrfxDeviceInit(const grfx::InstancePtr pGrfxInstance);
+    XrResult InitializeInteractionProfile();
+    void     Destroy();
 
-    void PollEvents(bool& exitRenderLoop);
+    void     PollEvents(bool& exitRenderLoop);
+    XrResult PollActions();
 
     void BeginFrame();
     void EndFrame(const std::vector<grfx::SwapchainPtr>& swapchains, uint32_t layerProjStartIndex, uint32_t layerQuadStartIndex);
@@ -234,11 +247,12 @@ private:
     bool                     mShouldRender       = false;
 
     // KHR controller input profile
-    XrActionSet mImguiInput          = XR_NULL_HANDLE;
-    XrSpace     mImguiPointingSpace  = XR_NULL_HANDLE;
-    XrAction    mImguiClickAction    = XR_NULL_HANDLE;
-    XrAction    mImguiPointingAction = XR_NULL_HANDLE;
-    XrTime      mImguiActionTime     = {};
+    bool        mInteractionProfileInitialized = false;
+    XrActionSet mImguiInput                    = XR_NULL_HANDLE;
+    XrSpace     mImguiPointingSpace            = XR_NULL_HANDLE;
+    XrAction    mImguiClickAction              = XR_NULL_HANDLE;
+    XrAction    mImguiPointingAction           = XR_NULL_HANDLE;
+    XrTime      mImguiActionTime               = {};
 
     std::optional<XrPosef> mImguiPointingState = {};
     std::optional<bool>    mImguiClickState    = {};

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1238,6 +1238,9 @@ void Application::ProcessEvents()
             return;
         }
     }
+    if (mImGui) {
+        mImGui->ProcessEvent();
+    }
 }
 
 void Application::RenderFrame()

--- a/src/ppx/application.cpp
+++ b/src/ppx/application.cpp
@@ -1239,7 +1239,7 @@ void Application::ProcessEvents()
         }
     }
     if (mImGui) {
-        mImGui->ProcessEvent();
+        mImGui->ProcessEvents();
     }
 }
 

--- a/src/ppx/imgui_impl.cpp
+++ b/src/ppx/imgui_impl.cpp
@@ -389,7 +389,7 @@ void ImGuiImplVk::ProcessXrInput()
     bool isMouseDown = xrComponent.GetUIClickState().value_or(false);
     if (isMouseDown != mSimulatedMouseDown) {
         mSimulatedMouseDown = isMouseDown;
-        io.AddMouseButtonEvent(0, isMouseDown);
+        io.AddMouseButtonEvent(ImGuiMouseButton_Left, isMouseDown);
     }
 
     std::optional<XrVector2f> cursor = xrComponent.GetUICursor();
@@ -412,7 +412,7 @@ void ImGuiImplVk::ProcessXrInput()
 }
 #endif
 
-void ImGuiImplVk::ProcessEvent()
+void ImGuiImplVk::ProcessEvents()
 {
 #if defined(PPX_BUILD_XR)
     ProcessXrInput();

--- a/src/ppx/imgui_impl.cpp
+++ b/src/ppx/imgui_impl.cpp
@@ -92,23 +92,23 @@ Result ImGuiImpl::Init(ppx::Application* pApp)
     // clang-format on
 
     //// Get the logical width and height of the monitor
-    // MONITORINFOEX monitorInfoEx = {};
-    // monitorInfoEx.cbSize        = sizeof(monitorInfoEx);
-    // GetMonitorInfo(monitor, &monitorInfoEx);
-    // auto cxLogical = monitorInfoEx.rcMonitor.right - monitorInfoEx.rcMonitor.left;
-    // auto cyLogical = monitorInfoEx.rcMonitor.bottom - monitorInfoEx.rcMonitor.top;
+    //MONITORINFOEX monitorInfoEx = {};
+    //monitorInfoEx.cbSize        = sizeof(monitorInfoEx);
+    //GetMonitorInfo(monitor, &monitorInfoEx);
+    //auto cxLogical = monitorInfoEx.rcMonitor.right - monitorInfoEx.rcMonitor.left;
+    //auto cyLogical = monitorInfoEx.rcMonitor.bottom - monitorInfoEx.rcMonitor.top;
     //
     //// Get the physical width and height of the monitor
-    // DEVMODE devMode       = {};
-    // devMode.dmSize        = sizeof(devMode);
-    // devMode.dmDriverExtra = 0;
-    // EnumDisplaySettings(monitorInfoEx.szDevice, ENUM_CURRENT_SETTINGS, &devMode);
-    // auto cxPhysical = devMode.dmPelsWidth;
-    // auto cyPhysical = devMode.dmPelsHeight;
+    //DEVMODE devMode       = {};
+    //devMode.dmSize        = sizeof(devMode);
+    //devMode.dmDriverExtra = 0;
+    //EnumDisplaySettings(monitorInfoEx.szDevice, ENUM_CURRENT_SETTINGS, &devMode);
+    //auto cxPhysical = devMode.dmPelsWidth;
+    //auto cyPhysical = devMode.dmPelsHeight;
     //
     //// Calculate the scaling factor
-    // float horizontalScale = ((float)cxPhysical / (float)cxLogical);
-    // float verticalScale   = ((float)cyPhysical / (float)cyLogical);
+    //float horizontalScale = ((float)cxPhysical / (float)cxLogical);
+    //float verticalScale   = ((float)cyPhysical / (float)cyLogical);
 
     // Scale fontSize based on scaling factor
     fontSize *= fontScale;
@@ -135,9 +135,9 @@ Result ImGuiImpl::Init(ppx::Application* pApp)
 
 void ImGuiImpl::SetColorStyle()
 {
-    // ImGui::StyleColorsClassic();
+    //ImGui::StyleColorsClassic();
     ImGui::StyleColorsDark();
-    // ImGui::StyleColorsLight();
+    //ImGui::StyleColorsLight();
 }
 
 void ImGuiImpl::NewFrame()
@@ -375,38 +375,47 @@ void ImGuiImplVk::Render(grfx::CommandBuffer* pCommandBuffer)
     ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), grfx::vk::ToApi(pCommandBuffer)->GetVkCommandBuffer());
 }
 
+#if defined(PPX_BUILD_XR)
+void ImGuiImplVk::ProcessXrInput()
+{
+    Application* pApp = Application::Get();
+    if (!pApp->IsXrEnabled()) {
+        return;
+    }
+
+    ImGuiIO&     io          = ImGui::GetIO();
+    XrComponent& xrComponent = pApp->GetXrComponent();
+
+    bool isMouseDown = xrComponent.GetUIClickState().value_or(false);
+    if (isMouseDown != mSimulatedMouseDown) {
+        mSimulatedMouseDown = isMouseDown;
+        io.AddMouseButtonEvent(0, isMouseDown);
+    }
+
+    std::optional<XrVector2f> cursor = xrComponent.GetUICursor();
+    if (cursor.has_value()) {
+        // Mapping cursor location from meters to Imgui screen coordinate
+        // x axis: [-0.5m, +0.5m] -> [0, 1] * swapchain.width
+        // y axis: [-0.5m, +0.5m] -> [1, 0] * swapchain.height
+        io.MousePos = ImVec2{
+            (cursor->x + 0.5f) * pApp->GetUISwapchain()->GetWidth(),
+            (-cursor->y + 0.5f) * pApp->GetUISwapchain()->GetHeight(),
+        };
+        io.MouseDrawCursor = true;
+        ImGui::SetMouseCursor(ImGuiMouseCursor_Arrow);
+    }
+    else {
+        io.MousePos        = ImVec2{-FLT_MAX, -FLT_MAX};
+        io.MouseDrawCursor = false;
+        ImGui::SetMouseCursor(ImGuiMouseCursor_None);
+    }
+}
+#endif
+
 void ImGuiImplVk::ProcessEvent()
 {
 #if defined(PPX_BUILD_XR)
-    ImGuiIO&     io   = ImGui::GetIO();
-    Application* pApp = Application::Get();
-    if (pApp->GetSettings()->xr.enable) {
-        XrComponent& xrComponent = pApp->GetXrComponent();
-
-        bool isMouseDown = xrComponent.GetUIClickState().value_or(false);
-        if (isMouseDown != mSimulatedMouseDown) {
-            mSimulatedMouseDown = isMouseDown;
-            io.AddMouseButtonEvent(0, isMouseDown);
-        }
-
-        std::optional<XrVector2f> cursor = xrComponent.GetUICursor();
-        if (cursor.has_value()) {
-            // Mappting cursor location from meters to Imgui screen coordinate
-            // x axis: [-0.5m, +0.5m] -> [0, 1] * swapchain.width
-            // y axis: [-0.5m, +0.5m] -> [1, 0] * swapchain.height
-            io.MousePos = ImVec2{
-                (cursor->x + 0.5f) * pApp->GetUISwapchain()->GetWidth(),
-                (-cursor->y + 0.5f) * pApp->GetUISwapchain()->GetHeight(),
-            };
-            io.MouseDrawCursor = true;
-            ImGui::SetMouseCursor(ImGuiMouseCursor_Arrow);
-        }
-        else {
-            io.MousePos        = ImVec2{-FLT_MAX, -FLT_MAX};
-            io.MouseDrawCursor = false;
-            ImGui::SetMouseCursor(ImGuiMouseCursor_None);
-        }
-    }
+    ProcessXrInput();
 #endif
 }
 

--- a/src/ppx/xr_component.cpp
+++ b/src/ppx/xr_component.cpp
@@ -64,14 +64,18 @@ float Sign(float x)
     return (x < 0 ? -1 : (x > 0 ? 1 : 0));
 }
 
+glm::quat FromXr(const XrQuaternionf& q)
+{
+    return glm::quat(q.w, q.x, q.y, q.z);
+}
+
 XrVector3f ForwardVector(const XrPosef& controller)
 {
-    XrQuaternionf q = controller.orientation;
-    return XrVector3f{
-        -2.0f * (q.x * q.z + q.w * q.y),
-        -2.0f * (q.y * q.z - q.w * q.x),
-        2.0f * (q.x * q.x + q.y * q.y) - 1.0f,
-    };
+    const glm::vec3 unitForward = glm::vec3(0, 0, -1);
+
+    const glm::quat q   = FromXr(controller.orientation);
+    const glm::vec3 res = glm::rotate(q, unitForward);
+    return XrVector3f{res.x, res.y, res.z};
 }
 
 std::optional<XrVector2f> ProjectCursor(XrPosef controller, float z)


### PR DESCRIPTION
Simulate a mouse using right controller.

Uses "Khronos Simple Controller Profile", which should be available on most devices.

Controller input is interpreted as follows:

- `/user/hand/right/input/select/click` as left button 
- `/user/hand/right/input/aim/pose` as cursor using ray cast

