### PR TITLE
Fix names for pointer variables and arguments

### DIFF
--- a/projects/fluid_simulation/README.md
+++ b/projects/fluid_simulation/README.md
@@ -125,3 +125,11 @@ appear brighter.
 This determines the grid size of the compute textures used
 during simulation. Higher values produce finer grids which
 produce a more accurate representation.
+
+## --shading <true|false>
+Indicates whether to perform diffuse shading on the resulting output.
+
+## --manual-advection <true|false>
+Indicates whether to perform manual advection on the velocity field. If
+enabled, advection is computed as a bi-linear interpolation on the velocity
+field. Otherwise, it is computed directly from velocity.

--- a/projects/fluid_simulation/main.cpp
+++ b/projects/fluid_simulation/main.cpp
@@ -24,4 +24,6 @@
 
 #include "sim.h"
 
+#include "ppx/application.h"
+
 SETUP_APPLICATION(FluidSim::FluidSimulationApp)

--- a/projects/fluid_simulation/shaders.h
+++ b/projects/fluid_simulation/shaders.h
@@ -68,9 +68,11 @@ public:
     // Render this grid.
     void Draw(const PerFrame& frame, ppx::float2 coord);
 
-    // Compute and return the size of the texture normalized to the resolution.
-    // given in pixels.  This maps the size of the texture to the normalized
-    // coordinates ([-1, 1], [-1, 1]).
+    // Compute and return the size of the texture normalized to the given resolution
+    // in pixels. To compute the normalized size, we know that the width in pixels given
+    // by resolution.x corresponds to 2 normalized units (because normalized coordinates
+    // span the range [-1, 1]).  A similar calculation is done to map and scale the
+    // height.
     ppx::float2 GetNormalizedSize(ppx::uint2 resolution) const
     {
         return ppx::float2(GetWidth() * 2.0f / static_cast<float>(resolution.x), GetHeight() * 2.0f / static_cast<float>(resolution.y));

--- a/projects/fluid_simulation/shaders.h
+++ b/projects/fluid_simulation/shaders.h
@@ -8,13 +8,15 @@
 #ifndef FLUID_SIMULATION_SHADERS_H
 #define FLUID_SIMULATION_SHADERS_H
 
-#include "ppx/graphics_util.h"
-#include "ppx/grfx/grfx_buffer.h"
+#include "ppx/bitmap.h"
 #include "ppx/grfx/grfx_config.h"
 #include "ppx/grfx/grfx_texture.h"
 #include "ppx/math_config.h"
 
-#include <iostream>
+#include <cstdint>
+#include <iosfwd>
+#include <string>
+#include <vector>
 
 namespace FluidSim {
 
@@ -143,8 +145,8 @@ public:
     // grids    A list of grids to be bound to the descriptor set. This list is assumed to be
     //              in the same order as the list of binding slots (mGridBindingSlots) set during
     //              construction.
-    // si       A pointer to the scalar inputs to the compute shader.
-    void Dispatch(PerFrame* pFrame, const std::vector<SimulationGrid*>& grids, ScalarInput* si);
+    // pSI      A pointer to the scalar inputs to the compute shader.
+    void Dispatch(PerFrame* pFrame, const std::vector<SimulationGrid*>& grids, ScalarInput* pSI);
 
 private:
     ppx::grfx::ComputePipelinePtr mPipeline;

--- a/projects/fluid_simulation/sim.h
+++ b/projects/fluid_simulation/sim.h
@@ -12,9 +12,14 @@
 
 #include "ppx/application.h"
 #include "ppx/grfx/grfx_config.h"
+#include "ppx/grfx/grfx_helper.h"
 #include "ppx/knob.h"
 #include "ppx/math_config.h"
 #include "ppx/random.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 namespace FluidSim {
 
@@ -190,12 +195,12 @@ private:
     // the application window and can fit at least "resolution" pixels in it.
     ppx::uint2 GetResolution(uint32_t resolution) const;
 
-    void         ApplyBloom(PerFrame* pFrame, SimulationGrid* source, SimulationGrid* destination);
-    void         ApplySunrays(PerFrame* pFrame, SimulationGrid* source, SimulationGrid* mask, SimulationGrid* destination);
-    void         Blur(PerFrame* pFrame, SimulationGrid* target, SimulationGrid* temp, uint32_t iterations);
+    void         ApplyBloom(PerFrame* pFrame, SimulationGrid* pSource, SimulationGrid* pDestination);
+    void         ApplySunrays(PerFrame* pFrame, SimulationGrid* pSource, SimulationGrid* pMask, SimulationGrid* pDestination);
+    void         Blur(PerFrame* pFrame, SimulationGrid* pTarget, SimulationGrid* pTemp, uint32_t iterations);
     float        CorrectRadius(float radius) const;
     void         DebugGrids(const PerFrame& frame);
-    void         DrawGrid(const PerFrame& frame, SimulationGrid* grid, ppx::float2 coord);
+    void         DrawGrid(const PerFrame& frame, SimulationGrid* pGrid, ppx::float2 coord);
     ppx::float3  GenerateColor();
     ppx::float3  HSVtoRGB(ppx::float3 hsv);
     void         MoveMarble();

--- a/projects/fluid_simulation/sim.h
+++ b/projects/fluid_simulation/sim.h
@@ -200,7 +200,6 @@ private:
     void         Blur(PerFrame* pFrame, SimulationGrid* pTarget, SimulationGrid* pTemp, uint32_t iterations);
     float        CorrectRadius(float radius) const;
     void         DebugGrids(const PerFrame& frame);
-    void         DrawGrid(const PerFrame& frame, SimulationGrid* pGrid, ppx::float2 coord);
     ppx::float3  GenerateColor();
     ppx::float3  HSVtoRGB(ppx::float3 hsv);
     void         MoveMarble();
@@ -209,7 +208,6 @@ private:
     ppx::Random& Random() { return mRandom; }
     void         SetupBloomGrids();
     void         SetupComputeShaders();
-    void         SetupGraphicsShaders();
     void         SetupGrids();
     void         SetupRenderingPipeline();
     void         SetupSunraysGrids();


### PR DESCRIPTION
This renames pointer variables to use the `pNAME` convention (from https://github.com/google/bigwheels/pull/396#discussion_r1447951887).

Additional minor NFC fixes:

- Fix IWYU issues in files.
- Document new knobs in `README.md`.
- Fix documentation for `GetNormalizedSize()` (#400)