### PR TITLE
Make fluid simulation window re-sizable

### DIFF
--- a/projects/fluid_simulation/shaders.cpp
+++ b/projects/fluid_simulation/shaders.cpp
@@ -205,8 +205,6 @@ void ComputeShader::Dispatch(PerFrame* pFrame, const std::vector<SimulationGrid*
 
     // Queue the dispatch operation.
     ppx::uint3 dispatchSize = ppx::uint3(output->GetWidth(), output->GetHeight(), 1);
-    PPX_LOG_DEBUG("Scheduling compute shader '" << mShaderFile << ".cs' (" << dispatchSize << ")\n");
-
     pFrame->cmd->TransitionImageLayout(output->GetImage(), PPX_ALL_SUBRESOURCES, ppx::grfx::RESOURCE_STATE_SHADER_RESOURCE, ppx::grfx::RESOURCE_STATE_UNORDERED_ACCESS);
     pFrame->cmd->BindComputeDescriptorSets(pApp->GetComputePipelineInterface(), 1, &dd->mDescriptorSet);
     pFrame->cmd->BindComputePipeline(mPipeline);

--- a/projects/fluid_simulation/sim.cpp
+++ b/projects/fluid_simulation/sim.cpp
@@ -158,6 +158,7 @@ void FluidSimulationApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.api              = kApi;
     settings.grfx.enableDebug      = clOptions.HasExtraOption("enable-debug");
     settings.allowThirdPartyAssets = true;
+    settings.window.resizable      = true;
 }
 
 void FluidSimulationApp::Setup()
@@ -309,6 +310,11 @@ void FluidSimulationApp::SetupRenderingPipeline()
     PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpci, &mGraphicsPipeline));
 }
 
+void FluidSimulationApp::Resize(uint32_t width, uint32_t height)
+{
+    SetupGrids();
+}
+
 void FluidSimulationApp::SetupGrids()
 {
     ppx::int2 simRes = GetResolution(GetConfig().pSimResolution->GetValue());
@@ -334,7 +340,7 @@ void FluidSimulationApp::SetupBloomGrids()
 {
     ppx::int2 res = GetResolution(GetConfig().pBloomResolution->GetValue());
     mBloomGrid    = std::make_unique<SimulationGrid>("bloom", res.x, res.y, kRGBA);
-    PPX_ASSERT_MSG(mBloomGrids.empty(), "Bloom grids already initialized");
+    mBloomGrids.clear();
     for (int i = 0; i < GetConfig().pBloomIterations->GetValue(); i++) {
         uint32_t width  = res.x >> (i + 1);
         uint32_t height = res.y >> (i + 1);

--- a/projects/fluid_simulation/sim.h
+++ b/projects/fluid_simulation/sim.h
@@ -94,6 +94,7 @@ public:
     virtual void Config(ppx::ApplicationSettings& settings) override;
     virtual void Setup() override;
     virtual void Render() override;
+    virtual void Resize(uint32_t width, uint32_t height) override;
 
     const SimulationConfig&           GetSimulationConfig() const { return mConfig; }
     ppx::grfx::SamplerPtr             GetClampSampler() const { return mClampSampler; }


### PR DESCRIPTION
**NOTE TO REVIEWERS: This is a very simple change but relies on the new code structure from #323, #396 and #397.  Please review those first. Thanks.**

This adds a call back for `Resize` so that the simulation grids can be re-allocated to match the new window size.

Fixes #229.