### PR TITLE
Fixes for graphics_pipeline benchmark wireframe mode and 1x1 texture mode

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -499,6 +499,7 @@ void GraphicsBenchmarkApp::UpdateSkyBoxDescriptors()
 
 void GraphicsBenchmarkApp::UpdateSphereDescriptors()
 {
+    GetDevice()->WaitIdle();
     uint32_t n = GetNumFramesInFlight();
     for (size_t i = 0; i < n; i++) {
         grfx::DescriptorSetPtr pDescriptorSet = mSphere.descriptorSets[i];

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -488,6 +488,7 @@ void GraphicsBenchmarkApp::SetupFullscreenQuadsResources()
 
 void GraphicsBenchmarkApp::UpdateSkyBoxDescriptors()
 {
+    GetDevice()->WaitIdle();
     uint32_t n = GetNumFramesInFlight();
     for (size_t i = 0; i < n; i++) {
         grfx::DescriptorSetPtr pDescriptorSet = mSkyBox.descriptorSets[i];
@@ -525,6 +526,7 @@ void GraphicsBenchmarkApp::UpdateSphereDescriptors()
 
 void GraphicsBenchmarkApp::UpdateFullscreenQuadsDescriptors()
 {
+    GetDevice()->WaitIdle();
     uint32_t n = GetNumFramesInFlight();
     for (size_t i = 0; i < n; i++) {
         grfx::DescriptorSetPtr pDescriptorSet = mFullscreenQuads.descriptorSets[i];

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -238,10 +238,12 @@ Result Device::ConfigureFeatures(const grfx::DeviceCreateInfo* pCreateInfo, VkPh
 
     // Default device features
     //
+    // 2024/02/13 - Changed fillModeNonSolid to true to allow use of VK_POLYGON_MODE_LINE.
     // 2021/11/15 - Changed logic to use feature bit from GPU for geo and tess shaders to accomodate
     //              SwiftShader not having support for these shader types.
     //
     features                                      = {};
+    features.fillModeNonSolid                     = VK_TRUE;
     features.fullDrawIndexUint32                  = VK_TRUE;
     features.imageCubeArray                       = VK_TRUE;
     features.independentBlend                     = foundFeatures.independentBlend;


### PR DESCRIPTION
Fixes:
- #432 Adding WaitIdle() before sphere descriptors are updated
- #423 Setting fillModeNonSolid to true for all applications to allow use of VK_POLYGON_MODE_LINE