### PR TITLE
Only activate extensions for selected shading rate mode.

### DIFF
--- a/include/ppx/grfx/vk/vk_device.h
+++ b/include/ppx/grfx/vk/vk_device.h
@@ -112,8 +112,6 @@ private:
     bool                                           mHasExtendedDynamicState                    = false;
     bool                                           mHasUnrestrictedDepthRange                  = false;
     bool                                           mHasDynamicRendering                        = false;
-    bool                                           mHasFDMExtensions                           = false;
-    bool                                           mHasVRSExtensions                           = false;
     PFN_vkResetQueryPoolEXT                        mFnResetQueryPoolEXT                        = nullptr;
     uint32_t                                       mGraphicsQueueFamilyIndex                   = 0;
     uint32_t                                       mComputeQueueFamilyIndex                    = 0;


### PR DESCRIPTION
This changes the logic for activating the shading rate extensions (VK_KHR_fragment_shading_rate, VK_EXT_fragment_density_map). Previously both extensions were activated whenever they were available, now only the extension corresponding to the requested shading rate mode is activated.

We already only enable the *feature* for one of the shading rate modes (to avoid a validation error), so this change just avoids adding unused extensions.