### PR TITLE
Add dynamic filtering

### DIFF
--- a/assets/fluid_simulation/shaders/config.hlsli
+++ b/assets/fluid_simulation/shaders/config.hlsli
@@ -47,6 +47,12 @@ Coord BlurVS(float2 xy, float2 normalizationScale, float2 texelSize)
     return coord;
 }
 
+// Filter option bitmasks to use in CSInput::filterOptions.
+#define kAdvectionManualFiltering  (1 << 0)
+#define kDisplayShading            (1 << 1)
+#define kDisplayBloom              (1 << 2)
+#define kDisplaySunrays            (1 << 3)
+
 // Scalar inputs for the filter programs. Needs to be 16-bit aligned to be copied
 // into a uniform buffer.
 //
@@ -78,6 +84,8 @@ struct CSInput
     float curl;
 
     float2 normalizationScale;
+
+    uint filterOptions;
 };
 
 ConstantBuffer<CSInput> Params : register(b0);

--- a/assets/fluid_simulation/shaders/display.hlsl
+++ b/assets/fluid_simulation/shaders/display.hlsl
@@ -7,10 +7,6 @@
 
 #include "config.hlsli"
 
-#define SHADING 1
-#define BLOOM   1
-#define SUNRAYS 1
-
 float3 linearToGamma(float3 color)
 {
     color = max(color, float3(0, 0, 0));
@@ -22,41 +18,43 @@ float3 linearToGamma(float3 color)
     Coord  coord = BaseVS(tid, Params.normalizationScale, Params.texelSize);
     float3 c     = UTexture.SampleLevel(ClampSampler, coord.vUv, 0).rgb;
 
-#ifdef SHADING
-    float3 lc = UTexture.SampleLevel(ClampSampler, coord.vL, 0).rgb;
-    float3 rc = UTexture.SampleLevel(ClampSampler, coord.vR, 0).rgb;
-    float3 tc = UTexture.SampleLevel(ClampSampler, coord.vT, 0).rgb;
-    float3 bc = UTexture.SampleLevel(ClampSampler, coord.vB, 0).rgb;
+    bool doShading = (Params.filterOptions & kDisplayShading);
+    bool doBloom = (Params.filterOptions & kDisplayBloom);
+    bool doSunrays = (Params.filterOptions & kDisplaySunrays);
 
-    float dx = length(rc) - length(lc);
-    float dy = length(tc) - length(bc);
+    if (doShading) {
+        float3 lc = UTexture.SampleLevel(ClampSampler, coord.vL, 0).rgb;
+        float3 rc = UTexture.SampleLevel(ClampSampler, coord.vR, 0).rgb;
+        float3 tc = UTexture.SampleLevel(ClampSampler, coord.vT, 0).rgb;
+        float3 bc = UTexture.SampleLevel(ClampSampler, coord.vB, 0).rgb;
 
-    float3 n = normalize(float3(dx, dy, length(Params.texelSize)));
-    float3 l = float3(0.0, 0.0, 1.0);
+        float dx = length(rc) - length(lc);
+        float dy = length(tc) - length(bc);
 
-    float diffuse = clamp(dot(n, l) + 0.7, 0.7, 1.0);
-    c *= diffuse;
-#endif
+        float3 n = normalize(float3(dx, dy, length(Params.texelSize)));
+        float3 l = float3(0.0, 0.0, 1.0);
 
-#ifdef BLOOM
-    float3 bloom = UBloom.SampleLevel(ClampSampler, coord.vUv, 0).rgb;
-#endif
+        float diffuse = clamp(dot(n, l) + 0.7, 0.7, 1.0);
+        c *= diffuse;
+    }
 
-#ifdef SUNRAYS
-    float sunrays = USunrays.SampleLevel(ClampSampler, coord.vUv, 0).r;
-    c *= sunrays;
-#ifdef BLOOM
-    bloom *= sunrays;
-#endif
-#endif
+    float3 bloom = (doBloom) ? UBloom.SampleLevel(ClampSampler, coord.vUv, 0).rgb : 0;
 
-#ifdef BLOOM
-    float noise = UDithering.SampleLevel(RepeatSampler, coord.vUv * Params.ditherScale, 0).r;
-    noise       = noise * 2.0 - 1.0;
-    bloom += noise / 255.0;
-    bloom = linearToGamma(bloom);
-    c += bloom;
-#endif
+    if (doSunrays) {
+        float sunrays = USunrays.SampleLevel(ClampSampler, coord.vUv, 0).r;
+        c *= sunrays;
+        if (doBloom) {
+            bloom *= sunrays;
+        }
+    }
+
+    if (doBloom) {
+        float noise = UDithering.SampleLevel(RepeatSampler, coord.vUv * Params.ditherScale, 0).r;
+        noise       = noise * 2.0 - 1.0;
+        bloom += noise / 255.0;
+        bloom = linearToGamma(bloom);
+        c += bloom;
+    }
 
     float a          = max(c.r, max(c.g, c.b));
     Output[coord.xy] = float4(c, a);

--- a/projects/fluid_simulation/shaders.h
+++ b/projects/fluid_simulation/shaders.h
@@ -93,6 +93,14 @@ private:
     ppx::grfx::DescriptorSetPtr mDescriptorSet = nullptr;
 };
 
+// Filter option bitmasks to use in ScalarInput::filterOptions.
+//
+// This MUST match the constants defined in assets/fluid_simulation/shaders/config.hlsli.
+const uint32_t kAdvectionManualFiltering = 1 << 0;
+const uint32_t kDisplayShading           = 1 << 1;
+const uint32_t kDisplayBloom             = 1 << 2;
+const uint32_t kDisplaySunrays           = 1 << 3;
+
 // Scalar inputs for the filter programs.
 //
 // This needs to be 16-bit aligned to be copied into a uniform buffer.
@@ -119,6 +127,7 @@ struct alignas(16) ScalarInput
     float       weight             = .0f;
     float       curl               = .0f;
     ppx::float2 normalizationScale = ppx::float2();
+    uint32_t    filterOptions      = 0;
 };
 
 class ComputeShader

--- a/projects/fluid_simulation/sim.cpp
+++ b/projects/fluid_simulation/sim.cpp
@@ -141,6 +141,14 @@ void FluidSimulationApp::InitKnobs()
     GetKnobManager().InitKnob(&mConfig.pSimResolution, "sim-resolution", 128, 1, 1000);
     mConfig.pSimResolution->SetDisplayName("Simulation Resolution");
     mConfig.pSimResolution->SetFlagDescription("This determines the grid size of the grids used during simulation. Higher values produce finer grids which produce a more accurate representation.");
+
+    GetKnobManager().InitKnob(&mConfig.pEnableShading, "shading", true);
+    mConfig.pEnableShading->SetDisplayName("Shading");
+    mConfig.pEnableShading->SetFlagDescription("Indicates whether to perform diffuse shading on the resulting output.");
+
+    GetKnobManager().InitKnob(&mConfig.pEnableManualAdvection, "manual-advection", false);
+    mConfig.pEnableManualAdvection->SetDisplayName("Manual advection");
+    mConfig.pEnableManualAdvection->SetFlagDescription("Indicates whether to perform manual advection on the velocity field. If enabled, advection is computed as a bi-linear interpolation on the velocity field. Otherwise, it is computed directly from velocity.");
 }
 
 void FluidSimulationApp::Config(ppx::ApplicationSettings& settings)
@@ -397,6 +405,12 @@ void FluidSimulationApp::Render()
         ScalarInput si;
         si.texelSize   = ppx::float2(1.0f / GetWindowWidth(), 1.0f / GetWindowHeight());
         si.ditherScale = mDitheringGrid->GetDitherScale(GetWindowWidth(), GetWindowHeight());
+        if (GetConfig().pEnableBloom->GetValue())
+            si.filterOptions |= kDisplayBloom;
+        if (GetConfig().pEnableSunrays->GetValue())
+            si.filterOptions |= kDisplaySunrays;
+        if (GetConfig().pEnableShading->GetValue())
+            si.filterOptions |= kDisplayShading;
         mDisplay->Dispatch(&frame, {mDyeGrid[0].get(), mBloomGrid.get(), mSunraysGrid.get(), mDitheringGrid.get(), mDisplayGrid.get()}, &si);
 
         ppx::grfx::RenderPassPtr renderPass = GetSwapchain()->GetRenderPass(imageIndex);
@@ -535,7 +549,6 @@ void FluidSimulationApp::MultipleSplats(PerFrame* pFrame, uint32_t amount)
         amount = Random().UInt32() % 20 + 5;
     }
 
-    PPX_LOG_DEBUG("Emitting " << amount << " splashes of color\n");
     for (uint32_t i = 0; i < amount; i++) {
         ppx::float3 color = GenerateColor();
         color.r *= 10.0f;
@@ -543,7 +556,6 @@ void FluidSimulationApp::MultipleSplats(PerFrame* pFrame, uint32_t amount)
         color.b *= 10.0f;
         ppx::float2 coordinate(Random().Float(), Random().Float());
         ppx::float2 delta(1000.0f * (Random().Float() - 0.5f), 1000.0f * (Random().Float() - 0.5f));
-        PPX_LOG_DEBUG("Splash #" << i << " at " << coordinate << " with color " << color << "\n");
         Splat(pFrame, coordinate, delta, color);
     }
 }
@@ -640,7 +652,6 @@ void FluidSimulationApp::DebugGrids(const PerFrame& frame)
             coord.y -= maxDimY;
             maxDimY = 0.0f;
         }
-        PPX_LOG_DEBUG("Scheduling grid draw for " << t->GetName() << " with normalized dimensions " << dim << " at coordinate " << coord << "\n");
         t->Draw(frame, coord);
         coord.x += dim.x + 0.005f;
         if (dim.y > maxDimY) {
@@ -743,11 +754,12 @@ void FluidSimulationApp::Step(PerFrame* pFrame, float delta)
     mGradientSubtract->Dispatch(pFrame, {mPressureGrid[0].get(), mVelocityGrid[0].get(), mVelocityGrid[1].get()}, &si);
     std::swap(mVelocityGrid[0], mVelocityGrid[1]);
 
-    si              = ScalarInput();
-    si.dt           = delta;
-    si.dissipation  = GetConfig().pVelocityDissipation->GetValue();
-    si.texelSize    = texelSize;
-    si.dyeTexelSize = texelSize;
+    si               = ScalarInput();
+    si.dt            = delta;
+    si.dissipation   = GetConfig().pVelocityDissipation->GetValue();
+    si.texelSize     = texelSize;
+    si.dyeTexelSize  = texelSize;
+    si.filterOptions = GetConfig().pEnableManualAdvection->GetValue() ? kAdvectionManualFiltering : 0;
     mAdvection->Dispatch(pFrame, {mVelocityGrid[0].get(), mVelocityGrid[0].get(), mVelocityGrid[1].get()}, &si);
     std::swap(mVelocityGrid[0], mVelocityGrid[1]);
 

--- a/projects/fluid_simulation/sim.cpp
+++ b/projects/fluid_simulation/sim.cpp
@@ -405,12 +405,15 @@ void FluidSimulationApp::Render()
         ScalarInput si;
         si.texelSize   = ppx::float2(1.0f / GetWindowWidth(), 1.0f / GetWindowHeight());
         si.ditherScale = mDitheringGrid->GetDitherScale(GetWindowWidth(), GetWindowHeight());
-        if (GetConfig().pEnableBloom->GetValue())
+        if (GetConfig().pEnableBloom->GetValue()) {
             si.filterOptions |= kDisplayBloom;
-        if (GetConfig().pEnableSunrays->GetValue())
+        }
+        if (GetConfig().pEnableSunrays->GetValue()) {
             si.filterOptions |= kDisplaySunrays;
-        if (GetConfig().pEnableShading->GetValue())
+        }
+        if (GetConfig().pEnableShading->GetValue()) {
             si.filterOptions |= kDisplayShading;
+        }
         mDisplay->Dispatch(&frame, {mDyeGrid[0].get(), mBloomGrid.get(), mSunraysGrid.get(), mDitheringGrid.get(), mDisplayGrid.get()}, &si);
 
         ppx::grfx::RenderPassPtr renderPass = GetSwapchain()->GetRenderPass(imageIndex);

--- a/projects/fluid_simulation/sim.h
+++ b/projects/fluid_simulation/sim.h
@@ -77,6 +77,8 @@ struct SimulationConfig
 
     // Misc knobs.
     std::shared_ptr<ppx::KnobSlider<int>> pSimResolution;
+    std::shared_ptr<ppx::KnobCheckbox>    pEnableShading;
+    std::shared_ptr<ppx::KnobCheckbox>    pEnableManualAdvection;
 };
 
 // Represents a virtual object bouncing around the field.


### PR DESCRIPTION
**NOTE TO REVIEWERS: This relies on the new code structure from #323, #396, #397 and #398. Please review those first. Thanks.**

This fixes #226.

Some options were dynamic in the C++ code, but were a static #define in the HLSL code.  This makes all these fitlering options a dynamic setting.