### PR TITLE
Fix typo in enabling VRS extension.

### DIFF
--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -162,7 +162,7 @@ Result Device::ConfigureExtensions(const grfx::DeviceCreateInfo* pCreateInfo)
     }
 
     // Variable rate shading
-    if (pCreateInfo->supportShadingRateMode == SHADING_RATE_FDM) {
+    if (pCreateInfo->supportShadingRateMode == SHADING_RATE_VRS) {
         PPX_ASSERT_MSG(
             ElementExists(std::string(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME), mFoundExtensions),
             "VRS shading rate requires unsupported extension " << VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);


### PR DESCRIPTION
This typo slipped by in the previous PR due to my testing the wrong APK. Apologies for the churn.