### PR TITLE
Add back virtual to GetXrComponent

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -532,7 +532,8 @@ public:
     virtual bool RecordMetricData(metrics::MetricID id, const metrics::MetricData& data);
 
 #if defined(PPX_BUILD_XR)
-    XrComponent& GetXrComponent()
+    // virtual is used for testing
+    virtual XrComponent& GetXrComponent()
     {
         return mXrComponent;
     }


### PR DESCRIPTION
It is used for internal tests to mock the GetXrComponent function