### PR TITLE
[knob-framework] Knob Framework V2

### DIFF
--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -20,6 +20,7 @@
 #include "ppx/fs.h"
 #include "ppx/imgui_impl.h"
 #include "ppx/knob.h"
+#include "ppx/knob_new.h"
 #include "ppx/math_config.h"
 #include "ppx/metrics.h"
 #include "ppx/timer.h"
@@ -258,6 +259,40 @@ struct StandardOptions
     std::shared_ptr<KnobFlag<std::string>> pShadingRateMode;
 };
 
+struct StandardOptionsNew
+{
+    // Flags
+    std::shared_ptr<GeneralKnob<bool>> pListGpus;
+    std::shared_ptr<GeneralKnob<bool>> pUseSoftwareRenderer;
+#if !defined(PPX_LINUX_HEADLESS)
+    std::shared_ptr<GeneralKnob<bool>> pHeadless;
+#endif
+    std::shared_ptr<GeneralKnob<bool>> pDeterministic;
+    std::shared_ptr<GeneralKnob<bool>> pEnableMetrics;
+    std::shared_ptr<GeneralKnob<bool>> pOverwriteMetricsFile;
+
+    // Options
+    std::shared_ptr<RangeKnob<uint32_t>> pGpuIndex;
+    std::shared_ptr<RangeKnob<uint64_t>> pFrameCount;
+    std::shared_ptr<RangeKnob<uint32_t>> pRunTimeMs;
+    std::shared_ptr<RangeKnob<int>>      pStatsFrameWindow;
+    std::shared_ptr<RangeKnob<int>>      pScreenshotFrameNumber;
+
+    std::shared_ptr<GeneralKnob<std::string>> pScreenshotPath;
+    std::shared_ptr<GeneralKnob<std::string>> pMetricsFilename;
+
+    std::shared_ptr<RangeKnob<int>> pResolution;
+#if defined(PPX_BUILD_XR)
+    std::shared_ptr<RangeKnob<int>>                        pXrUiResolution;
+    std::shared_ptr<GeneralKnob<std::vector<std::string>>> pXrRequiredExtensions;
+#endif
+
+    std::shared_ptr<GeneralKnob<std::vector<std::string>>> pAssetsPaths;
+    std::shared_ptr<GeneralKnob<std::vector<std::string>>> pConfigJsonPaths;
+
+    std::shared_ptr<GeneralKnob<std::string>> pShadingRateMode;
+};
+
 // -------------------------------------------------------------------------------------------------
 // Application
 // -------------------------------------------------------------------------------------------------
@@ -372,6 +407,8 @@ struct ApplicationSettings
         std::vector<std::string> xrRequiredExtensions = {};
 #endif
     } standardKnobsDefaultValue;
+
+    bool useKnobManagerNew = false;
 };
 
 //! @class Application
@@ -440,7 +477,8 @@ protected:
     void DrawDebugInfo();
     void DrawProfilerGrfxApiFunctions();
 
-    KnobManager& GetKnobManager() { return mKnobManager; }
+    KnobManager&    GetKnobManager() { return mKnobManager; }
+    KnobManagerNew& GetKnobManagerNew() { return mKnobManagerNew; }
 
 public:
     int  Run(int argc, char** argv);
@@ -451,6 +489,7 @@ public:
 
     const ApplicationSettings* GetSettings() const { return &mSettings; }
     const StandardOptions&     GetStandardOptions() const { return mStandardOpts; }
+    const StandardOptionsNew&  GetStandardOptionsNew() const { return mStandardOptsNew; }
     uint32_t                   GetWindowWidth() const { return mSettings.window.width; }
     uint32_t                   GetWindowHeight() const { return mSettings.window.height; }
     bool                       IsWindowIconified() const;
@@ -589,6 +628,7 @@ private:
 
     // Initializes standard knobs
     void InitStandardKnobs();
+    void InitStandardKnobsNew();
 
     // List gpus
     void ListGPUs() const;
@@ -628,6 +668,7 @@ private:
 private:
     CommandLineParser               mCommandLineParser;
     StandardOptions                 mStandardOpts;
+    StandardOptionsNew              mStandardOptsNew;
     float                           mRunTimeSeconds;
     ApplicationSettings             mSettings = {};
     std::string                     mDecoratedApiName;
@@ -643,6 +684,7 @@ private:
     std::vector<grfx::SwapchainPtr> mSwapchains;                           // Requires enableDisplay
     std::unique_ptr<ImGuiImpl>      mImGui;
     KnobManager                     mKnobManager;
+    KnobManagerNew                  mKnobManagerNew;
 
     uint64_t          mFrameCount        = 0;
     uint32_t          mSwapchainIndex    = 0;

--- a/include/ppx/knob_new.h
+++ b/include/ppx/knob_new.h
@@ -1,0 +1,940 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ppx_knob_new_h
+#define ppx_knob_new_h
+
+#include "ppx/options_new.h"
+#include "ppx/config.h"
+#include "ppx/imgui_impl.h"
+#include "ppx/log.h"
+#include "ppx/string_util.h"
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <unordered_set>
+#include <vector>
+
+namespace ppx {
+
+// Knobs represent parameters that can be adjusted during the application runtime.
+//
+// Defining and registering a knob with the application's KnobManagerNew will create a parameter
+// whose starting value is determined by (from high priority -> low):
+// - A specified command-line flag
+// - A value specified in a config file
+// - The default value provided when the knob is created
+//
+// The startup value is saved when the KnobManagerNew finalizes the knobs.
+//
+// Then, while the application is running:
+// - Users can manually adjust the knob through the UI
+// - The application can access the knob's values through the knob getters and setters
+// - JSON config files can be saved and loaded
+
+enum class KnobDisplayType
+{
+    PLAIN,
+    CHECKBOX,
+    FAST_SLIDER,
+    SLOW_SLIDER,
+    DROPDOWN,
+    COLOR
+};
+
+// ---------------------------------------------------------------------------------------------
+// KnobNew Classes
+// ---------------------------------------------------------------------------------------------
+
+// KnobNew is an abstract class which contains common features for all knobs and knob hierarchy
+class KnobNew
+{
+public:
+    KnobNew(const std::string& flagName)
+        : mDisplayIndent(0),
+          mDisplayName(flagName),
+          mDisplayType(KnobDisplayType::PLAIN),
+          mDisplayVisible(true),
+          mFinalized(false),
+          mFlagName(flagName),
+          mStartupDisplayVisible(false),
+          mStartupOnly(false),
+          mUpdatedFlag(false) {}
+    virtual ~KnobNew() = default;
+
+    // Customize knob functionality
+    void SetStartupOnly();
+
+    // Customize flag usage message
+    void SetFlagDescription(const std::string& flagDescription) { mFlagDescription = flagDescription; }
+    void SetFlagParameters(const std::string& flagParameters) { mFlagParameters = flagParameters; }
+
+    // Customize how knob is drawn in the UI
+    void SetDisplayType(KnobDisplayType newDisplayType) { mDisplayType = newDisplayType; }
+    void SetDisplayName(const std::string& displayName) { mDisplayName = displayName; }
+    void SetIndent(size_t indent) { mDisplayIndent = indent; }
+    void SetVisible(bool visible) { mDisplayVisible = visible; }
+
+    // Returns true if there has been an update to the knob value
+    bool DigestUpdate();
+
+protected:
+    void RaiseUpdatedFlag() { mUpdatedFlag = true; }
+
+    // Helper functions for drawing in UI
+    void DrawPlain();
+    void DrawToolTip();
+
+private:
+    // Called from KnobManagerNew
+    virtual void        Draw()        = 0;
+    virtual std::string ValueString() = 0;
+    void                Finalize();
+    void                ResetToStartup();
+    std::string         GetFlagParameters();
+
+    // Called by the ones above
+    virtual void        FinalizeValues()           = 0;
+    virtual void        ResetValuesToStartup()     = 0;
+    virtual std::string GetDefaultFlagParameters() = 0;
+
+    // Convert list of strings to knob values and vice versa
+    virtual void                     Load(const std::vector<std::string>& valueStrings) = 0;
+    virtual std::vector<std::string> Save()                                             = 0;
+
+protected:
+    std::string mFlagName;
+
+    // Parameters for how the knob will be displayed in the UI
+    std::string     mDisplayName;
+    KnobDisplayType mDisplayType;
+
+    // If true, startup values have been stored and can no longer be changed
+    bool mFinalized;
+
+    // If true, once finalized this knob cannot have its value changed
+    bool mStartupOnly;
+
+private:
+    // Boolean flag tracking when the knob value has been updated
+    bool mUpdatedFlag;
+
+    // Parameters for how the knob is described in the usage message
+    std::string mFlagParameters;
+    std::string mFlagDescription; // also used in the tooltip
+
+    // Parameters for how the knob will be displayed in the UI
+    size_t          mDisplayIndent;
+    bool            mDisplayVisible;
+    bool            mStartupDisplayVisible;
+    KnobDisplayType mStartupDisplayType;
+
+private:
+    friend class KnobManagerNew;
+};
+
+// GeneralKnob can hold varied types and can have a user-specified validator function.
+template <typename T>
+class GeneralKnob final
+    : public KnobNew
+{
+public:
+    GeneralKnob(const std::string& flagName, T defaultValue)
+        : KnobNew(flagName)
+    {
+        PPX_ASSERT_MSG(IsValidValue(defaultValue), "GeneralKnob " + mFlagName + " cannot be created with value " + ppx::string_util::ToString(defaultValue));
+        SetValue(defaultValue);
+    }
+
+    T GetValue() const { return mValue; }
+
+    void SetValue(T newValue)
+    {
+        if (mFinalized && mStartupOnly) {
+            PPX_LOG_ERROR("GeneralKnob " + mFlagName + " is startup-only and cannot be set after finalization");
+            return;
+        }
+        if (!IsValidValue(newValue)) {
+            PPX_LOG_ERROR("GeneralKnob " + mFlagName + " cannot be set to value " + ppx::string_util::ToString(newValue));
+            return;
+        }
+        if (mValue == newValue) {
+            return;
+        }
+        mValue = newValue;
+        RaiseUpdatedFlag();
+    }
+
+    void SetValidator(std::function<bool(T)> validatorFunc)
+    {
+        PPX_ASSERT_MSG(!mFinalized, "GeneralKnob " + mFlagName + " cannot have a validator set since it is finalized");
+        PPX_ASSERT_MSG(validatorFunc(mValue), "GeneralKnob " + mFlagName + " cannot have a validator set that makes the current value invalid");
+
+        mValidatorFunc = validatorFunc;
+    }
+
+private:
+    void Draw() override
+    {
+        switch (mDisplayType) {
+            case KnobDisplayType::PLAIN: {
+                DrawPlain();
+                return;
+            }
+            case KnobDisplayType::CHECKBOX: {
+                if constexpr (std::is_same_v<T, bool>) {
+                    bool displayValue = mValue;
+                    bool interacted   = ImGui::Checkbox(mDisplayName.c_str(), &displayValue);
+                    DrawToolTip();
+                    if (!interacted) {
+                        return;
+                    }
+                    SetValue(displayValue);
+                    return;
+                }
+                PPX_ASSERT_MSG(false, "GeneralKnob " << mFlagName << " is incompatable with display type CHECKBOX");
+                return;
+            }
+        }
+        PPX_ASSERT_MSG(false, "GeneralKnob " << mFlagName << " does not support display type " << static_cast<int>(mDisplayType));
+        return;
+    }
+
+    void FinalizeValues() override
+    {
+        mStartupValue = mValue;
+    }
+
+    void ResetValuesToStartup() override
+    {
+        mValue = mStartupValue;
+        RaiseUpdatedFlag();
+    }
+
+    std::string GetDefaultFlagParameters() override
+    {
+        return ""; // Empty parameters for GeneralKnob
+    }
+
+    void Load(const std::vector<std::string>& valueStrings) override
+    {
+        LoadValue(mValue, valueStrings);
+    }
+
+    std::vector<std::string> Save() override
+    {
+        return SaveValue(mValue);
+    }
+
+    std::string ValueString() override
+    {
+        return ppx::string_util::ToString(mValue);
+    }
+
+    bool IsValidValue(T val)
+    {
+        if (!mValidatorFunc) {
+            return true;
+        }
+        return mValidatorFunc(val);
+    }
+
+    // Tries to parse the option string into the type of the current value and load it into mValue.
+    template <typename U>
+    void LoadValue(const U& currentValue, const std::vector<std::string>& valueStrings)
+    {
+        // The knob value is not a vector, interpret from only the last value string
+        auto valueStr = valueStrings.back();
+        U    parsedValue;
+        auto res = ppx::string_util::Parse(valueStr, parsedValue);
+        if (Failed(res)) {
+            PPX_LOG_ERROR("GeneralKnob " << mFlagName << " could not be loaded with string " << valueStr);
+            return;
+        }
+        SetValue(parsedValue);
+    }
+
+    // Same as above, but intended for GeneralKnob of vector type.
+    template <typename U>
+    void LoadValue(const std::vector<U>& currentValues, const std::vector<std::string>& valueStrings)
+    {
+        // The knob value is a vector, interpret each value string as an element in the vector
+        std::vector<U> parsedValues;
+        for (size_t i = 0; i < valueStrings.size(); ++i) {
+            U    parsedValue{};
+            auto res = ppx::string_util::Parse(valueStrings.at(i), parsedValue);
+            if (Failed(res)) {
+                PPX_LOG_ERROR("GeneralKnob " << mFlagName << " element could not be loaded with string " << valueStrings.at(i));
+                return;
+            }
+            parsedValues.emplace_back(parsedValue);
+        }
+        SetValue(parsedValues);
+    }
+
+    // Returns the current value (non-list) as a vector of strings with one element.
+    template <typename U>
+    std::vector<std::string> SaveValue(const U& currentValue)
+    {
+        std::vector<std::string> valueStrings = {};
+        valueStrings.emplace_back(ppx::string_util::ToString(currentValue));
+        return valueStrings;
+    }
+
+    // Same as above, but intended for GeneralKnob of vector type
+    // Returns vector of strings with the same number of elements as the current value.
+    template <typename U>
+    std::vector<std::string> SaveValue(const std::vector<U>& currentValues)
+    {
+        std::vector<std::string> valueStrings = {};
+        for (const auto& currentValue : currentValues) {
+            valueStrings.emplace_back(ppx::string_util::ToString(currentValue));
+        }
+        return valueStrings;
+    }
+
+private:
+    T mValue;
+    T mStartupValue;
+
+    std::function<bool(T)> mValidatorFunc;
+};
+
+// RangeKnob can hold arithmetic types and restricts the value to be between min~max range, inclusive.
+template <typename T>
+class RangeKnob final
+    : public KnobNew
+{
+public:
+    template <typename Iter>
+    RangeKnob(const std::string& flagName, Iter defaultsBegin, Iter defaultsEnd)
+        : KnobNew(flagName)
+    {
+        size_t                   i = 0;
+        std::vector<std::string> displaySuffixes;
+        for (auto iter = defaultsBegin; iter != defaultsEnd; ++iter) {
+            mMaxValues.push_back(std::numeric_limits<T>::max());
+            mMinValues.push_back(std::numeric_limits<T>::min());
+            PPX_ASSERT_MSG(IsValidValue(i, *iter), "RangeKnob " << mFlagName << " cannot be created with value " << *iter << " at position " << i);
+            mValues.push_back(*iter);
+            displaySuffixes.push_back(ppx::string_util::ToString(i));
+            i++;
+        }
+        mDisplayValues = mValues;
+        SetDisplaySuffixes(displaySuffixes);
+        RaiseUpdatedFlag();
+    }
+
+    RangeKnob(const std::string& flagName, T defaultValue)
+        : RangeKnob(flagName, std::vector<T>{defaultValue}) {}
+
+    RangeKnob(const std::string& flagName, std::vector<T> defaultValues)
+        : RangeKnob(flagName, std::begin(defaultValues), std::end(defaultValues)) {}
+
+    T GetValue(size_t i) const
+    {
+        PPX_ASSERT_MSG((i >= 0) && (i < mValues.size()), "RangeKnob " << mFlagName << " value cannot be accessed at position " << i);
+        return mValues[i];
+    }
+
+    void SetValue(size_t i, T newValue)
+    {
+        if (mFinalized && mStartupOnly) {
+            PPX_LOG_ERROR("RangeKnob " + mFlagName + " is startup-only and cannot be set after finalization");
+            return;
+        }
+        PPX_ASSERT_MSG((i >= 0) && (i < mValues.size()) && (i < mDisplayValues.size()), "RangeKnob " << mFlagName << " value cannot be accessed at position " << i);
+        if (!IsValidValue(i, newValue)) {
+            LogRange(i);
+            PPX_LOG_ERROR("RangeKnob " + mFlagName + " position " + ppx::string_util::ToString(i) + " cannot be set to value " + ppx::string_util::ToString(newValue));
+            return;
+        }
+        if (mValues[i] == newValue) {
+            return;
+        }
+        mValues[i]        = newValue;
+        mDisplayValues[i] = newValue;
+        RaiseUpdatedFlag();
+    }
+
+    void SetMax(size_t i, T newMaxValue)
+    {
+        if (mFinalized && mStartupOnly) {
+            PPX_LOG_ERROR("RangeKnob " + mFlagName + " is startup-only and cannot be set after finalization");
+            return;
+        }
+        PPX_ASSERT_MSG((i >= 0) && (i < mMaxValues.size()), "RangeKnob " << mFlagName << " max cannot be accessed at position " << i);
+        PPX_ASSERT_MSG(newMaxValue >= mMinValues[i], "RangeKnob " << mFlagName << " max cannot be smaller than min at position " << i);
+        mMaxValues[i] = newMaxValue;
+        if (mValues[i] > newMaxValue) {
+            SetValue(i, newMaxValue);
+        }
+    }
+
+    void SetMin(size_t i, T newMinValue)
+    {
+        if (mFinalized && mStartupOnly) {
+            PPX_LOG_ERROR("RangeKnob " + mFlagName + " is startup-only and cannot be set after finalization");
+            return;
+        }
+        PPX_ASSERT_MSG((i >= 0) && (i < mMinValues.size()), "RangeKnob " << mFlagName << " min cannot be accessed at position " << i);
+        PPX_ASSERT_MSG(newMinValue <= mMaxValues[i], "RangeKnob " << mFlagName << " min cannot be larger than max at position " << i);
+        mMinValues[i] = newMinValue;
+        if (mValues[i] < newMinValue) {
+            SetValue(i, newMinValue);
+        }
+    }
+
+    // For N=1 case
+    T GetValue() const
+    {
+        PPX_ASSERT_MSG(mValues.size() == 1, "specify index when RangeKnob N>1");
+        return GetValue(0);
+    }
+    void SetValue(T newValue)
+    {
+        PPX_ASSERT_MSG(mValues.size() == 1, "specify index when RangeKnob N>1");
+        SetValue(0, newValue);
+    }
+    void SetMax(T newMaxValue)
+    {
+        PPX_ASSERT_MSG(mValues.size() == 1, "specify index when RangeKnob N>1");
+        SetMax(0, newMaxValue);
+    }
+    void SetMin(T newMaxValue)
+    {
+        PPX_ASSERT_MSG(mValues.size() == 1, "specify index when RangeKnob N>1");
+        SetMin(0, newMaxValue);
+    }
+
+    // For N>1 cases
+    void SetAllValues(T newValue)
+    {
+        for (size_t i = 0; i < mValues.size(); i++) {
+            SetValue(i, newValue);
+        }
+    }
+    void SetAllMaxes(T newMaxValue)
+    {
+        for (size_t i = 0; i < mMaxValues.size(); i++) {
+            SetMax(i, newMaxValue);
+        }
+    }
+    void SetAllMins(T newMinValue)
+    {
+        for (size_t i = 0; i < mMinValues.size(); i++) {
+            SetMin(i, newMinValue);
+        }
+    }
+
+    void SetDisplaySuffixes(const std::vector<std::string>& newSuffixes)
+    {
+        PPX_ASSERT_MSG(newSuffixes.size() == mValues.size(), "RangeKnob " << mFlagName << " must have " << mValues.size() << " suffixes set");
+        mDisplaySuffixes = newSuffixes;
+    }
+
+private:
+    void FinalizeValues() override
+    {
+        mStartupValues    = mValues;
+        mStartupMinValues = mMinValues;
+        mStartupMaxValues = mMaxValues;
+
+        mDisplayValues = mValues;
+    }
+
+    void ResetValuesToStartup() override
+    {
+        mValues    = mStartupValues;
+        mMinValues = mStartupMinValues;
+        mMaxValues = mStartupMaxValues;
+
+        mDisplayValues = mValues;
+        RaiseUpdatedFlag();
+    }
+
+    std::string GetDefaultFlagParameters() override
+    {
+        std::vector<std::string> minStrings;
+        for (const auto& min : mMinValues) {
+            if (min == std::numeric_limits<T>::min()) {
+                minStrings.push_back("MIN");
+                continue;
+            }
+            minStrings.push_back(ppx::string_util::ToString(min));
+        }
+        std::vector<std::string> maxStrings;
+        for (const auto& max : mMaxValues) {
+            if (max == std::numeric_limits<T>::max()) {
+                maxStrings.push_back("MAX");
+                continue;
+            }
+            maxStrings.push_back(ppx::string_util::ToString(max));
+        }
+        return "<" + ppx::string_util::ToString(minStrings) + " ~ " + ppx::string_util::ToString(maxStrings) + ">";
+    }
+
+    void Draw() override
+    {
+        switch (mDisplayType) {
+            case KnobDisplayType::PLAIN: {
+                DrawPlain();
+                return;
+            }
+            case KnobDisplayType::SLOW_SLIDER: {
+                if constexpr (std::is_same_v<T, int>) {
+                    for (size_t i = 0; i < mValues.size(); i++) {
+                        std::string displayName = mDisplayName + " " + mDisplaySuffixes.at(i);
+                        if (mValues.size() == 1) {
+                            displayName = mDisplayName;
+                        }
+                        ImGui::SliderInt(displayName.c_str(), &mDisplayValues[i], mMinValues[i], mMaxValues[i], NULL, ImGuiSliderFlags_AlwaysClamp);
+                        if (ImGui::IsItemDeactivatedAfterEdit()) {
+                            SetValue(i, mDisplayValues[i]);
+                        }
+                        DrawToolTip();
+                    }
+                }
+                else if constexpr (std::is_same_v<T, float>) {
+                    for (size_t i = 0; i < mValues.size(); i++) {
+                        std::string displayName = mDisplayName + " " + mDisplaySuffixes.at(i);
+                        if (mValues.size() == 1) {
+                            displayName = mDisplayName;
+                        }
+                        ImGui::SliderFloat(displayName.c_str(), &mDisplayValues[i], mMinValues[i], mMaxValues[i], "%.3f", ImGuiSliderFlags_AlwaysClamp);
+                        if (ImGui::IsItemDeactivatedAfterEdit()) {
+                            SetValue(i, mDisplayValues[i]);
+                        }
+                        DrawToolTip();
+                    }
+                }
+                else {
+                    PPX_ASSERT_MSG(false, "RangeKnob " << mFlagName << " is incompatible with display type SLOW_SLIDER");
+                }
+                return;
+            }
+            case KnobDisplayType::FAST_SLIDER: {
+                if constexpr (std::is_same_v<T, int>) {
+                    for (size_t i = 0; i < mValues.size(); i++) {
+                        std::string displayName = mDisplayName + " " + mDisplaySuffixes.at(i);
+                        if (mValues.size() == 1) {
+                            displayName = mDisplayName;
+                        }
+                        if (ImGui::SliderInt(displayName.c_str(), &mValues[i], mMinValues[i], mMaxValues[i], NULL, ImGuiSliderFlags_AlwaysClamp)) {
+                            RaiseUpdatedFlag();
+                        }
+                        DrawToolTip();
+                    }
+                }
+                else if constexpr (std::is_same_v<T, float>) {
+                    for (size_t i = 0; i < mValues.size(); i++) {
+                        std::string displayName = mDisplayName + " " + mDisplaySuffixes.at(i);
+                        if (mValues.size() == 1) {
+                            displayName = mDisplayName;
+                        }
+                        if (ImGui::SliderFloat(displayName.c_str(), &mValues[i], mMinValues[i], mMaxValues[i], "%.3f", ImGuiSliderFlags_AlwaysClamp)) {
+                            RaiseUpdatedFlag();
+                        }
+                        DrawToolTip();
+                    }
+                }
+                else {
+                    PPX_ASSERT_MSG(false, "RangeKnob " << mFlagName << " is incompatible with display type FAST_SLIDER");
+                }
+                return;
+            }
+        }
+        PPX_ASSERT_MSG(false, "RangeKnob " << mFlagName << " does not support display type " << static_cast<int>(mDisplayType));
+        return;
+    }
+
+    void Load(const std::vector<std::string>& valueStrings) override
+    {
+        // Only use the last value string
+        std::string valueString = valueStrings.back();
+
+        // Interpret the first non-numerical character as a delimeter
+        // [0-9] and '.', '-' are all considered numerical
+        char delimiter = ',';
+        for (auto& c : valueString) {
+            if (!std::isdigit(c) && c != '.' && c != '-') {
+                delimiter = c;
+                break;
+            }
+        }
+
+        auto splitValues = ppx::string_util::Split(valueString, delimiter);
+        if (splitValues.size() != mValues.size()) {
+            PPX_LOG_ERROR("RangeKnob " << mFlagName << " could not be loaded with string " << valueString);
+            return;
+        }
+
+        std::vector<T> parsedValues;
+        for (size_t i = 0; i < splitValues.size(); ++i) {
+            T    parsedValue;
+            auto res = ppx::string_util::Parse(splitValues.at(i), parsedValue);
+            if (Failed(res)) {
+                PPX_LOG_ERROR("RangeKnob " << mFlagName << " element could not be loaded with string " << splitValues.at(i));
+                return;
+            }
+            parsedValues.emplace_back(parsedValue);
+        }
+
+        for (size_t i = 0; i < parsedValues.size(); ++i) {
+            SetValue(i, parsedValues.at(i));
+        }
+    }
+
+    std::vector<std::string> Save() override
+    {
+        std::vector<std::string> valueStrings;
+        // single comma-separated string
+        valueStrings.emplace_back(ValueString());
+        return valueStrings;
+    }
+
+    std::string ValueString() override
+    {
+        return ppx::string_util::ToString(mValues);
+    }
+
+    bool IsValidValue(size_t i, T val)
+    {
+        PPX_ASSERT_MSG((i >= 0) && (i < mMinValues.size()) && (i < mMaxValues.size()), "RangeKnob " << mFlagName << " index out of range: " << i);
+
+        if ((val >= mMinValues[i]) && (val <= mMaxValues[i])) {
+            return true;
+        }
+        return false;
+    }
+
+    void LogRange(size_t i)
+    {
+        PPX_LOG_INFO("RangeKnob " + mFlagName + " at position " + ppx::string_util::ToString(i) + " has range " + ppx::string_util::ToString(mMinValues[i]) + "~" + ppx::string_util::ToString(mMaxValues[i]));
+    }
+
+private:
+    std::vector<T>           mValues;
+    std::vector<T>           mStartupValues;
+    std::vector<T>           mMinValues;
+    std::vector<T>           mStartupMinValues;
+    std::vector<T>           mMaxValues;
+    std::vector<T>           mStartupMaxValues;
+    std::vector<T>           mDisplayValues;
+    std::vector<std::string> mDisplaySuffixes;
+};
+
+// OptionKnobEntry is used to supply choices to OptionKnob
+template <typename T, typename NameT = const char*>
+struct OptionKnobEntry
+{
+    NameT name;
+    T     value;
+};
+
+// OptionKnob stores the index of a selected choice, a list of allowed options, and a mask of which options are valid
+template <typename T>
+class OptionKnob final
+    : public KnobNew
+{
+private:
+    using Entry = OptionKnobEntry<T, std::string>;
+    Entry ConvertToEntry(const T& value)
+    {
+        using string_util::ToString;
+        std::string name;
+        if constexpr (std::is_same_v<T, std::string>) {
+            name = value;
+        }
+        else {
+            name = ToString(value);
+        }
+        return {std::move(name), value};
+    }
+    template <typename NameT>
+    Entry ConvertToEntry(const OptionKnobEntry<T, NameT>& entry)
+    {
+        return {entry.name, entry.value};
+    }
+
+public:
+    template <typename Iter>
+    OptionKnob(
+        const std::string& flagName,
+        size_t             defaultIndex,
+        Iter               choicesBegin,
+        Iter               choicesEnd)
+        : KnobNew(flagName), mIndex(defaultIndex), mStartupIndex(defaultIndex)
+    {
+        for (auto iter = choicesBegin; iter != choicesEnd; ++iter) {
+            mChoices.push_back(ConvertToEntry(*iter));
+            mMask.push_back(true);
+        }
+        PPX_ASSERT_MSG(defaultIndex < mChoices.size(), "defaultIndex is out of range");
+        RaiseUpdatedFlag();
+    }
+
+    template <typename Container>
+    OptionKnob(
+        const std::string& flagName,
+        size_t             defaultIndex,
+        const Container&   container)
+        : OptionKnob(flagName, defaultIndex, std::begin(container), std::end(container)) {}
+
+    size_t   GetIndex() const { return mIndex; }
+    const T& GetValue() const { return mChoices[mIndex].value; }
+
+    void SetIndex(size_t newIndex)
+    {
+        if (mFinalized && mStartupOnly) {
+            PPX_LOG_ERROR("OptionKnob " + mFlagName + " is startup-only and cannot be set after finalization");
+            return;
+        }
+        if (!IsValidIndex(newIndex)) {
+            PPX_LOG_ERROR(mFlagName << " does not have this index in allowed choices: " << newIndex);
+            return;
+        }
+        if (newIndex == mIndex) {
+            return;
+        }
+        mIndex = newIndex;
+        RaiseUpdatedFlag();
+    }
+
+    void SetMask(size_t i, bool newValue)
+    {
+        if (mFinalized && mStartupOnly) {
+            PPX_LOG_ERROR("OptionKnob " + mFlagName + " is startup-only and cannot be set after finalization");
+            return;
+        }
+        PPX_ASSERT_MSG(i < mMask.size(), "OptionKnob " + mFlagName + " mask index out of range " + ppx::string_util::ToString(i));
+        mMask[i] = newValue;
+
+        if ((i == mIndex) && (!newValue)) {
+            SetIndex(GetFirstValidIndex());
+        }
+    }
+
+    void SetMask(const std::vector<bool>& newMask)
+    {
+        if (mFinalized && mStartupOnly) {
+            PPX_LOG_ERROR("OptionKnob " + mFlagName + " is startup-only and cannot be set after finalization");
+            return;
+        }
+        PPX_ASSERT_MSG(newMask.size() == mMask.size(), "OptionKnob " + mFlagName + " new mask must be same size");
+        mMask = newMask;
+
+        if (!mMask[mIndex]) {
+            SetIndex(GetFirstValidIndex());
+        }
+    }
+
+private:
+    void FinalizeValues() override
+    {
+        mStartupIndex = mIndex;
+        mStartupMask  = mMask;
+    }
+
+    void ResetValuesToStartup() override
+    {
+        mIndex = mStartupIndex;
+        mMask  = mStartupMask;
+        RaiseUpdatedFlag();
+    }
+
+    std::string GetDefaultFlagParameters() override
+    {
+        std::string choiceStr = "";
+        for (size_t i = 0; i < mChoices.size(); i++) {
+            if (mMask[i]) {
+                auto choice   = mChoices[i];
+                bool hasSpace = choice.name.find_first_of("\t ") != std::string::npos;
+                if (hasSpace) {
+                    choiceStr += "\"" + choice.name + "\"|";
+                }
+                else {
+                    choiceStr += choice.name + "|";
+                }
+            }
+        }
+        if (!choiceStr.empty()) {
+            choiceStr.pop_back();
+        }
+        choiceStr = "<" + choiceStr + ">";
+        return choiceStr;
+    }
+
+    void Draw() override
+    {
+        switch (mDisplayType) {
+            case KnobDisplayType::PLAIN: {
+                DrawPlain();
+                return;
+            }
+            case KnobDisplayType::DROPDOWN: {
+                bool interacted = ImGui::BeginCombo(mDisplayName.c_str(), mChoices.at(mIndex).name.c_str());
+                if (!interacted) {
+                    DrawToolTip(); // Cannot display tooltip when Combo is open
+                    return;
+                }
+                for (size_t i = 0; i < mChoices.size(); ++i) {
+                    if (!mMask.at(i)) {
+                        continue;
+                    }
+                    bool isSelected = (i == mIndex);
+                    if (ImGui::Selectable(mChoices.at(i).name.c_str(), isSelected)) {
+                        if (i != mIndex) { // A new choice is selected
+                            mIndex = i;
+                            RaiseUpdatedFlag();
+                        }
+                    }
+                    if (isSelected) {
+                        ImGui::SetItemDefaultFocus();
+                    }
+                }
+                ImGui::EndCombo();
+                return;
+            }
+        }
+        PPX_ASSERT_MSG(false, "OptionKnob " << mFlagName << " does not support display type " << static_cast<int>(mDisplayType));
+        return;
+    }
+
+    void Load(const std::vector<std::string>& valueStrings) override
+    {
+        // Only use the last value string
+        std::string valueString = valueStrings.back();
+
+        auto temp = std::find_if(
+            mChoices.cbegin(),
+            mChoices.cend(),
+            [&valueString](const Entry& entry) {
+                return entry.name == valueString;
+            });
+        if (temp == mChoices.cend()) {
+            PPX_LOG_ERROR("OptionKnob " + mFlagName + " could not be loaded with name: " + valueString);
+        }
+        size_t newIndex = std::distance(mChoices.cbegin(), temp);
+
+        SetIndex(newIndex);
+    }
+
+    std::vector<std::string> Save() override
+    {
+        std::vector<std::string> valueStrings;
+        valueStrings.emplace_back(ValueString());
+        return valueStrings;
+    }
+
+    std::string ValueString() override
+    {
+        return mChoices[mIndex].name;
+    }
+
+    bool IsValidIndex(size_t index)
+    {
+        if (index >= mMask.size()) {
+            return false;
+        }
+        return mMask[index];
+    }
+
+    size_t GetFirstValidIndex()
+    {
+        auto it = std::find(mMask.begin(), mMask.end(), true);
+        PPX_ASSERT_MSG(it != mMask.end(), "OptionKnob " << mFlagName << " no longer has any valid options");
+        return it - mMask.begin();
+    }
+
+private:
+    // mIndex indicates which of the mChoices is selected
+    size_t             mIndex;
+    size_t             mStartupIndex;
+    std::vector<Entry> mChoices;
+    std::vector<bool>  mMask;
+    std::vector<bool>  mStartupMask;
+};
+
+// KnobManagerNew holds the knobs in an application
+class KnobManagerNew
+{
+public:
+    KnobManagerNew()                      = default;
+    KnobManagerNew(const KnobManagerNew&) = delete;
+    KnobManagerNew& operator=(const KnobManagerNew&) = delete;
+
+private:
+    // Knobs are added on creation and never removed
+    std::vector<std::shared_ptr<KnobNew>> mKnobs;
+
+    // mFlagNames is kept to prevent multiple knobs having the same mFlagName
+    std::unordered_set<std::string> mFlagNames;
+
+public:
+    bool IsEmpty() { return mKnobs.empty(); }
+
+    // This will mark all the current knobs as startup-only
+    // Called after the Standard knobs are registered
+    void SetAllStartupOnly();
+
+    // Save startup states and prevent registration of new knobs, can only be called once
+    void FinalizeAll();
+
+    // The knobs can be reset to startup values
+    void ResetAllToStartup();
+
+    // Initialize the knob in-place and register it with the knob manager
+    template <typename T, typename... ArgsT>
+    void InitKnob(std::shared_ptr<T>* ppKnob, const std::string& flagName, ArgsT&&... args)
+    {
+        PPX_ASSERT_MSG(ppKnob != nullptr, "output parameter is nullptr");
+        PPX_ASSERT_MSG(mFlagNames.count(flagName) == 0, "knob with this name already exists: " + flagName);
+
+        std::shared_ptr<T> knobPtr(new T(flagName, std::forward<ArgsT>(args)...));
+        RegisterKnob(flagName, knobPtr);
+
+        *ppKnob = knobPtr;
+    }
+
+    void        DrawAllKnobs(bool inExistingWindow = false);
+    std::string GetUsageMsg();
+
+    void Load(const OptionsNew& opts);
+    void Save(OptionsNew& opts, bool excludeStartupOnly = false);
+
+private:
+    void RegisterKnob(const std::string& flagName, std::shared_ptr<KnobNew> newKnob);
+
+private:
+    bool mFinalized           = false;
+    char mConfigFilePath[128] = "";
+
+    std::string mUsageMsg = R"(
+USAGE
+==============================
+Boolean options can be turned on with:
+  --flag-name true, --flag-name 1, --flag-name
+And turned off with:
+  --flag-name false, --flag-name 0, --no-flag-name
+
+--help : Prints this help message and exits.
+==============================
+)";
+};
+
+} // namespace ppx
+
+#endif // ppx_knob_new_h

--- a/include/ppx/options_new.h
+++ b/include/ppx/options_new.h
@@ -1,0 +1,132 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ppx_options_new_h
+#define ppx_options_new_h
+
+#include "nlohmann/json.hpp"
+#include "ppx/config.h"
+#include "ppx/log.h"
+#include "ppx/string_util.h"
+
+#include <cstdint>
+#include <ios>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+namespace ppx {
+
+// -------------------------------------------------------------------------------------------------
+// OptionsNew
+// -------------------------------------------------------------------------------------------------
+//
+// OptionsNew is an intermediate format structure consisting of an unordered map of key-value pairs
+// that contain information used in knobs, command line flags, and JSON config files
+//
+// keys (string): The knob's unique flag name
+// values (list of strings): Values that have been specified for those keys from low to high priority
+//
+class OptionsNew
+{
+public:
+    OptionsNew() = default;
+    OptionsNew(const std::unordered_map<std::string, std::vector<std::string>>& newOptions) { mAllOptions = newOptions; }
+
+    bool HasOption(const std::string& option) const { return mAllOptions.find(option) != mAllOptions.end(); }
+
+    size_t GetNumUniqueOptions() const { return mAllOptions.size(); }
+
+    std::unordered_map<std::string, std::vector<std::string>> GetMap() const { return mAllOptions; }
+
+    std::vector<std::string> GetValueStrings(const std::string& optionName) const { return mAllOptions.at(optionName); }
+
+    // Adds new option if the option does not already exist
+    // Otherwise, the new value is appended to the end of the vector of stored parameters for this option
+    void AddOption(std::string_view optionName, std::string_view value);
+
+    // Same as above, but appends an array of values at the same key
+    void AddOption(std::string_view optionName, const std::vector<std::string>& valueArray);
+
+    // For all options existing in newOptions, current entries in mAllOptions will be replaced by them
+    void OverwriteOptions(const OptionsNew& newOptions);
+
+    bool operator==(const OptionsNew& rhs) const
+    {
+        return (mAllOptions == rhs.GetMap());
+    }
+
+private:
+    // All flag names (string) and parameters (vector of strings) specified on the command line
+    std::unordered_map<std::string, std::vector<std::string>> mAllOptions;
+};
+
+// -------------------------------------------------------------------------------------------------
+// CommandLineParserNew
+// -------------------------------------------------------------------------------------------------
+//
+// CommandLineParserNew can parse command-line arguments into OptionsNew intermediate format.
+// This includes any JSON config files specified with the flag mJsonConfigFlagName.
+//
+class CommandLineParserNew
+{
+public:
+    // Parse the given arguments into options. Return false if parsing
+    // succeeded. Otherwise, return true if an error occurred,
+    // and write the error to `out_error`.
+    //
+    // Value syntax:
+    // - strings cannot contain "="
+    // - boolean values stored as "0", "false", "1", "true", ""
+    Result ParseOptions(int argc, const char* argv[], OptionsNew& options);
+
+    std::string GetJsonConfigFlagName() const { return mJsonConfigFlagName; }
+
+private:
+    // Adds one instance of an option to the OptionsNew
+    // Checks for the special no- prefix allowed for the command line flags
+    Result AddOption(OptionsNew& opts, std::string_view optionName, std::string_view valueStr);
+
+private:
+    std::string mJsonConfigFlagName = "config-json-path";
+};
+
+// -------------------------------------------------------------------------------------------------
+// JsonConverterNew
+// -------------------------------------------------------------------------------------------------
+//
+// JsonConverterNew can convert JSON structures and files to and from OptionsNew intermediate format.
+//
+class JsonConverterNew
+{
+public:
+    // Parses all options specified within the JSON file and adds them to options.
+    Result ParseOptionsFromFile(const std::string& jsonPath, OptionsNew& options);
+
+    // Creates/overwrites file at jsonPath with all options in JSON format
+    Result ExportOptionsToFile(const OptionsNew& options, const std::string& jsonPath);
+
+    // Exposed for testing
+    void ParseOptions(const nlohmann::json& jsonConfig, OptionsNew& options);
+    void ExportOptions(const OptionsNew& options, nlohmann::json& jsonConfig);
+};
+
+} // namespace ppx
+
+#endif // ppx_options_new_h

--- a/include/ppx/string_util.h
+++ b/include/ppx/string_util.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,6 +44,11 @@ std::string_view TrimBothEnds(std::string_view s, std::string_view c = " \t");
 // Returns an empty second element if there is no delimiter
 std::pair<std::string_view, std::string_view> SplitInTwo(std::string_view s, char delimiter);
 
+// Splits s at all instances of delimiter and returns N substrings
+// If the delimiter is at the beginning or the end of the string or right beside another delimiter,
+// empty strings can be returned.
+std::vector<std::string_view> Split(std::string_view s, char delimiter);
+
 // -------------------------------------------------------------------------------------------------
 // Formatting Strings
 // -------------------------------------------------------------------------------------------------
@@ -53,6 +58,10 @@ std::pair<std::string_view, std::string_view> SplitInTwo(std::string_view s, cha
 // middle of a word if possible.
 // Leading and trailing whitespace is trimmed from each line.
 std::string WrapText(const std::string& s, size_t width, size_t indent = 0);
+
+// -------------------------------------------------------------------------------------------------
+// Converting to Strings
+// -------------------------------------------------------------------------------------------------
 
 // Provides string representation of value for printing or display
 template <typename T>
@@ -72,10 +81,10 @@ std::string ToString(std::vector<T> values)
 {
     std::stringstream ss;
     for (const auto& value : values) {
-        ss << ToString<T>(value) << ", ";
+        ss << ToString<T>(value) << ",";
     }
     std::string valueStr = ss.str();
-    return valueStr.substr(0, valueStr.length() - 2);
+    return valueStr.substr(0, valueStr.length() - 1);
 }
 
 // Same as above, for pairs
@@ -83,7 +92,7 @@ template <typename T>
 std::string ToString(std::pair<T, T> values)
 {
     std::stringstream ss;
-    ss << ToString<T>(values.first) << ", " << ToString<T>(values.second);
+    ss << ToString<T>(values.first) << "," << ToString<T>(values.second);
     return ss.str();
 }
 
@@ -105,7 +114,7 @@ Result Parse(std::string_view valueStr, std::string& parsedValue);
 Result Parse(std::string_view valueStr, bool& parsedValue);
 
 // For integers, chars and floats
-// e.g. "1.0" -> 1.0f
+// e.g. "1.0" -> 1.0f or 1
 // e.g. "-20" -> -20
 // e.g. "c" -> 'c'
 template <typename T>
@@ -121,6 +130,11 @@ Result Parse(std::string_view valueStr, T& parsedValue)
         return ERROR_FAILED;
     }
     parsedValue = valueAsNum;
+
+    if (std::is_integral_v<T> && (valueStr.find('.') != std::string_view::npos)) {
+        PPX_LOG_WARN("value string is truncated: " << valueStr);
+    }
+
     return SUCCESS;
 }
 

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -49,6 +49,7 @@ add_subdirectory(alloc)
 add_subdirectory(fishtornado)
 add_subdirectory(fluid_simulation)
 add_subdirectory(oit_demo)
+add_subdirectory(knob_demo)
 
 if (PPX_BUILD_XR)
 add_subdirectory(cube_xr)

--- a/projects/knob_demo/CMakeLists.txt
+++ b/projects/knob_demo/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+project(knob_demo)
+
+add_samples_for_all_apis(
+    NAME ${PROJECT_NAME}
+    SOURCES
+    "KnobDemo.h"
+    "KnobDemo.cpp"
+    "main.cpp"
+    SHADER_DEPENDENCIES "shader_static_vertex_colors")

--- a/projects/knob_demo/KnobDemo.cpp
+++ b/projects/knob_demo/KnobDemo.cpp
@@ -1,0 +1,298 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "KnobDemo.h"
+#include "ppx/ppx.h"
+using namespace ppx;
+
+#if defined(USE_DX12)
+const grfx::Api kApi = grfx::API_DX_12_0;
+#elif defined(USE_VK)
+const grfx::Api kApi = grfx::API_VK_1_1;
+#endif
+
+void KnobDemoApp::InitKnobs()
+{
+    GetKnobManagerNew().InitKnob(&(mKnobs.pGeneralStringA), "general-string-a", "hello world");
+    mKnobs.pGeneralStringA->SetDisplayType(KnobDisplayType::PLAIN);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pGeneralBoolA), "general-bool-a", true);
+    mKnobs.pGeneralBoolA->SetFlagDescription("Must be true");
+    mKnobs.pGeneralBoolA->SetValidator([](bool value) {
+        return value;
+    });
+    mKnobs.pGeneralBoolA->SetDisplayType(KnobDisplayType::CHECKBOX);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pRangeIntA), "range-int-a", 0);
+    mKnobs.pRangeIntA->SetFlagDescription("Minimum of range-int-c");
+    mKnobs.pRangeIntA->SetMin(0);
+    mKnobs.pRangeIntA->SetMax(5);
+    mKnobs.pRangeIntA->SetDisplayType(KnobDisplayType::PLAIN);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pRangeIntB), "range-int-b", 10);
+    mKnobs.pRangeIntB->SetFlagDescription("Maximum of range-int-c");
+    mKnobs.pRangeIntB->SetMin(5);
+    mKnobs.pRangeIntB->SetMax(10);
+    mKnobs.pRangeIntB->SetDisplayType(KnobDisplayType::SLOW_SLIDER);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pRangeIntC), "range-int-c", 5);
+    mKnobs.pRangeIntC->SetMin(0);
+    mKnobs.pRangeIntC->SetMax(10);
+    mKnobs.pRangeIntC->SetDisplayType(KnobDisplayType::FAST_SLIDER);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pRangeInt3A), "range-int-3-a", std::vector<int>{0, 10, 20});
+    mKnobs.pRangeInt3A->SetMin(0, 0);
+    mKnobs.pRangeInt3A->SetMax(0, 9);
+    mKnobs.pRangeInt3A->SetMin(1, 10);
+    mKnobs.pRangeInt3A->SetMax(1, 19);
+    mKnobs.pRangeInt3A->SetMin(2, 20);
+    mKnobs.pRangeInt3A->SetMax(2, 29);
+    mKnobs.pRangeInt3A->SetDisplaySuffixes(std::vector<std::string>{"X", "Y", "Z"});
+    mKnobs.pRangeInt3A->SetFlagDescription("No effect");
+    mKnobs.pRangeInt3A->SetDisplayType(KnobDisplayType::FAST_SLIDER);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pRangeFloatA), "range-float-a", 0.5f);
+    mKnobs.pRangeFloatA->SetFlagDescription("Slowly set range-float-3-a A");
+    mKnobs.pRangeFloatA->SetMin(0.0f);
+    mKnobs.pRangeFloatA->SetMax(1.0f);
+    mKnobs.pRangeFloatA->SetDisplayType(KnobDisplayType::SLOW_SLIDER);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pRangeFloatB), "range-float-b", 0.5f);
+    mKnobs.pRangeFloatB->SetFlagDescription("Quickly set range-float-3-a B");
+    mKnobs.pRangeFloatB->SetMin(0.0f);
+    mKnobs.pRangeFloatB->SetMax(1.0f);
+    mKnobs.pRangeFloatB->SetDisplayType(KnobDisplayType::FAST_SLIDER);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pRangeFloat3A), "range-float-3-a", std::vector<float>{0.5f, 0.5f, 0.5f});
+    mKnobs.pRangeFloat3A->SetAllMins(0.0f);
+    mKnobs.pRangeFloat3A->SetAllMaxes(1.0f);
+    mKnobs.pRangeFloat3A->SetDisplaySuffixes(std::vector<std::string>{"A", "B", "None"});
+    mKnobs.pRangeFloat3A->SetDisplayType(KnobDisplayType::FAST_SLIDER);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pOptionIntA), "option-bool-a", 0, kOptionBoolA);
+    mKnobs.pOptionIntA->SetDisplayName("option-bool-a DISPLAY NAME");
+    mKnobs.pOptionIntA->SetDisplayType(KnobDisplayType::PLAIN);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pGeneralBoolB), "general-bool-b", false);
+    mKnobs.pGeneralBoolB->SetFlagDescription("Check to only show even numbers in option-int-a");
+    mKnobs.pGeneralBoolB->SetDisplayType(KnobDisplayType::CHECKBOX);
+
+    GetKnobManagerNew().InitKnob(&(mKnobs.pOptionIntA), "option-int-a", 0, kOptionIntA);
+    mKnobs.pOptionIntA->SetFlagDescription("Filtered by general-knob-b");
+    mKnobs.pOptionIntA->SetDisplayType(KnobDisplayType::DROPDOWN);
+}
+
+void KnobDemoApp::Config(ApplicationSettings& settings)
+{
+    settings.appName           = "knob_demo";
+    settings.enableImGui       = true;
+    settings.grfx.api          = kApi;
+    settings.grfx.enableDebug  = false;
+    settings.window.resizable  = true;
+    settings.useKnobManagerNew = true;
+}
+
+void KnobDemoApp::Setup()
+{
+    // Pipeline
+    {
+        std::vector<char> bytecode = LoadShader("basic/shaders", "StaticVertexColors.vs");
+        PPX_ASSERT_MSG(!bytecode.empty(), "VS shader bytecode load failed");
+        grfx::ShaderModuleCreateInfo shaderCreateInfo = {static_cast<uint32_t>(bytecode.size()), bytecode.data()};
+        PPX_CHECKED_CALL(GetDevice()->CreateShaderModule(&shaderCreateInfo, &mVS));
+
+        bytecode = LoadShader("basic/shaders", "StaticVertexColors.ps");
+        PPX_ASSERT_MSG(!bytecode.empty(), "PS shader bytecode load failed");
+        shaderCreateInfo = {static_cast<uint32_t>(bytecode.size()), bytecode.data()};
+        PPX_CHECKED_CALL(GetDevice()->CreateShaderModule(&shaderCreateInfo, &mPS));
+
+        grfx::PipelineInterfaceCreateInfo piCreateInfo = {};
+        PPX_CHECKED_CALL(GetDevice()->CreatePipelineInterface(&piCreateInfo, &mPipelineInterface));
+
+        mVertexBinding.AppendAttribute({"POSITION", 0, grfx::FORMAT_R32G32B32_FLOAT, 0, PPX_APPEND_OFFSET_ALIGNED, grfx::VERTEX_INPUT_RATE_VERTEX});
+        mVertexBinding.AppendAttribute({"COLOR", 1, grfx::FORMAT_R32G32B32_FLOAT, 0, PPX_APPEND_OFFSET_ALIGNED, grfx::VERTEX_INPUT_RATE_VERTEX});
+
+        grfx::GraphicsPipelineCreateInfo2 gpCreateInfo  = {};
+        gpCreateInfo.VS                                 = {mVS.Get(), "vsmain"};
+        gpCreateInfo.PS                                 = {mPS.Get(), "psmain"};
+        gpCreateInfo.vertexInputState.bindingCount      = 1;
+        gpCreateInfo.vertexInputState.bindings[0]       = mVertexBinding;
+        gpCreateInfo.topology                           = grfx::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        gpCreateInfo.polygonMode                        = grfx::POLYGON_MODE_FILL;
+        gpCreateInfo.cullMode                           = grfx::CULL_MODE_NONE;
+        gpCreateInfo.frontFace                          = grfx::FRONT_FACE_CCW;
+        gpCreateInfo.depthReadEnable                    = false;
+        gpCreateInfo.depthWriteEnable                   = false;
+        gpCreateInfo.blendModes[0]                      = grfx::BLEND_MODE_NONE;
+        gpCreateInfo.outputState.renderTargetCount      = 1;
+        gpCreateInfo.outputState.renderTargetFormats[0] = GetSwapchain()->GetColorFormat();
+        gpCreateInfo.pPipelineInterface                 = mPipelineInterface;
+        PPX_CHECKED_CALL(GetDevice()->CreateGraphicsPipeline(&gpCreateInfo, &mPipeline));
+    }
+
+    // Per frame data
+    {
+        PerFrame frame = {};
+
+        PPX_CHECKED_CALL(GetGraphicsQueue()->CreateCommandBuffer(&frame.cmd));
+
+        grfx::SemaphoreCreateInfo semaCreateInfo = {};
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.imageAcquiredSemaphore));
+
+        grfx::FenceCreateInfo fenceCreateInfo = {};
+        PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
+        fenceCreateInfo = {true}; // Create signaled
+        PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
+
+        mPerFrame.push_back(frame);
+    }
+
+    // Buffer and geometry data
+    {
+        // clang-format off
+        std::vector<float> vertexData = {
+            // position           // vertex colors
+             0.0f,  0.5f, 0.0f,   1.0f, 0.0f, 0.0f,
+            -0.5f, -0.5f, 0.0f,   0.0f, 1.0f, 0.0f,
+             0.5f, -0.5f, 0.0f,   0.0f, 0.0f, 1.0f,
+        };
+        // clang-format on
+        uint32_t dataSize = SizeInBytesU32(vertexData);
+
+        grfx::BufferCreateInfo bufferCreateInfo       = {};
+        bufferCreateInfo.size                         = dataSize;
+        bufferCreateInfo.usageFlags.bits.vertexBuffer = true;
+        bufferCreateInfo.memoryUsage                  = grfx::MEMORY_USAGE_CPU_TO_GPU;
+        bufferCreateInfo.initialState                 = grfx::RESOURCE_STATE_VERTEX_BUFFER;
+
+        PPX_CHECKED_CALL(GetDevice()->CreateBuffer(&bufferCreateInfo, &mVertexBuffer));
+
+        void* pAddr = nullptr;
+        PPX_CHECKED_CALL(mVertexBuffer->MapMemory(0, &pAddr));
+        memcpy(pAddr, vertexData.data(), dataSize);
+        mVertexBuffer->UnmapMemory();
+    }
+}
+
+void KnobDemoApp::ProcessKnobs()
+{
+    if (mKnobs.pGeneralBoolB->DigestUpdate()) {
+        PPX_LOG_INFO("pGeneralBoolB updated");
+        std::vector<bool> newMask;
+        if (mKnobs.pGeneralBoolB->GetValue()) {
+            // Show only even numbers in pOptionIntA when pGeneralBoolB is true
+            for (auto& element : kOptionIntA) {
+                newMask.push_back(element.value % 2 == 0);
+            }
+            mKnobs.pOptionIntA->SetMask(newMask);
+        }
+        else {
+            newMask = std::vector<bool>(kOptionIntA.size(), true);
+        }
+        mKnobs.pOptionIntA->SetMask(newMask);
+    }
+
+    if (mKnobs.pRangeIntA->DigestUpdate()) {
+        PPX_LOG_INFO("pRangeIntA updated");
+        mKnobs.pRangeIntC->SetMin(mKnobs.pRangeIntA->GetValue());
+    }
+    if (mKnobs.pRangeIntB->DigestUpdate()) {
+        PPX_LOG_INFO("pRangeIntB updated");
+        mKnobs.pRangeIntC->SetMax(mKnobs.pRangeIntB->GetValue());
+    }
+
+    if (mKnobs.pRangeFloatA->DigestUpdate()) {
+        PPX_LOG_INFO("pRangeFloatA updated");
+        mKnobs.pRangeFloat3A->SetValue(0, mKnobs.pRangeFloatA->GetValue());
+    }
+    if (mKnobs.pRangeFloatB->DigestUpdate()) {
+        PPX_LOG_INFO("pRangeFloatB updated");
+        mKnobs.pRangeFloat3A->SetValue(1, mKnobs.pRangeFloatB->GetValue());
+    }
+}
+
+void KnobDemoApp::Render()
+{
+    ProcessKnobs();
+
+    PerFrame& frame = mPerFrame[0];
+
+    grfx::SwapchainPtr swapchain = GetSwapchain();
+
+    uint32_t imageIndex = UINT32_MAX;
+    PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
+
+    // Wait for and reset image acquired fence
+    PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
+
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
+    // Build command buffer
+    PPX_CHECKED_CALL(frame.cmd->Begin());
+    {
+        grfx::RenderPassPtr renderPass = swapchain->GetRenderPass(imageIndex);
+        PPX_ASSERT_MSG(!renderPass.IsNull(), "render pass object is null");
+
+        grfx::RenderPassBeginInfo beginInfo = {};
+        beginInfo.pRenderPass               = renderPass;
+        beginInfo.renderArea                = renderPass->GetRenderArea();
+        beginInfo.RTVClearCount             = 1;
+        beginInfo.RTVClearValues[0]         = {{1, 0, 0, 1}};
+
+        frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_PRESENT, grfx::RESOURCE_STATE_RENDER_TARGET);
+        frame.cmd->BeginRenderPass(&beginInfo);
+        {
+            frame.cmd->SetScissors(GetScissor());
+            frame.cmd->SetViewports(GetViewport());
+            frame.cmd->BindGraphicsDescriptorSets(mPipelineInterface, 0, nullptr);
+            frame.cmd->BindGraphicsPipeline(mPipeline);
+            frame.cmd->BindVertexBuffers(1, &mVertexBuffer, &mVertexBinding.GetStride());
+            frame.cmd->Draw(3, 1, 0, 0);
+
+            // Draw ImGui
+            DrawDebugInfo();
+#if defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
+            DrawProfilerGrfxApiFunctions();
+#endif // defined(PPX_ENABLE_PROFILE_GRFX_API_FUNCTIONS)
+
+            // GUI
+            ImGui::Begin("Debug Info");
+            ImGui::Separator();
+            ImGui::Text("Knobs");
+            GetKnobManagerNew().DrawAllKnobs(true);
+            ImGui::End();
+            DrawImGui(frame.cmd);
+        }
+        frame.cmd->EndRenderPass();
+        frame.cmd->TransitionImageLayout(renderPass->GetRenderTargetImage(0), PPX_ALL_SUBRESOURCES, grfx::RESOURCE_STATE_RENDER_TARGET, grfx::RESOURCE_STATE_PRESENT);
+    }
+    PPX_CHECKED_CALL(frame.cmd->End());
+
+    grfx::SubmitInfo submitInfo     = {};
+    submitInfo.commandBufferCount   = 1;
+    submitInfo.ppCommandBuffers     = &frame.cmd;
+    submitInfo.waitSemaphoreCount   = 1;
+    submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
+    submitInfo.signalSemaphoreCount = 1;
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.pFence               = frame.renderCompleteFence;
+
+    PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
+
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+}

--- a/projects/knob_demo/KnobDemo.h
+++ b/projects/knob_demo/KnobDemo.h
@@ -1,0 +1,83 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef KNOB_DEMO_H
+#define KNOB_DEMO_H
+
+#include "ppx/ppx.h"
+#include "ppx/knob_new.h"
+using namespace ppx;
+
+static constexpr std::array<OptionKnobEntry<int>, 3> kOptionBoolA = {{
+    {"red", true},
+    {"orange", true},
+    {"banana", false},
+}};
+
+static constexpr std::array<OptionKnobEntry<int>, 5> kOptionIntA = {{
+    {"Ten", 10},
+    {"Fifteen", 15},
+    {"Twenty", 20},
+    {"Twenty-five", 25},
+    {"Thirty", 30},
+}};
+
+class KnobDemoApp
+    : public Application
+{
+public:
+    virtual void InitKnobs() override;
+    virtual void Config(ApplicationSettings& settings) override;
+    virtual void Setup() override;
+    virtual void Render() override;
+    void         ProcessKnobs();
+
+private:
+    struct PerFrame
+    {
+        grfx::CommandBufferPtr cmd;
+        grfx::SemaphorePtr     imageAcquiredSemaphore;
+        grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
+        grfx::FencePtr         renderCompleteFence;
+    };
+
+    std::vector<PerFrame>      mPerFrame;
+    grfx::ShaderModulePtr      mVS;
+    grfx::ShaderModulePtr      mPS;
+    grfx::PipelineInterfacePtr mPipelineInterface;
+    grfx::GraphicsPipelinePtr  mPipeline;
+    grfx::BufferPtr            mVertexBuffer;
+    grfx::VertexBinding        mVertexBinding;
+
+    struct Knobs
+    {
+        std::shared_ptr<GeneralKnob<std::string>> pGeneralStringA; // PLAIN
+        std::shared_ptr<GeneralKnob<bool>>        pGeneralBoolA;   // CHECKBOX
+        std::shared_ptr<GeneralKnob<bool>>        pGeneralBoolB;   // CHECKBOX
+        std::shared_ptr<RangeKnob<int>>           pRangeIntA;      // PLAIN
+        std::shared_ptr<RangeKnob<int>>           pRangeIntB;      // SLOW_SLIDER
+        std::shared_ptr<RangeKnob<int>>           pRangeIntC;      // FAST_SLIDER
+        std::shared_ptr<RangeKnob<int>>           pRangeInt3A;     // 3x FAST_SLIDER
+        std::shared_ptr<RangeKnob<float>>         pRangeFloatA;    // SLOW_SLIDER
+        std::shared_ptr<RangeKnob<float>>         pRangeFloatB;    // FAST_SLIDER
+        std::shared_ptr<RangeKnob<float>>         pRangeFloat3A;   // 3x FAST_SLIDER
+        std::shared_ptr<OptionKnob<bool>>         pOptionBoolA;    // PLAIN
+        std::shared_ptr<OptionKnob<int>>          pOptionIntA;     // DROPDOWN
+    };
+
+    Knobs mKnobs;
+};
+
+#endif // KNOB_DEMO_H

--- a/projects/knob_demo/README.md
+++ b/projects/knob_demo/README.md
@@ -1,0 +1,26 @@
+# Knob Demo
+
+Using `sample_01_triangle` as base, this simple application demonstrates at least one of all available knobs display widgets. It also seeks to demonstrate when properties of the knobs are altered during runtime.
+
+## GeneralKnob
+* Display types:
+    * `PLAIN`
+    * `CHECKBOX` (bool)
+* Unique functions:
+    * `SetValidator()`
+
+## RangeKnob
+* Display types:
+    * `PLAIN`
+    * `FAST_SLIDER` (int, float) (N)
+    * `SLOW_SLIDER` (int, float) (N)
+* Unique functions:
+    * `SetMax()`
+    * `SetMin()`
+
+## OptionKnob
+* Display types:
+    * `PLAIN`
+    * `DROPDOWN`
+* Unique functions:
+    * `SetMask()`

--- a/projects/knob_demo/main.cpp
+++ b/projects/knob_demo/main.cpp
@@ -1,0 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "KnobDemo.h"
+
+SETUP_APPLICATION(KnobDemoApp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -163,10 +163,12 @@ list(
     ${INC_DIR}/ppx/graphics_util.h
     ${INC_DIR}/ppx/imgui_impl.h
     ${INC_DIR}/ppx/knob.h
+    ${INC_DIR}/ppx/knob_new.h
     ${INC_DIR}/ppx/log.h
     ${INC_DIR}/ppx/metrics.h
     ${INC_DIR}/ppx/mipmap.h
     ${INC_DIR}/ppx/obj_ptr.h
+    ${INC_DIR}/ppx/options_new.h
     ${INC_DIR}/ppx/platform.h
     ${INC_DIR}/ppx/ppx.h
     ${INC_DIR}/ppx/ppm_export.h
@@ -199,10 +201,12 @@ list(
     ${SRC_DIR}/ppx/graphics_util.cpp
     ${SRC_DIR}/ppx/imgui_impl.cpp
     ${SRC_DIR}/ppx/knob.cpp
+    ${SRC_DIR}/ppx/knob_new.cpp
     ${SRC_DIR}/ppx/log.cpp
     ${SRC_DIR}/ppx/math_config.cpp
     ${SRC_DIR}/ppx/metrics.cpp
     ${SRC_DIR}/ppx/mipmap.cpp
+    ${SRC_DIR}/ppx/options_new.cpp
     ${SRC_DIR}/ppx/platform.cpp
     ${SRC_DIR}/ppx/ppm_export.cpp
     ${SRC_DIR}/ppx/profiler.cpp

--- a/src/ppx/knob_new.cpp
+++ b/src/ppx/knob_new.cpp
@@ -1,0 +1,252 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ppx/knob_new.h"
+#include "ppx/string_util.h"
+
+#include <cstring>
+
+namespace ppx {
+
+// Spacing:
+//
+// --flag_name <params>    description...
+//                         continued description...
+// |kUsageMsgIndentWidth--|
+// |kUsageMsgTotalWidth-----------------------------|
+constexpr size_t kUsageMsgIndentWidth = 20;
+constexpr size_t kUsageMsgTotalWidth  = 80;
+
+// -------------------------------------------------------------------------------------------------
+// KnobNew
+// -------------------------------------------------------------------------------------------------
+
+void KnobNew::SetStartupOnly()
+{
+    PPX_ASSERT_MSG(!mFinalized, "knob " + mFlagName + " cannot be made startup only, has not been finalized yet");
+
+    mStartupOnly    = true;
+    mDisplayVisible = false;
+}
+
+bool KnobNew::DigestUpdate()
+{
+    PPX_ASSERT_MSG(mFinalized, "knob " + mFlagName + " cannot check if updated, has not been finalized yet");
+
+    if (!mUpdatedFlag) {
+        return false;
+    }
+    mUpdatedFlag = false;
+    return true;
+}
+
+void KnobNew::DrawPlain()
+{
+    std::string flagText = mDisplayName + ": " + ValueString();
+    ImGui::Text("%s", flagText.c_str());
+    DrawToolTip();
+    return;
+}
+
+void KnobNew::DrawToolTip()
+{
+    if (mFlagDescription.length() == 0) {
+        return;
+    }
+
+    ImGui::SameLine();
+    ImGui::TextDisabled("(?)");
+    if (ImGui::BeginItemTooltip()) {
+        ImGui::TextUnformatted(mFlagDescription.c_str());
+        ImGui::EndTooltip();
+    }
+}
+
+void KnobNew::Finalize()
+{
+    PPX_ASSERT_MSG(!mFinalized, "knob " + mFlagName + " has been finalized already");
+
+    mStartupDisplayVisible = mDisplayVisible;
+    mStartupDisplayType    = mDisplayType;
+    FinalizeValues();
+    mFinalized = true;
+}
+
+void KnobNew::ResetToStartup()
+{
+    PPX_ASSERT_MSG(mFinalized, "knob " + mFlagName + " cannot be reset, has not been finalized yet");
+
+    if (mFinalized && mStartupOnly) {
+        return;
+    }
+
+    mDisplayVisible = mStartupDisplayVisible;
+    mDisplayType    = mStartupDisplayType;
+    ResetValuesToStartup();
+}
+
+std::string KnobNew::GetFlagParameters()
+{
+    if (mFlagParameters != "") {
+        return mFlagParameters;
+    }
+    return GetDefaultFlagParameters();
+}
+
+// -------------------------------------------------------------------------------------------------
+// KnobManagerNew
+// -------------------------------------------------------------------------------------------------
+
+void KnobManagerNew::SetAllStartupOnly()
+{
+    for (auto& knobPtr : mKnobs) {
+        knobPtr->SetStartupOnly();
+    }
+}
+
+void KnobManagerNew::FinalizeAll()
+{
+    for (auto& knobPtr : mKnobs) {
+        knobPtr->Finalize();
+    }
+
+    mFinalized = true;
+}
+
+void KnobManagerNew::ResetAllToStartup()
+{
+    PPX_ASSERT_MSG(mFinalized, "cannot reset to startup before finalization");
+    for (auto& knobPtr : mKnobs) {
+        knobPtr->ResetToStartup();
+    }
+}
+
+void KnobManagerNew::DrawAllKnobs(bool inExistingWindow)
+{
+    if (!inExistingWindow) {
+        ImGui::Begin("Knobs");
+    }
+
+    for (const auto& knobPtr : mKnobs) {
+        if (!(knobPtr->mDisplayVisible)) {
+            continue;
+        }
+        for (size_t i = 0; i < knobPtr->mDisplayIndent; i++) {
+            ImGui::Indent();
+        }
+        knobPtr->Draw();
+        for (size_t i = 0; i < knobPtr->mDisplayIndent; i++) {
+            ImGui::Unindent();
+        }
+    }
+
+    ImGui::Separator();
+
+    if (ImGui::Button("Reset to Startup Values")) {
+        ResetAllToStartup();
+    }
+
+    ImGui::InputText("Config File Path", mConfigFilePath, IM_ARRAYSIZE(mConfigFilePath));
+
+    bool clickedLoad = ImGui::Button("Load");
+    ImGui::SameLine();
+    bool clickedSave = ImGui::Button("Save");
+    ImGui::SameLine();
+    bool clickedSaveAll = ImGui::Button("Save All");
+
+    if (clickedSave || clickedSaveAll || clickedLoad) {
+        OptionsNew       options;
+        JsonConverterNew jsonConverter;
+
+        if (clickedSave) {
+            PPX_LOG_INFO("Saving partial config: " << mConfigFilePath);
+            Save(options, true);
+            jsonConverter.ExportOptionsToFile(options, mConfigFilePath);
+        }
+        else if (clickedSaveAll) {
+            PPX_LOG_INFO("Saving full config: " << mConfigFilePath);
+            Save(options, false);
+            jsonConverter.ExportOptionsToFile(options, mConfigFilePath);
+        }
+        else if (clickedLoad) {
+            PPX_LOG_INFO("Loading config: " << mConfigFilePath);
+            jsonConverter.ParseOptionsFromFile(mConfigFilePath, options);
+            Load(options);
+        }
+    }
+
+    if (!inExistingWindow) {
+        ImGui::End();
+    }
+}
+
+std::string KnobManagerNew::GetUsageMsg()
+{
+    std::string usageMsg = "\nFlags:\n";
+    for (const auto& knobPtr : mKnobs) {
+        std::string knobMsg        = "--" + knobPtr->mFlagName;
+        auto        flagParameters = knobPtr->GetFlagParameters();
+        if (flagParameters != "") {
+            knobMsg += " " + flagParameters;
+        }
+        knobMsg += "\n";
+        std::string knobDefault = "(Default: " + knobPtr->ValueString() + ")";
+        knobMsg += ppx::string_util::WrapText(knobDefault, kUsageMsgTotalWidth, kUsageMsgIndentWidth);
+        if (knobPtr->mFlagDescription != "") {
+            knobMsg += ppx::string_util::WrapText(knobPtr->mFlagDescription, kUsageMsgTotalWidth, kUsageMsgIndentWidth);
+        }
+        usageMsg += knobMsg + "\n";
+    }
+    return usageMsg;
+}
+
+void KnobManagerNew::Load(const OptionsNew& opts)
+{
+    std::unordered_map<std::string, std::vector<std::string>> optsMap;
+    optsMap = opts.GetMap();
+
+    // Validate that all keys correspond to existing knobs
+    for (auto& it : optsMap) {
+        PPX_ASSERT_MSG(mFlagNames.count(it.first), "option does not exist as knob: " + it.first);
+    }
+
+    // Load knob values from opts
+    for (auto& knobPtr : mKnobs) {
+        if (!optsMap.count(knobPtr->mFlagName)) {
+            continue;
+        }
+        knobPtr->Load(optsMap.at(knobPtr->mFlagName));
+        PPX_LOG_INFO("KNOB: " << knobPtr->mFlagName << " : (" << knobPtr->ValueString() << ")");
+    }
+}
+
+void KnobManagerNew::Save(OptionsNew& opts, bool excludeStartupOnly)
+{
+    // Save knob values to opts
+    for (auto& knobPtr : mKnobs) {
+        if (excludeStartupOnly && knobPtr->mStartupOnly) {
+            continue;
+        }
+        std::vector<std::string> valueStrings = knobPtr->Save();
+        opts.AddOption(knobPtr->mFlagName, valueStrings);
+    }
+}
+
+void KnobManagerNew::RegisterKnob(const std::string& flagName, std::shared_ptr<KnobNew> newKnob)
+{
+    mFlagNames.insert(flagName);
+    mKnobs.emplace_back(std::move(newKnob));
+}
+
+} // namespace ppx

--- a/src/ppx/options_new.cpp
+++ b/src/ppx/options_new.cpp
@@ -1,0 +1,253 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <locale>
+#include <vector>
+#include <stdexcept>
+#include <cctype>
+
+#include "ppx/options_new.h"
+
+namespace {
+
+bool StartsWithDoubleDash(std::string_view s)
+{
+    if (s.size() >= 3) {
+        return s.substr(0, 2) == "--";
+    }
+    return false;
+}
+
+} // namespace
+
+namespace ppx {
+
+// -------------------------------------------------------------------------------------------------
+// OptionsNew
+// -------------------------------------------------------------------------------------------------
+void OptionsNew::OverwriteOptions(const OptionsNew& newOptions)
+{
+    for (auto& it : newOptions.mAllOptions) {
+        mAllOptions[it.first] = it.second;
+    }
+}
+
+void OptionsNew::AddOption(std::string_view optionName, std::string_view value)
+{
+    std::string optionNameStr(optionName);
+    std::string valueStr(value);
+    auto        it = mAllOptions.find(optionNameStr);
+    if (it == mAllOptions.cend()) {
+        std::vector<std::string> v{std::move(valueStr)};
+        mAllOptions.emplace(std::move(optionNameStr), std::move(v));
+        return;
+    }
+    it->second.push_back(valueStr);
+}
+
+void OptionsNew::AddOption(std::string_view optionName, const std::vector<std::string>& valueArray)
+{
+    std::string optionNameStr(optionName);
+    auto        it = mAllOptions.find(optionNameStr);
+    if (it == mAllOptions.cend()) {
+        mAllOptions.emplace(std::move(optionNameStr), valueArray);
+        return;
+    }
+    auto storedValueArray = it->second;
+    storedValueArray.insert(storedValueArray.end(), valueArray.cbegin(), valueArray.cend());
+}
+
+// -------------------------------------------------------------------------------------------------
+// CommandLineParserNew
+// -------------------------------------------------------------------------------------------------
+
+Result CommandLineParserNew::ParseOptions(int argc, const char* argv[], OptionsNew& options)
+{
+    // argc should be >= 1 and argv[0] the name of the executable.
+    if (argc < 2) {
+        return SUCCESS;
+    }
+
+    // Initial pass to trim the name of executable and to split any flag and parameters that are connected with '='
+    std::vector<std::string_view> args;
+    for (size_t i = 1; i < argc; ++i) {
+        std::string_view argString(argv[i]);
+        if (argString.find('=') != std::string_view::npos) {
+            if (std::count(argString.cbegin(), argString.cend(), '=') != 1) {
+                PPX_LOG_ERROR("invalid number of '=' in flag: \"" << argString << "\"");
+                return ERROR_FAILED;
+            }
+            std::pair<std::string_view, std::string_view> optionAndValue = ppx::string_util::SplitInTwo(argString, '=');
+            args.emplace_back(optionAndValue.first);
+            args.emplace_back(optionAndValue.second);
+            continue;
+        }
+        args.emplace_back(argString);
+    }
+
+    // Another pass to identify JSON config files, add that option, and remove it from the argument list
+    std::vector<std::string_view> argsFiltered;
+    std::vector<std::string>      jsonConfigFilePaths;
+    for (size_t i = 0; i < args.size(); ++i) {
+        bool nextArgumentIsParameter = (i + 1 < args.size()) && !StartsWithDoubleDash(args[i + 1]);
+        if ((args[i] == "--" + mJsonConfigFlagName) && nextArgumentIsParameter) {
+            jsonConfigFilePaths.emplace_back(ppx::string_util::TrimBothEnds(args[i + 1]));
+            ++i;
+            continue;
+        }
+        argsFiltered.emplace_back(args[i]);
+    }
+    args = argsFiltered;
+    argsFiltered.clear();
+
+    // Flags inside JSON files are processed first
+    // These are always lower priority than flags on the command-line
+    std::vector<std::string> configJsonPaths;
+    JsonConverterNew         jsonConverter;
+    OptionsNew               jsonOptions;
+    for (const auto& jsonPath : jsonConfigFilePaths) {
+        auto res = jsonConverter.ParseOptionsFromFile(jsonPath, jsonOptions);
+        if (Failed(res)) {
+            return res;
+        }
+        options.OverwriteOptions(jsonOptions);
+    }
+
+    OptionsNew commandlineOptions;
+    // Main pass, process arguments into either standalone flags or options with parameters.
+    for (size_t i = 0; i < args.size(); ++i) {
+        std::string_view name = ppx::string_util::TrimBothEnds(args[i]);
+        if (!StartsWithDoubleDash(name)) {
+            PPX_LOG_ERROR("Invalid command-line option: \"" << name << "\"");
+            return ERROR_FAILED;
+        }
+        name = name.substr(2);
+
+        std::string_view value = "";
+        if (i + 1 < args.size()) {
+            auto nextElem = ppx::string_util::TrimBothEnds(args[i + 1]);
+            if (!StartsWithDoubleDash(nextElem)) {
+                // The next element is a parameter for the current option
+                value = nextElem;
+                ++i;
+            }
+        }
+        auto res = AddOption(commandlineOptions, name, value);
+        if (Failed(res)) {
+            return res;
+        }
+    }
+    options.OverwriteOptions(commandlineOptions);
+
+    return SUCCESS;
+}
+
+Result CommandLineParserNew::AddOption(OptionsNew& opts, std::string_view optionName, std::string_view valueStr)
+{
+    if (optionName.length() > 2 && optionName.substr(0, 3) == "no-") {
+        if (valueStr.length() > 0) {
+            PPX_LOG_ERROR("invalid prefix no- for option \"" << optionName << "\" and value \"" << valueStr << "\"");
+            return ERROR_FAILED;
+        }
+        optionName = optionName.substr(3);
+        valueStr   = "0";
+    }
+
+    opts.AddOption(optionName, valueStr);
+    return SUCCESS;
+}
+
+// -------------------------------------------------------------------------------------------------
+// JsonConverterNew
+// -------------------------------------------------------------------------------------------------
+
+Result JsonConverterNew::ParseOptionsFromFile(const std::string& jsonPath, OptionsNew& opts)
+{
+    std::ifstream f(jsonPath);
+    if (f.fail()) {
+        PPX_LOG_ERROR("Cannot locate JSON file : " << jsonPath);
+        return ERROR_FAILED;
+    }
+
+    PPX_LOG_INFO("Parsing JSON config file: " << jsonPath);
+    nlohmann::json data;
+    try {
+        data = nlohmann::json::parse(f);
+    }
+    catch (nlohmann::json::parse_error& e) {
+        PPX_LOG_ERROR("nlohmann::json::parse error: " << e.what() << '\n'
+                                                      << "exception id: " << e.id << '\n'
+                                                      << "byte position of error: " << e.byte);
+    }
+    if (!(data.is_object())) {
+        PPX_LOG_ERROR("The following config file could not be parsed as a JSON object: " << jsonPath);
+        return ERROR_FAILED;
+    }
+
+    ParseOptions(data, opts);
+
+    return SUCCESS;
+}
+
+Result JsonConverterNew::ExportOptionsToFile(const OptionsNew& options, const std::string& jsonPath)
+{
+    std::ofstream f(jsonPath);
+    if (f.fail()) {
+        PPX_LOG_ERROR("Cannot write to JSON file : " << jsonPath);
+        return ERROR_FAILED;
+    }
+
+    nlohmann::json data;
+    ExportOptions(options, data);
+    f << data.dump(0);
+    f.close();
+
+    return SUCCESS;
+}
+
+void JsonConverterNew::ParseOptions(const nlohmann::json& jsonConfig, OptionsNew& opts)
+{
+    std::stringstream ss;
+    for (auto it = jsonConfig.cbegin(); it != jsonConfig.cend(); ++it) {
+        if ((it.value()).is_array()) {
+            // Special case, arrays specified in JSON are added directly to opts to avoid inserting element by element
+            std::vector<std::string> jsonStringArray;
+            for (const auto& elem : it.value()) {
+                ss << elem;
+                jsonStringArray.push_back(std::string(ppx::string_util::TrimBothEnds(ss.str(), " \t\"")));
+                ss.str("");
+            }
+            opts.AddOption(it.key(), jsonStringArray);
+            continue;
+        }
+
+        ss << it.value();
+        std::string value = ss.str();
+        ss.str("");
+        opts.AddOption(it.key(), ppx::string_util::TrimBothEnds(value, " \t\""));
+    }
+}
+
+void JsonConverterNew::ExportOptions(const OptionsNew& options, nlohmann::json& jsonConfig)
+{
+    auto optMap = options.GetMap();
+    for (const auto& iter : optMap) {
+        jsonConfig[iter.first] = ppx::string_util::ToString(iter.second);
+    }
+}
+
+} // namespace ppx

--- a/src/ppx/string_util.cpp
+++ b/src/ppx/string_util.cpp
@@ -76,11 +76,13 @@ std::string_view TrimBothEnds(std::string_view s, std::string_view c)
         return s;
     }
     auto strBegin = s.find_first_not_of(c);
+    if (strBegin == std::string_view::npos) {
+        return "";
+    }
     auto strEnd   = s.find_last_not_of(c);
     auto strRange = strEnd - strBegin + 1;
     return s.substr(strBegin, strRange);
 }
-
 std::pair<std::string_view, std::string_view> SplitInTwo(std::string_view s, char delimiter)
 {
     std::pair<std::string_view, std::string_view> stringViewPair;
@@ -97,6 +99,27 @@ std::pair<std::string_view, std::string_view> SplitInTwo(std::string_view s, cha
     stringViewPair.first  = s.substr(0, delimiterIndex);
     stringViewPair.second = s.substr(delimiterIndex + 1);
     return stringViewPair;
+}
+
+std::vector<std::string_view> Split(std::string_view s, char delimiter)
+{
+    std::vector<std::string_view> stringViewList;
+    if (s.size() == 0) {
+        stringViewList.push_back("");
+        return stringViewList;
+    }
+
+    std::string_view remainingString = s;
+    size_t           delimiterIndex  = remainingString.find(delimiter);
+    while (delimiterIndex != std::string_view::npos) {
+        std::string_view element = remainingString.substr(0, delimiterIndex);
+        stringViewList.emplace_back(element);
+        remainingString = remainingString.substr(delimiterIndex + 1);
+        delimiterIndex  = remainingString.find(delimiter);
+    }
+    stringViewList.emplace_back(remainingString);
+
+    return stringViewList;
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -52,8 +52,10 @@ list(
     command_line_parser_test.cpp
     format_test.cpp
     knob_test.cpp
+    knob_new_test.cpp
     log_console_test.cpp
     metrics_test.cpp
+    options_new_test.cpp
     ppm_export_test.cpp
     string_util_test.cpp
     transform_test.cpp

--- a/src/test/knob_new_test.cpp
+++ b/src/test/knob_new_test.cpp
@@ -1,0 +1,881 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+
+#include "ppx/knob_new.h"
+
+#if !defined(NDEBUG)
+#define PERFORM_DEATH_TESTS
+#endif
+
+// ---------------------------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------------------------
+
+class KnobTestFixture : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ppx::Log::Initialize(ppx::LOG_MODE_CONSOLE, nullptr);
+    }
+
+    void TearDown() override
+    {
+        ppx::Log::Shutdown();
+    }
+};
+
+class KnobManagerNewTestFixture : public KnobTestFixture
+{
+protected:
+    ppx::KnobManagerNew km;
+};
+
+class KnobManagerNewWithKnobsTestFixture : public KnobManagerNewTestFixture
+{
+protected:
+    void SetUp() override
+    {
+        ppx::Log::Initialize(ppx::LOG_MODE_CONSOLE, nullptr);
+
+        km.InitKnob(&pGeneralBoolean, "general_boolean", true);
+
+        km.InitKnob(&pGeneralBooleanList, "general_boolean_list", std::vector<bool>{true, true, true});
+        pGeneralBooleanList->SetValidator([](std::vector<bool> values) {
+            for (auto v : values) {
+                if (!v) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+        km.InitKnob(&pRange1Int, "range_1_int", 0);
+        pRange1Int->SetMin(-10);
+        pRange1Int->SetMax(10);
+
+        km.InitKnob(&pRange3Int, "range_3_int", std::vector<int>{1, 2, 3});
+        pRange3Int->SetAllMins(-10);
+        pRange3Int->SetAllMaxes(10);
+
+        km.InitKnob(&pRange3Float, "range_3_float", std::vector<float>{1.5f, 2.5f, 3.5f});
+        pRange3Float->SetAllMins(-10.0f);
+        pRange3Float->SetAllMaxes(10.0f);
+
+        std::vector<ppx::OptionKnobEntry<int>> entries = {{"c1", 1}, {"c2", 2}, {"c3 and more", 3}};
+        km.InitKnob(&pOptionInt, "option_int", 1, entries);
+        pOptionInt->SetMask(0, false);
+
+        km.InitKnob(&pOptionString, "option_string", 1, std::vector<std::string>{"c1", "c2", "c3 and more"});
+        pOptionString->SetMask(0, false);
+    }
+
+protected:
+    std::shared_ptr<ppx::GeneralKnob<bool>>              pGeneralBoolean;
+    std::shared_ptr<ppx::GeneralKnob<std::vector<bool>>> pGeneralBooleanList;
+    std::shared_ptr<ppx::RangeKnob<int>>                 pRange1Int;
+    std::shared_ptr<ppx::RangeKnob<int>>                 pRange3Int;
+    std::shared_ptr<ppx::RangeKnob<float>>               pRange3Float;
+    std::shared_ptr<ppx::OptionKnob<int>>                pOptionInt;
+    std::shared_ptr<ppx::OptionKnob<std::string>>        pOptionString;
+};
+
+namespace ppx {
+
+// -------------------------------------------------------------------------------------------------
+// GeneralKnob
+// -------------------------------------------------------------------------------------------------
+
+TEST_F(KnobTestFixture, GeneralKnob_CreateBoolean)
+{
+    GeneralKnob pKnob = GeneralKnob<bool>("flag_name1", true);
+    EXPECT_TRUE(pKnob.GetValue());
+}
+
+TEST_F(KnobTestFixture, GeneralKnob_CreateInt)
+{
+    GeneralKnob pKnob = GeneralKnob<int>("flag_name1", 10);
+    EXPECT_EQ(pKnob.GetValue(), 10);
+}
+
+TEST_F(KnobTestFixture, GeneralKnob_CreateBooleanList)
+{
+    GeneralKnob pKnob = GeneralKnob<std::vector<bool>>("flag_name1", std::vector<bool>{true, true, false});
+    EXPECT_TRUE(pKnob.GetValue().at(0));
+    EXPECT_TRUE(pKnob.GetValue().at(1));
+    EXPECT_FALSE(pKnob.GetValue().at(2));
+}
+
+TEST_F(KnobTestFixture, GeneralKnob_CanSetBoolValue)
+{
+    GeneralKnob pKnob = GeneralKnob<bool>("flag_name1", false);
+    EXPECT_FALSE(pKnob.GetValue());
+    pKnob.SetValue(true);
+    EXPECT_TRUE(pKnob.GetValue());
+}
+
+TEST_F(KnobTestFixture, GeneralKnob_CustomValidator)
+{
+    GeneralKnob pKnob = GeneralKnob<bool>("flag_name1", false);
+    pKnob.SetValidator([](bool newVal) { return !newVal; });
+
+    EXPECT_FALSE(pKnob.GetValue());
+    pKnob.SetValue(true);
+    EXPECT_FALSE(pKnob.GetValue());
+}
+
+#if defined(PERFORM_DEATH_TESTS)
+TEST_F(KnobTestFixture, GeneralKnob_CustomValidatorInvalid)
+{
+    GeneralKnob pKnob = GeneralKnob<bool>("flag_name1", false);
+    EXPECT_DEATH(
+        {
+            pKnob.SetValidator([](bool newVal) { return newVal; });
+        },
+        "");
+}
+#endif
+
+// -------------------------------------------------------------------------------------------------
+// RangeKnob
+// -------------------------------------------------------------------------------------------------
+
+TEST_F(KnobTestFixture, RangeKnob1_CreateIntIterators)
+{
+    std::vector<int> defaultValues = {1};
+    RangeKnob        pKnob         = RangeKnob<int>("flag_name1", defaultValues.begin(), defaultValues.end());
+    EXPECT_EQ(pKnob.GetValue(0), 1);
+}
+
+TEST_F(KnobTestFixture, RangeKnob1_CreateIntContainer)
+{
+    std::vector<int> defaultValues = {1};
+    RangeKnob        pKnob         = RangeKnob<int>("flag_name1", defaultValues);
+    EXPECT_EQ(pKnob.GetValue(0), 1);
+}
+
+TEST_F(KnobTestFixture, RangeKnob1_CreateIntConvenient)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", 1);
+    EXPECT_EQ(pKnob.GetValue(), 1);
+}
+
+TEST_F(KnobTestFixture, RangeKnob1_CanSetValue)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", 1);
+    pKnob.SetValue(5);
+    EXPECT_EQ(pKnob.GetValue(), 5);
+}
+
+TEST_F(KnobTestFixture, RangeKnob1_SetMax)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", 1);
+    pKnob.SetMax(0);
+    EXPECT_EQ(pKnob.GetValue(), 0);
+}
+
+TEST_F(KnobTestFixture, RangeKnob1_SetMin)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", 1);
+    pKnob.SetMin(10);
+    EXPECT_EQ(pKnob.GetValue(), 10);
+}
+
+#if defined(PERFORM_DEATH_TESTS)
+TEST_F(KnobTestFixture, RangeKnob1_SetMaxBelowMin)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", 1);
+    pKnob.SetMin(0);
+    EXPECT_DEATH(
+        {
+            pKnob.SetMax(-1);
+        },
+        "");
+}
+
+TEST_F(KnobTestFixture, RangeKnob1_SetMinAboveMax)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", 1);
+    pKnob.SetMax(0);
+    EXPECT_DEATH(
+        {
+            pKnob.SetMin(1);
+        },
+        "");
+}
+#endif
+
+TEST_F(KnobTestFixture, RangeKnob1_SetOutOfRange)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", 1);
+    pKnob.SetMin(0);
+    pKnob.SetMax(10);
+    pKnob.SetValue(22);
+    EXPECT_EQ(pKnob.GetValue(), 1);
+}
+
+TEST_F(KnobTestFixture, RangeKnob3_CreateInt)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", std::vector<int>{1, 2, 3});
+    EXPECT_EQ(pKnob.GetValue(0), 1);
+    EXPECT_EQ(pKnob.GetValue(1), 2);
+    EXPECT_EQ(pKnob.GetValue(2), 3);
+}
+
+TEST_F(KnobTestFixture, RangeKnob3_CreateFloat)
+{
+    RangeKnob pKnob = RangeKnob<float>("flag_name1", std::vector<float>{1.5f, 2.5f, 3.5f});
+    EXPECT_EQ(pKnob.GetValue(0), 1.5f);
+    EXPECT_EQ(pKnob.GetValue(1), 2.5f);
+    EXPECT_EQ(pKnob.GetValue(2), 3.5f);
+}
+
+TEST_F(KnobTestFixture, RangeKnob3_CanSetValue)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", std::vector<int>{1, 2, 3});
+    pKnob.SetValue(2, 5);
+    EXPECT_EQ(pKnob.GetValue(0), 1);
+    EXPECT_EQ(pKnob.GetValue(1), 2);
+    EXPECT_EQ(pKnob.GetValue(2), 5);
+}
+
+TEST_F(KnobTestFixture, RangeKnob3_SetMax)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", std::vector<int>{1, 2, 3});
+    pKnob.SetMax(2, 0);
+    EXPECT_EQ(pKnob.GetValue(0), 1);
+    EXPECT_EQ(pKnob.GetValue(1), 2);
+    EXPECT_EQ(pKnob.GetValue(2), 0);
+}
+
+TEST_F(KnobTestFixture, RangeKnob3_SetMin)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", std::vector<int>{1, 2, 3});
+    pKnob.SetMin(2, 10);
+    EXPECT_EQ(pKnob.GetValue(0), 1);
+    EXPECT_EQ(pKnob.GetValue(1), 2);
+    EXPECT_EQ(pKnob.GetValue(2), 10);
+}
+
+TEST_F(KnobTestFixture, RangeKnob3_SetOutOfRange)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", std::vector<int>{1, 2, 3});
+    pKnob.SetMin(2, 0);
+    pKnob.SetMax(2, 10);
+    pKnob.SetValue(2, 22);
+    EXPECT_EQ(pKnob.GetValue(0), 1);
+    EXPECT_EQ(pKnob.GetValue(1), 2);
+    EXPECT_EQ(pKnob.GetValue(2), 3);
+}
+
+TEST_F(KnobTestFixture, RangeKnob3_SetAllOutOfRange)
+{
+    RangeKnob pKnob = RangeKnob<int>("flag_name1", std::vector<int>{1, 2, 3});
+    pKnob.SetAllMins(0);
+    pKnob.SetAllMaxes(2);
+    pKnob.SetAllValues(10);
+    EXPECT_EQ(pKnob.GetValue(0), 1);
+    EXPECT_EQ(pKnob.GetValue(1), 2);
+    EXPECT_EQ(pKnob.GetValue(2), 2); // Was changed by the reduced max value
+}
+
+// -------------------------------------------------------------------------------------------------
+// OptionKnob
+// -------------------------------------------------------------------------------------------------
+TEST_F(KnobTestFixture, OptionKnob_CreateIntEntryIterators)
+{
+    std::vector<OptionKnobEntry<int>> choices = {{"name1", 10}, {"name2", 20}};
+    OptionKnob                        pKnob   = OptionKnob<int>("flag_name1", 1, choices.begin(), choices.end());
+    EXPECT_EQ(pKnob.GetIndex(), 1);
+    EXPECT_EQ(pKnob.GetValue(), 20);
+}
+
+TEST_F(KnobTestFixture, OptionKnob_CreateIntEntryContainer)
+{
+    std::vector<OptionKnobEntry<int>> choices = {{"name1", 10}, {"name2", 20}};
+    OptionKnob                        pKnob   = OptionKnob<int>("flag_name1", 1, choices);
+    EXPECT_EQ(pKnob.GetIndex(), 1);
+    EXPECT_EQ(pKnob.GetValue(), 20);
+}
+
+TEST_F(KnobTestFixture, OptionKnob_CreateString)
+{
+    std::vector<std::string> choices = {"name1", "name2"};
+    OptionKnob               pKnob   = OptionKnob<std::string>("flag_name1", 1, choices);
+    EXPECT_EQ(pKnob.GetIndex(), 1);
+    EXPECT_EQ(pKnob.GetValue(), "name2");
+}
+
+TEST_F(KnobTestFixture, OptionKnob_CanSetIndex)
+{
+    std::vector<OptionKnobEntry<int>> choices = {{"name1", 10}, {"name2", 20}};
+    OptionKnob                        pKnob   = OptionKnob<int>("flag_name1", 1, choices);
+    pKnob.SetIndex(0);
+    EXPECT_EQ(pKnob.GetIndex(), 0);
+    EXPECT_EQ(pKnob.GetValue(), 10);
+}
+
+TEST_F(KnobTestFixture, OptionKnob_SetMaskByIndex)
+{
+    std::vector<OptionKnobEntry<int>> choices = {{"name1", 10}, {"name2", 20}};
+    OptionKnob                        pKnob   = OptionKnob<int>("flag_name1", 1, choices);
+    pKnob.SetMask(1, false);
+    EXPECT_EQ(pKnob.GetIndex(), 0);
+    EXPECT_EQ(pKnob.GetValue(), 10);
+}
+
+TEST_F(KnobTestFixture, OptionKnob_SetMaskEntire)
+{
+    std::vector<OptionKnobEntry<int>> choices = {{"name1", 10}, {"name2", 20}};
+    OptionKnob                        pKnob   = OptionKnob<int>("flag_name1", 1, choices);
+    std::vector<bool>                 mask    = {true, false};
+    pKnob.SetMask(mask);
+    EXPECT_EQ(pKnob.GetIndex(), 0);
+    EXPECT_EQ(pKnob.GetValue(), 10);
+}
+
+TEST_F(KnobTestFixture, OptionKnob_SetOutOfRange)
+{
+    std::vector<OptionKnobEntry<int>> choices = {{"name1", 10}, {"name2", 20}};
+    OptionKnob                        pKnob   = OptionKnob<int>("flag_name1", 1, choices);
+    pKnob.SetIndex(3);
+    EXPECT_EQ(pKnob.GetIndex(), 1);
+    EXPECT_EQ(pKnob.GetValue(), 20);
+}
+
+TEST_F(KnobTestFixture, OptionKnob_SetOutOfMaskRange)
+{
+    std::vector<OptionKnobEntry<int>> choices = {{"name1", 10}, {"name2", 20}};
+    OptionKnob                        pKnob   = OptionKnob<int>("flag_name1", 1, choices);
+    std::vector<bool>                 mask    = {false, true};
+    pKnob.SetMask(mask);
+    pKnob.SetIndex(0);
+    EXPECT_EQ(pKnob.GetIndex(), 1);
+    EXPECT_EQ(pKnob.GetValue(), 20);
+}
+
+#if defined(PERFORM_DEATH_TESTS)
+TEST_F(KnobTestFixture, OptionKnob_SetMaskIndexInvalid)
+{
+    std::vector<OptionKnobEntry<int>> choices = {{"name1", 10}, {"name2", 20}};
+    OptionKnob                        pKnob   = OptionKnob<int>("flag_name1", 1, choices);
+
+    EXPECT_DEATH(
+        {
+            pKnob.SetMask(2, false);
+        },
+        "");
+}
+
+TEST_F(KnobTestFixture, OptionKnob_SetMaskEntireInvalid)
+{
+    std::vector<OptionKnobEntry<int>> choices = {{"name1", 10}, {"name2", 20}};
+    OptionKnob                        pKnob   = OptionKnob<int>("flag_name1", 1, choices);
+    std::vector<bool>                 mask    = {true, false, true};
+
+    EXPECT_DEATH(
+        {
+            pKnob.SetMask(mask);
+        },
+        "");
+}
+#endif
+
+// -------------------------------------------------------------------------------------------------
+// KnobManagerNew
+// -------------------------------------------------------------------------------------------------
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_Empty)
+{
+    EXPECT_TRUE(km.IsEmpty());
+}
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_RegisterGeneralKnobBool)
+{
+    std::shared_ptr<GeneralKnob<bool>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", true);
+    EXPECT_FALSE(km.IsEmpty());
+    EXPECT_EQ(pKnob->GetValue(), true);
+}
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_RegisterGeneralKnobBoolList)
+{
+    std::shared_ptr<GeneralKnob<std::vector<bool>>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", std::vector<bool>{true, false});
+    EXPECT_FALSE(km.IsEmpty());
+    std::vector<bool> gotValue = pKnob->GetValue();
+    EXPECT_EQ(gotValue.size(), 2);
+    EXPECT_EQ(gotValue.at(0), true);
+    EXPECT_EQ(gotValue.at(1), false);
+}
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_RegisterRangeKnob1Int)
+{
+    std::shared_ptr<RangeKnob<int>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", 1);
+    EXPECT_FALSE(km.IsEmpty());
+    EXPECT_EQ(pKnob->GetValue(), 1);
+}
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_RegisterRangeKnob3Int)
+{
+    std::shared_ptr<RangeKnob<int>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", std::vector<int>{1, 2, 3});
+    EXPECT_FALSE(km.IsEmpty());
+    EXPECT_EQ(pKnob->GetValue(0), 1);
+    EXPECT_EQ(pKnob->GetValue(1), 2);
+    EXPECT_EQ(pKnob->GetValue(2), 3);
+}
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_RegisterOptionKnobInt)
+{
+    std::shared_ptr<OptionKnob<int>> pKnob;
+    std::vector<int>                 choices = {1, 2, 3};
+    km.InitKnob(&pKnob, "flag_name1", 1, choices);
+    EXPECT_FALSE(km.IsEmpty());
+    EXPECT_EQ(pKnob->GetIndex(), 1);
+    EXPECT_EQ(pKnob->GetValue(), 2);
+}
+
+#if defined(PERFORM_DEATH_TESTS)
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_RegisterDuplicateNameFail)
+{
+    std::shared_ptr<ppx::GeneralKnob<bool>> pKnob;
+    std::shared_ptr<ppx::GeneralKnob<bool>> pKnob2;
+    km.InitKnob(&pKnob, "flag_name1", true);
+    EXPECT_DEATH(
+        {
+            km.InitKnob(&pKnob2, "flag_name1", true);
+        },
+        "");
+}
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_BeforeFinalizationResetFail)
+{
+    std::shared_ptr<ppx::GeneralKnob<bool>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", true);
+    EXPECT_DEATH(
+        {
+            km.ResetAllToStartup();
+        },
+        "");
+}
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_BeforeFinalizationDigestFail)
+{
+    std::shared_ptr<ppx::GeneralKnob<bool>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", true);
+    EXPECT_DEATH(
+        {
+            pKnob->DigestUpdate();
+        },
+        "");
+}
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_AfterFinalizationSetStartupOnlyFail)
+{
+    std::shared_ptr<ppx::GeneralKnob<bool>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", true);
+    km.FinalizeAll();
+    EXPECT_DEATH(
+        {
+            pKnob->SetStartupOnly();
+        },
+        "");
+}
+#endif
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_StartupGeneral)
+{
+    std::shared_ptr<ppx::GeneralKnob<bool>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", true);
+    pKnob->SetStartupOnly();
+    km.FinalizeAll();
+
+    EXPECT_EQ(pKnob->GetValue(), true);
+    pKnob->SetValue(false);
+    EXPECT_EQ(pKnob->GetValue(), true);
+}
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_StartupRange)
+{
+    std::shared_ptr<ppx::RangeKnob<int>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", 3);
+    pKnob->SetStartupOnly();
+    km.FinalizeAll();
+
+    EXPECT_EQ(pKnob->GetValue(), 3);
+    pKnob->SetValue(4);
+    EXPECT_EQ(pKnob->GetValue(), 3);
+    pKnob->SetMin(4);
+    EXPECT_EQ(pKnob->GetValue(), 3);
+    pKnob->SetMax(2);
+    EXPECT_EQ(pKnob->GetValue(), 3);
+}
+
+TEST_F(KnobManagerNewTestFixture, KnobManagerNew_StartupOption)
+{
+    std::shared_ptr<ppx::OptionKnob<std::string>> pKnob;
+    km.InitKnob(&pKnob, "flag_name1", 1, std::vector<std::string>{"c1", "c2"});
+    pKnob->SetStartupOnly();
+    km.FinalizeAll();
+
+    EXPECT_EQ(pKnob->GetIndex(), 1);
+    pKnob->SetIndex(0);
+    EXPECT_EQ(pKnob->GetIndex(), 1);
+    pKnob->SetMask(1, false);
+    EXPECT_EQ(pKnob->GetIndex(), 1);
+    pKnob->SetMask(std::vector<bool>{true, false});
+    EXPECT_EQ(pKnob->GetIndex(), 1);
+}
+
+// -------------------------------------------------------------------------------------------------
+// KnobManagerNew (complex)
+// -------------------------------------------------------------------------------------------------
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_DigestUpdatesSetters)
+{
+    km.FinalizeAll();
+
+    // Clear updates
+    EXPECT_TRUE(pGeneralBoolean->DigestUpdate());
+    EXPECT_FALSE(pGeneralBoolean->DigestUpdate());
+    EXPECT_TRUE(pRange3Int->DigestUpdate());
+    EXPECT_FALSE(pRange3Int->DigestUpdate());
+    EXPECT_TRUE(pOptionInt->DigestUpdate());
+    EXPECT_FALSE(pOptionInt->DigestUpdate());
+
+    // Change with setter
+    pGeneralBoolean->SetValue(false);
+    EXPECT_TRUE(pGeneralBoolean->DigestUpdate());
+    pRange3Int->SetValue(0, 8);
+    EXPECT_TRUE(pRange3Int->DigestUpdate());
+    pOptionInt->SetIndex(2);
+    EXPECT_TRUE(pOptionInt->DigestUpdate());
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_DigestUpdatesReset)
+{
+    km.FinalizeAll();
+
+    // Clear updates
+    EXPECT_TRUE(pGeneralBoolean->DigestUpdate());
+    EXPECT_FALSE(pGeneralBoolean->DigestUpdate());
+    EXPECT_TRUE(pRange3Int->DigestUpdate());
+    EXPECT_FALSE(pRange3Int->DigestUpdate());
+    EXPECT_TRUE(pOptionInt->DigestUpdate());
+    EXPECT_FALSE(pOptionInt->DigestUpdate());
+
+    // Change with reset to startup
+    km.ResetAllToStartup();
+    EXPECT_TRUE(pGeneralBoolean->DigestUpdate());
+    EXPECT_TRUE(pRange3Int->DigestUpdate());
+    EXPECT_TRUE(pOptionInt->DigestUpdate());
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_SetAllStartupOnly)
+{
+    km.SetAllStartupOnly();
+    km.FinalizeAll();
+
+    // Try to change from startup
+    pGeneralBoolean->SetValue(false);
+    pRange3Int->SetValue(0, 8);
+    pOptionInt->SetIndex(2);
+
+    EXPECT_TRUE(pGeneralBoolean->GetValue());
+    EXPECT_EQ(pRange3Int->GetValue(0), 1);
+    EXPECT_EQ(pOptionInt->GetIndex(), 1);
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_ResetAllToStartup)
+{
+    km.FinalizeAll();
+
+    // Change from startup
+    pGeneralBoolean->SetValue(false);
+    pRange3Int->SetValue(0, 8);
+    pOptionInt->SetIndex(2);
+
+    km.ResetAllToStartup();
+    EXPECT_TRUE(pGeneralBoolean->GetValue());
+    EXPECT_EQ(pRange3Int->GetValue(0), 1);
+    EXPECT_EQ(pOptionInt->GetIndex(), 1);
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_GetBasicUsageMsg)
+{
+    std::string usageMsg = R"(
+Flags:
+--general_boolean
+                    (Default: true)
+
+--general_boolean_list
+                    (Default: true,true,true)
+
+--range_1_int <-10 ~ 10>
+                    (Default: 0)
+
+--range_3_int <-10,-10,-10 ~ 10,10,10>
+                    (Default: 1,2,3)
+
+--range_3_float <-10,-10,-10 ~ 10,10,10>
+                    (Default: 1.5,2.5,3.5)
+
+--option_int <c2|"c3 and more">
+                    (Default: c2)
+
+--option_string <c2|"c3 and more">
+                    (Default: c2)
+
+)";
+    EXPECT_EQ(km.GetUsageMsg(), usageMsg);
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_GetCustomizedUsageMsg)
+{
+    pGeneralBoolean->SetFlagParameters("<bool>");
+    pGeneralBoolean->SetFlagDescription("pGeneralBoolean description");
+    pRange3Int->SetMax(1, INT_MAX);
+    pRange3Int->SetMin(0, INT_MIN);
+    pRange3Int->SetFlagDescription("pRange3Int description");
+    pRange3Float->SetMax(1, FLT_MAX);
+    pRange3Float->SetMin(0, FLT_MIN);
+    pRange3Float->SetFlagDescription("pRange3Float description");
+
+    std::string usageMsg = R"(
+Flags:
+--general_boolean <bool>
+                    (Default: true)
+                    pGeneralBoolean description
+
+--general_boolean_list
+                    (Default: true,true,true)
+
+--range_1_int <-10 ~ 10>
+                    (Default: 0)
+
+--range_3_int <MIN,-10,-10 ~ 10,MAX,10>
+                    (Default: 1,2,3)
+                    pRange3Int description
+
+--range_3_float <MIN,-10,-10 ~ 10,MAX,10>
+                    (Default: 1.5,2.5,3.5)
+                    pRange3Float description
+
+--option_int <c2|"c3 and more">
+                    (Default: c2)
+
+--option_string <c2|"c3 and more">
+                    (Default: c2)
+
+)";
+    EXPECT_EQ(km.GetUsageMsg(), usageMsg);
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_SaveAll)
+{
+    km.FinalizeAll();
+
+    OptionsNew wantOptions = OptionsNew(
+        {{"general_boolean", std::vector<std::string>{"true"}},
+         {"general_boolean_list", std::vector<std::string>{"true", "true", "true"}},
+         {"range_1_int", std::vector<std::string>{"0"}},
+         {"range_3_int", std::vector<std::string>{"1,2,3"}},
+         {"range_3_float", std::vector<std::string>{"1.5,2.5,3.5"}},
+         {"option_int", std::vector<std::string>{"c2"}},
+         {"option_string", std::vector<std::string>{"c2"}}});
+    OptionsNew gotOptions;
+    km.Save(gotOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_SaveNonStartupOnly)
+{
+    pGeneralBoolean->SetStartupOnly();
+    pRange3Float->SetStartupOnly();
+    km.FinalizeAll();
+
+    OptionsNew wantOptions = OptionsNew(
+        {{"general_boolean_list", std::vector<std::string>{"true", "true", "true"}},
+         {"range_1_int", std::vector<std::string>{"0"}},
+         {"range_3_int", std::vector<std::string>{"1,2,3"}},
+         {"option_int", std::vector<std::string>{"c2"}},
+         {"option_string", std::vector<std::string>{"c2"}}});
+    OptionsNew gotOptions;
+    km.Save(gotOptions, true);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_Load)
+{
+    km.FinalizeAll();
+
+    OptionsNew loadOptions = OptionsNew(
+        {{"general_boolean", std::vector<std::string>{"false"}},
+         {"general_boolean_list", std::vector<std::string>{"true", "true"}},
+         {"range_1_int", std::vector<std::string>{"5"}},
+         {"range_3_int", std::vector<std::string>{"1,2,3"}},
+         {"range_3_float", std::vector<std::string>{"5.0,5.0,5.0"}},
+         {"option_int", std::vector<std::string>{"c3 and more"}},
+         {"option_string", std::vector<std::string>{"c3 and more"}}});
+    km.Load(loadOptions);
+    EXPECT_EQ(pGeneralBoolean->GetValue(), false);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().size(), 2);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().at(0), true);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().at(1), true);
+    EXPECT_EQ(pRange1Int->GetValue(), 5);
+    EXPECT_EQ(pRange3Int->GetValue(0), 1);
+    EXPECT_EQ(pRange3Int->GetValue(1), 2);
+    EXPECT_EQ(pRange3Int->GetValue(2), 3);
+    EXPECT_EQ(pRange3Float->GetValue(0), 5.0f);
+    EXPECT_EQ(pRange3Float->GetValue(1), 5.0f);
+    EXPECT_EQ(pRange3Float->GetValue(2), 5.0f);
+    EXPECT_EQ(pOptionInt->GetIndex(), 2);
+    EXPECT_EQ(pOptionInt->GetValue(), 3);
+    EXPECT_EQ(pOptionString->GetIndex(), 2);
+    EXPECT_EQ(pOptionString->GetValue(), "c3 and more");
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_LoadBeforeFinalize)
+{
+    OptionsNew loadOptions = OptionsNew(
+        {{"general_boolean", std::vector<std::string>{"false"}},
+         {"general_boolean_list", std::vector<std::string>{"true", "true"}},
+         {"range_1_int", std::vector<std::string>{"5"}},
+         {"range_3_int", std::vector<std::string>{"1,2,3"}},
+         {"range_3_float", std::vector<std::string>{"5.0,5.0,5.0"}},
+         {"option_int", std::vector<std::string>{"c3 and more"}},
+         {"option_string", std::vector<std::string>{"c3 and more"}}});
+    km.Load(loadOptions);
+    EXPECT_EQ(pGeneralBoolean->GetValue(), false);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().size(), 2);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().at(0), true);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().at(1), true);
+    EXPECT_EQ(pRange1Int->GetValue(), 5);
+    EXPECT_EQ(pRange3Int->GetValue(0), 1);
+    EXPECT_EQ(pRange3Int->GetValue(1), 2);
+    EXPECT_EQ(pRange3Int->GetValue(2), 3);
+    EXPECT_EQ(pRange3Float->GetValue(0), 5.0f);
+    EXPECT_EQ(pRange3Float->GetValue(1), 5.0f);
+    EXPECT_EQ(pRange3Float->GetValue(2), 5.0f);
+    EXPECT_EQ(pOptionInt->GetIndex(), 2);
+    EXPECT_EQ(pOptionInt->GetValue(), 3);
+    EXPECT_EQ(pOptionString->GetIndex(), 2);
+    EXPECT_EQ(pOptionString->GetValue(), "c3 and more");
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_LoadNonStartupOnly)
+{
+    pGeneralBoolean->SetStartupOnly();
+    pRange3Float->SetStartupOnly();
+    km.FinalizeAll();
+
+    OptionsNew loadOptions = OptionsNew(
+        {{"general_boolean", std::vector<std::string>{"false"}},
+         {"general_boolean_list", std::vector<std::string>{"true", "true"}},
+         {"range_1_int", std::vector<std::string>{"5"}},
+         {"range_3_int", std::vector<std::string>{"1,2,3"}},
+         {"range_3_float", std::vector<std::string>{"5.0,5.0,5.0"}},
+         {"option_int", std::vector<std::string>{"c3 and more"}},
+         {"option_string", std::vector<std::string>{"c3 and more"}}});
+    km.Load(loadOptions);
+    EXPECT_EQ(pGeneralBoolean->GetValue(), true);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().size(), 2);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().at(0), true);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().at(1), true);
+    EXPECT_EQ(pRange1Int->GetValue(), 5);
+    EXPECT_EQ(pRange3Int->GetValue(0), 1);
+    EXPECT_EQ(pRange3Int->GetValue(1), 2);
+    EXPECT_EQ(pRange3Int->GetValue(2), 3);
+    EXPECT_EQ(pRange3Float->GetValue(0), 1.5f);
+    EXPECT_EQ(pRange3Float->GetValue(1), 2.5f);
+    EXPECT_EQ(pRange3Float->GetValue(2), 3.5f);
+    EXPECT_EQ(pOptionInt->GetIndex(), 2);
+    EXPECT_EQ(pOptionInt->GetValue(), 3);
+    EXPECT_EQ(pOptionString->GetIndex(), 2);
+    EXPECT_EQ(pOptionString->GetValue(), "c3 and more");
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_LoadGeneralKnobInvalid)
+{
+    OptionsNew loadOptions = OptionsNew(
+        {{"general_boolean_list", std::vector<std::string>{"false", "false", "false"}}});
+    km.Load(loadOptions);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().size(), 3);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().at(0), true);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().at(1), true);
+    EXPECT_EQ(pGeneralBooleanList->GetValue().at(2), true);
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_LoadRangeKnobValidDelimiters)
+{
+    OptionsNew loadOptions = OptionsNew(
+        {{"range_3_int", std::vector<std::string>{"-4X3X-10"}},
+         {"range_3_float", std::vector<std::string>{"1.0X-3.0X4.0"}}});
+    km.Load(loadOptions);
+    EXPECT_EQ(pRange3Int->GetValue(0), -4);
+    EXPECT_EQ(pRange3Int->GetValue(1), 3);
+    EXPECT_EQ(pRange3Int->GetValue(2), -10);
+    EXPECT_EQ(pRange3Float->GetValue(0), 1.0f);
+    EXPECT_EQ(pRange3Float->GetValue(1), -3.0f);
+    EXPECT_EQ(pRange3Float->GetValue(2), 4.0f);
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_LoadRangeKnobInvalid)
+{
+    km.FinalizeAll();
+
+    OptionsNew loadOptions = OptionsNew(
+        {{"range_3_int", std::vector<std::string>{"-4X3XX-10"}},
+         {"range_3_float", std::vector<std::string>{"1.0X-3.0,4.0"}}});
+    km.Load(loadOptions);
+    EXPECT_EQ(pRange3Int->GetValue(0), 1);
+    EXPECT_EQ(pRange3Int->GetValue(1), 2);
+    EXPECT_EQ(pRange3Int->GetValue(2), 3);
+    EXPECT_EQ(pRange3Float->GetValue(0), 1.5f);
+    EXPECT_EQ(pRange3Float->GetValue(1), 2.5f);
+    EXPECT_EQ(pRange3Float->GetValue(2), 3.5f);
+}
+
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_LoadOptionKnobInvalid)
+{
+    km.FinalizeAll();
+
+    OptionsNew loadOptions = OptionsNew(
+        {{"option_int", std::vector<std::string>{"c1"}},
+         {"option_string", std::vector<std::string>{"anything"}}});
+    km.Load(loadOptions);
+    EXPECT_EQ(pOptionInt->GetIndex(), 1);
+    EXPECT_EQ(pOptionString->GetIndex(), 1);
+}
+
+#if defined(PERFORM_DEATH_TESTS)
+TEST_F(KnobManagerNewWithKnobsTestFixture, KnobManagerNew_LoadUnknownKnobFail)
+{
+    km.FinalizeAll();
+
+    OptionsNew loadOptions = OptionsNew(
+        {{"UNKNOWN", std::vector<std::string>{"hello world"}}});
+    EXPECT_DEATH(
+        {
+            km.Load(loadOptions);
+        },
+        "");
+}
+#endif
+
+} // namespace ppx

--- a/src/test/knob_test.cpp
+++ b/src/test/knob_test.cpp
@@ -614,10 +614,10 @@ Flags:
                     (Default: 5)
 
 --flag_name9
-                    (Default: 1, 2)
+                    (Default: 1,2)
 
 --flag_name10
-                    (Default: a, b, c, d and more)
+                    (Default: a,b,c,d and more)
 
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);
@@ -669,11 +669,11 @@ Flags:
                     (Default: 5)
 
 --flag_name9
-                    (Default: 1, 2)
+                    (Default: 1,2)
                     description9
 
 --flag_name10 <string>
-                    (Default: a, b, c, d and more)
+                    (Default: a,b,c,d and more)
 
 )";
     EXPECT_EQ(km.GetUsageMsg(), usageMsg);

--- a/src/test/options_new_test.cpp
+++ b/src/test/options_new_test.cpp
@@ -1,0 +1,377 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "ppx/options_new.h"
+
+namespace ppx {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(OptionsNewTest, NoOptions)
+{
+    OptionsNew gotOptions;
+    EXPECT_FALSE(gotOptions.HasOption("test"));
+    EXPECT_EQ(gotOptions.GetNumUniqueOptions(), 0);
+}
+
+TEST(OptionsNewTest, AddOption_OneValue)
+{
+    OptionsNew wantOptions = OptionsNew({{"name1", std::vector<std::string>{"value1"}}});
+    OptionsNew gotOptions;
+    gotOptions.AddOption("name1", "value1");
+    EXPECT_EQ(gotOptions, wantOptions);
+
+    EXPECT_TRUE(gotOptions.HasOption("name1"));
+    EXPECT_EQ(gotOptions.GetNumUniqueOptions(), 1);
+    std::vector<std::string> gotValue = gotOptions.GetValueStrings("name1");
+    EXPECT_EQ(gotValue.at(0), "value1");
+}
+
+TEST(OptionsNewTest, AddOption_MultipleValues)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"value1", "value2"}}});
+    OptionsNew gotOptions;
+    gotOptions.AddOption("name1", "value1");
+    gotOptions.AddOption("name1", "value2");
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(OptionsNewTest, AddOption_MultipleValuesList)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"value1", "value2"}}});
+    OptionsNew gotOptions;
+    gotOptions.AddOption("name1", std::vector<std::string>{"value1", "value2"});
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(OptionsNewTest, AddOption_MultipleOptions)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"value1"}},
+         {"name2", std::vector<std::string>{"value3"}}});
+    OptionsNew gotOptions;
+    gotOptions.AddOption("name1", "value1");
+    gotOptions.AddOption("name2", "value3");
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(OptionsNewTest, OverwriteOptions_EmptyOverwrite)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"value1", "value2"}},
+         {"name2", std::vector<std::string>{"value3", "value4"}}});
+    OptionsNew gotOptions;
+    OptionsNew overwriteOptions;
+    gotOptions.AddOption("name1", std::vector<std::string>{"value1", "value2"});
+    gotOptions.AddOption("name2", std::vector<std::string>{"value3", "value4"});
+    gotOptions.OverwriteOptions(overwriteOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(OptionsNewTest, OverwriteOptions_EmptyBase)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"value1", "value2"}},
+         {"name2", std::vector<std::string>{"value3", "value4"}}});
+    OptionsNew gotOptions;
+    OptionsNew overwriteOptions;
+    overwriteOptions.AddOption("name1", std::vector<std::string>{"value1", "value2"});
+    overwriteOptions.AddOption("name2", std::vector<std::string>{"value3", "value4"});
+    gotOptions.OverwriteOptions(overwriteOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(OptionsNewTest, OverwriteOptions_Complex)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"newvalue1"}},
+         {"name2", std::vector<std::string>{"oldvalue3", "oldvalue4"}},
+         {"name3", std::vector<std::string>{"newvalue5", "newvalue6"}}});
+    OptionsNew gotOptions;
+    gotOptions.AddOption("name1", std::vector<std::string>{"oldvalue1", "oldvalue2"});
+    gotOptions.AddOption("name2", std::vector<std::string>{"oldvalue3", "oldvalue4"});
+    OptionsNew overwriteOptions;
+    overwriteOptions.AddOption("name1", std::vector<std::string>{"newvalue1"});
+    overwriteOptions.AddOption("name3", std::vector<std::string>{"newvalue5", "newvalue6"});
+    gotOptions.OverwriteOptions(overwriteOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(CommandLineParserNewTest, Parse_ZeroArguments)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    EXPECT_TRUE(Success(parser.ParseOptions(0, nullptr, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 0);
+}
+
+TEST(CommandLineParserNewTest, Parse_FirstArgumentIgnored)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 0);
+}
+
+TEST(CommandLineParserNewTest, Parse_Booleans)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--b", "1", "--c", "true", "--no-d", "--e", "0", "--f", "false"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 6);
+    auto optsMap = opts.GetMap();
+    EXPECT_EQ(optsMap.at("a"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("b"), std::vector<std::string>{"1"});
+    EXPECT_EQ(optsMap.at("c"), std::vector<std::string>{"true"});
+    EXPECT_EQ(optsMap.at("d"), std::vector<std::string>{"0"}); // no- prefix is interpreted as such
+    EXPECT_EQ(optsMap.at("e"), std::vector<std::string>{"0"});
+    EXPECT_EQ(optsMap.at("f"), std::vector<std::string>{"false"});
+}
+
+TEST(CommandLineParserNewTest, Parse_Values)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] =
+        {"/path/to/executable",
+         "--a",
+         "filename with spaces",
+         "--b",
+         "filenameWithoutSpaces",
+         "--c",
+         "filename,with/.punctuation,",
+         "--d",
+         "",
+         "--e",
+         "--f",
+         "-5",
+         "--g",
+         "10.4",
+         "--h",
+         "-300.0"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 8);
+    auto optsMap = opts.GetMap();
+    EXPECT_EQ(optsMap.at("a"), std::vector<std::string>{"filename with spaces"});
+    EXPECT_EQ(optsMap.at("b"), std::vector<std::string>{"filenameWithoutSpaces"});
+    EXPECT_EQ(optsMap.at("c"), std::vector<std::string>{"filename,with/.punctuation,"});
+    EXPECT_EQ(optsMap.at("d"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("e"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("f"), std::vector<std::string>{"-5"});
+    EXPECT_EQ(optsMap.at("g"), std::vector<std::string>{"10.4"});
+    EXPECT_EQ(optsMap.at("h"), std::vector<std::string>{"-300.0"});
+}
+
+TEST(CommandLineParserNewTest, Parse_StringList)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "some-path", "--a", "some-other-path", "--a", "last-path"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 1);
+    auto gotValues = opts.GetValueStrings("a");
+    EXPECT_EQ(gotValues.size(), 3);
+    if (gotValues.size() == 3) {
+        EXPECT_EQ(gotValues[0], "some-path");
+        EXPECT_EQ(gotValues[1], "some-other-path");
+        EXPECT_EQ(gotValues[2], "last-path");
+    }
+}
+
+TEST(CommandLineParserNewTest, Parse_EqualSigns)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--b=5", "--c", "--d", "11"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 4);
+    auto optsMap = opts.GetMap();
+    EXPECT_EQ(optsMap.at("a"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("b"), std::vector<std::string>{"5"});
+    EXPECT_EQ(optsMap.at("c"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("d"), std::vector<std::string>{"11"});
+}
+
+TEST(CommandLineParserNewTest, Parse_EqualSignsMultipleFail)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--b=5=8", "--c", "--d", "11"};
+    EXPECT_TRUE(Failed(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+}
+
+TEST(CommandLineParserNewTest, Parse_EqualSignsNoNameFail)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--=5", "--c", "--d", "11"};
+    EXPECT_TRUE(Failed(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+}
+
+TEST(CommandLineParserNewTest, Parse_EqualSignsNoFlagFail)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "=5", "--c", "--d", "11"};
+    EXPECT_TRUE(Failed(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+}
+
+TEST(CommandLineParserNewTest, Parse_EqualSignsEmptyValuePass)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--b=", "--c", "--d", "11"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 4);
+    auto optsMap = opts.GetMap();
+    EXPECT_EQ(optsMap.at("a"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("b"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("c"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("d"), std::vector<std::string>{"11"});
+}
+
+TEST(CommandLineParserNewTest, Parse_LeadingParameterFail)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "10", "--a", "--b", "5", "--c", "--d", "11"};
+    EXPECT_TRUE(Failed(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+}
+
+TEST(CommandLineParserNewTest, Parse_AdjacentParameterFail)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--b", "5", "8", "--c", "--d", "11"};
+    EXPECT_TRUE(Failed(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+}
+
+TEST(CommandLineParserNewTest, Parse_MultipleUsageFlag)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "1", "--b", "1", "--a", "2", "--a", "3"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 2);
+    auto optsMap = opts.GetMap();
+    EXPECT_EQ(optsMap.at("a").at(0), "1");
+    EXPECT_EQ(optsMap.at("a").at(1), "2");
+    EXPECT_EQ(optsMap.at("a").at(2), "3");
+    EXPECT_EQ(optsMap.at("b"), std::vector<std::string>{"1"});
+}
+
+TEST(JsonConverterTest, ParseOptions_Empty)
+{
+    JsonConverterNew parser;
+    OptionsNew       opts;
+    nlohmann::json   jsonConfig;
+    parser.ParseOptions(jsonConfig, opts);
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 0);
+}
+
+TEST(JsonConverterTest, ParseOptions_Simple)
+{
+    JsonConverterNew parser;
+    std::string      jsonText    = R"(
+  {
+    "a": true,
+    "b": false,
+    "c": 1.234,
+    "d": 5,
+    "e": "helloworld",
+    "f": "hello world",
+    "g": "200x300"
+  }
+)";
+    OptionsNew       wantOptions = OptionsNew(
+        {{"a", std::vector<std::string>{"true"}},
+         {"b", std::vector<std::string>{"false"}},
+         {"c", std::vector<std::string>{"1.234"}},
+         {"d", std::vector<std::string>{"5"}},
+         {"e", std::vector<std::string>{"helloworld"}},
+         {"f", std::vector<std::string>{"hello world"}},
+         {"g", std::vector<std::string>{"200x300"}}});
+    OptionsNew     gotOptions = {};
+    nlohmann::json jsonConfig = nlohmann::json::parse(jsonText);
+    parser.ParseOptions(jsonConfig, gotOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(JsonConverterTest, ParseOptions_NestedStructureFlattened)
+{
+    JsonConverterNew parser;
+    std::string      jsonText    = R"(
+  {
+    "a": true,
+    "b": {
+        "c" : 1,
+        "d" : 2
+    }
+  }
+)";
+    OptionsNew       wantOptions = OptionsNew(
+        {{"a", std::vector<std::string>{"true"}},
+         {"b", std::vector<std::string>{"{\"c\":1,\"d\":2}"}}});
+    OptionsNew     gotOptions = {};
+    nlohmann::json jsonConfig = nlohmann::json::parse(jsonText);
+    parser.ParseOptions(jsonConfig, gotOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(JsonConverterTest, ParseOptions_IntArray)
+{
+    JsonConverterNew parser;
+    std::string      jsonText    = R"(
+  {
+    "a": true,
+    "b": [1, 2, 3]
+  }
+)";
+    OptionsNew       wantOptions = OptionsNew(
+        {{"a", std::vector<std::string>{"true"}},
+         {"b", std::vector<std::string>{"1", "2", "3"}}});
+    OptionsNew     gotOptions = {};
+    nlohmann::json jsonConfig = nlohmann::json::parse(jsonText);
+    parser.ParseOptions(jsonConfig, gotOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(JsonConverterTest, ParseOptions_HeterogeneousArray)
+{
+    JsonConverterNew parser;
+    std::string      jsonText    = R"(
+  {
+    "a": true,
+    "b": [1, "2", {"c" : 3}, 4.0]
+  }
+)";
+    OptionsNew       wantOptions = OptionsNew(
+        {{"a", std::vector<std::string>{"true"}},
+         {"b", std::vector<std::string>{"1", "2", "{\"c\":3}", "4.0"}}});
+    OptionsNew     gotOptions = {};
+    nlohmann::json jsonConfig = nlohmann::json::parse(jsonText);
+    parser.ParseOptions(jsonConfig, gotOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+} // namespace
+} // namespace ppx

--- a/src/test/string_util_test.cpp
+++ b/src/test/string_util_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -75,6 +75,14 @@ TEST(StringUtilTest, TrimBothEnds_LeftAndRightSpaces)
     EXPECT_EQ(toTrim, "  Some spaces  ");
 }
 
+TEST(StringUtilTest, TrimBothEnds_OnlySpaces)
+{
+    std::string_view toTrim  = "    ";
+    std::string_view trimmed = TrimBothEnds(toTrim);
+    EXPECT_EQ(trimmed, "");
+    EXPECT_EQ(toTrim, "    ");
+}
+
 TEST(StringUtilTest, SplitInTwo_EmptyString)
 {
     std::string_view                              toSplit = "";
@@ -136,6 +144,62 @@ TEST(StringUtilTest, SplitInTwo_TwoElementsWithConsecutiveDelimiters)
     std::string_view                              toSplit = "Apple,,Banana";
     std::pair<std::string_view, std::string_view> want    = std::make_pair("Apple", ",Banana");
     std::pair<std::string_view, std::string_view> got     = SplitInTwo(toSplit, ',');
+    EXPECT_EQ(got, want);
+}
+
+TEST(StringUtilTest, Split_EmptyString)
+{
+    std::string_view              toSplit = "";
+    std::vector<std::string_view> want    = std::vector<std::string_view>{""};
+    std::vector<std::string_view> got     = Split(toSplit, ',');
+    EXPECT_EQ(got, want);
+}
+
+TEST(StringUtilTest, Split_Pass)
+{
+    std::string_view              toSplit = "one,two";
+    std::vector<std::string_view> want    = std::vector<std::string_view>{"one", "two"};
+    std::vector<std::string_view> got     = Split(toSplit, ',');
+    EXPECT_EQ(got, want);
+}
+
+TEST(StringUtilTest, Split_NoDelimiter)
+{
+    std::string_view              toSplit = "testing this string";
+    std::vector<std::string_view> want    = std::vector<std::string_view>{"testing this string"};
+    std::vector<std::string_view> got     = Split(toSplit, ',');
+    EXPECT_EQ(got, want);
+}
+
+TEST(StringUtilTest, Split_LeadingDelimiter)
+{
+    std::string_view              toSplit = ",testing";
+    std::vector<std::string_view> want    = std::vector<std::string_view>{"", "testing"};
+    std::vector<std::string_view> got     = Split(toSplit, ',');
+    EXPECT_EQ(got, want);
+}
+
+TEST(StringUtilTest, Split_TrailingDelimiter)
+{
+    std::string_view              toSplit = "testing,";
+    std::vector<std::string_view> want    = std::vector<std::string_view>{"testing", ""};
+    std::vector<std::string_view> got     = Split(toSplit, ',');
+    EXPECT_EQ(got, want);
+}
+
+TEST(StringUtilTest, Split_OnlyDelimiter)
+{
+    std::string_view              toSplit = ",";
+    std::vector<std::string_view> want    = std::vector<std::string_view>{"", ""};
+    std::vector<std::string_view> got     = Split(toSplit, ',');
+    EXPECT_EQ(got, want);
+}
+
+TEST(StringUtilTest, Split_ConsecutiveDelimiter)
+{
+    std::string_view              toSplit = "one,,two";
+    std::vector<std::string_view> want    = std::vector<std::string_view>{"one", "", "two"};
+    std::vector<std::string_view> got     = Split(toSplit, ',');
     EXPECT_EQ(got, want);
 }
 
@@ -314,7 +378,7 @@ TEST(StringUtilTest, ToString_FloatNoTrailingZeroes)
 TEST(StringUtilTest, ToString_PairInt)
 {
     std::pair<int, int> pi         = std::make_pair(10, 20);
-    std::string         wantString = "10, 20";
+    std::string         wantString = "10,20";
     std::string         gotString  = ToString(pi);
     EXPECT_EQ(gotString, wantString);
 }
@@ -322,7 +386,7 @@ TEST(StringUtilTest, ToString_PairInt)
 TEST(StringUtilTest, ToString_VectorString)
 {
     std::vector<std::string> vs         = {"hello", "world", "!"};
-    std::string              wantString = "hello, world, !";
+    std::string              wantString = "hello,world,!";
     std::string              gotString  = ToString(vs);
     EXPECT_EQ(gotString, wantString);
 }
@@ -330,7 +394,7 @@ TEST(StringUtilTest, ToString_VectorString)
 TEST(StringUtilTest, ToString_VectorBool)
 {
     std::vector<bool> vb         = {true, false, true, true, false};
-    std::string       wantString = "true, false, true, true, false";
+    std::string       wantString = "true,false,true,true,false";
     std::string       gotString  = ToString(vb);
     EXPECT_EQ(gotString, wantString);
 }
@@ -430,6 +494,17 @@ TEST(StringUtilTest, Parse_BoolFail)
 TEST(StringUtilTest, Parse_IntegerPass)
 {
     std::string toParse     = "-10";
+    int         parsedValue = 0;
+    int         wantValue   = -10;
+
+    auto res = Parse(toParse, parsedValue);
+    EXPECT_TRUE(ppx::Success(res));
+    EXPECT_EQ(parsedValue, wantValue);
+}
+
+TEST(StringUtilTest, Parse_IntegerTruncated)
+{
+    std::string toParse     = "-10.3";
     int         parsedValue = 0;
     int         wantValue   = -10;
 


### PR DESCRIPTION
Adding a newer version of the knob framework and a demo that utilizes it.

Added in this PR:
- `ApplicationSettings.useKnobManagerNew` : A flag for applications to use the new knob framework on top of the old one
- `OptionsNew`: An intermediate format along with some supporting classes (`JsonConverterNew` and `CommandLineParserNew`) that are intended to replace `CliOptions` and `CommandLineParser`
- `KnobManagerNew` and `KnobNew`
- `knob_demo/` : Example project that features the newer knob framework
- Minor changes to `string_util`, adding Split function and removing whitespace padding from compound strings produced by `ToString()` functions

Some notable features of the newer version of knob framework:
- Decoupled knob function and display
- Runtime adjustable knob parameters (e.g. min, max, available subset of options)
- Runtime Load/Save support with JSON config files
- Can now identify if non-knob options are specified on the command line and terminate the application early

Future plans:
- Switch all projects and benchmarks to use the new knob framework.
- Change `ppx::Application` to use only the new knob framework and `mStandardOptsNew`
- Remove code for old knob framework and `CommandLineParser` + `CliOptions`
- Rename the replacements to remove "New" suffix