### PR TITLE
[knob-framework] Add intermediate format `OptionsNew`

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Setup clang-format
         run: |
-          sudo apt-get install -yqq clang-format-12
+          sudo apt-get install -yqq clang-format-16
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Setup clang-format
         run: |
-          sudo apt-get install -yqq clang-format-16
+          sudo apt-get install -yqq clang-format-12
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/include/ppx/options_new.h
+++ b/include/ppx/options_new.h
@@ -1,0 +1,132 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ppx_options_new_h
+#define ppx_options_new_h
+
+#include "nlohmann/json.hpp"
+#include "ppx/config.h"
+#include "ppx/log.h"
+#include "ppx/string_util.h"
+
+#include <cstdint>
+#include <ios>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+namespace ppx {
+
+// -------------------------------------------------------------------------------------------------
+// OptionsNew
+// -------------------------------------------------------------------------------------------------
+//
+// OptionsNew is an intermediate format structure consisting of an unordered map of key-value pairs
+// that contain information used in knobs, command line flags, and JSON config files
+//
+// keys (string): The knob's unique flag name
+// values (list of strings): Values that have been specified for those keys from low to high priority
+//
+class OptionsNew
+{
+public:
+    OptionsNew() = default;
+    OptionsNew(const std::unordered_map<std::string, std::vector<std::string>>& newOptions) { mAllOptions = newOptions; }
+
+    bool HasOption(const std::string& option) const { return mAllOptions.find(option) != mAllOptions.end(); }
+
+    size_t GetNumUniqueOptions() const { return mAllOptions.size(); }
+
+    std::unordered_map<std::string, std::vector<std::string>> GetMap() const { return mAllOptions; }
+
+    std::vector<std::string> GetValueStrings(const std::string& optionName) const { return mAllOptions.at(optionName); }
+
+    // Adds new option if the option does not already exist
+    // Otherwise, the new value is appended to the end of the vector of stored parameters for this option
+    void AddOption(std::string_view optionName, std::string_view value);
+
+    // Same as above, but appends an array of values at the same key
+    void AddOption(std::string_view optionName, const std::vector<std::string>& valueArray);
+
+    // For all options existing in newOptions, current entries in mAllOptions will be replaced by them
+    void OverwriteOptions(const OptionsNew& newOptions);
+
+    bool operator==(const OptionsNew& rhs) const
+    {
+        return (mAllOptions == rhs.GetMap());
+    }
+
+private:
+    // All flag names (string) and parameters (vector of strings) specified on the command line
+    std::unordered_map<std::string, std::vector<std::string>> mAllOptions;
+};
+
+// -------------------------------------------------------------------------------------------------
+// CommandLineParserNew
+// -------------------------------------------------------------------------------------------------
+//
+// CommandLineParserNew can parse command-line arguments into OptionsNew intermediate format.
+// This includes any JSON config files specified with the flag mJsonConfigFlagName.
+//
+class CommandLineParserNew
+{
+public:
+    // Parse the given arguments into options. Return false if parsing
+    // succeeded. Otherwise, return true if an error occurred,
+    // and write the error to `out_error`.
+    //
+    // Value syntax:
+    // - strings cannot contain "="
+    // - boolean values stored as "0", "false", "1", "true", ""
+    Result ParseOptions(int argc, const char* argv[], OptionsNew& options);
+
+    std::string GetJsonConfigFlagName() const { return mJsonConfigFlagName; }
+
+private:
+    // Adds one instance of an option to the OptionsNew
+    // Checks for the special no- prefix allowed for the command line flags
+    Result AddOption(OptionsNew& opts, std::string_view optionName, std::string_view valueStr);
+
+private:
+    std::string mJsonConfigFlagName = "config-json-path";
+};
+
+// -------------------------------------------------------------------------------------------------
+// JsonConverterNew
+// -------------------------------------------------------------------------------------------------
+//
+// JsonConverterNew can convert JSON structures and files to and from OptionsNew intermediate format.
+//
+class JsonConverterNew
+{
+public:
+    // Parses all options specified within the JSON file and adds them to options.
+    Result ParseOptionsFromFile(const std::string& jsonPath, OptionsNew& options);
+
+    // Creates/overwrites file at jsonPath with all options in JSON format
+    Result ExportOptionsToFile(const OptionsNew& options, const std::string& jsonPath);
+
+    // Exposed for testing
+    void ParseOptions(const nlohmann::json& jsonConfig, OptionsNew& options);
+    void ExportOptions(const OptionsNew& options, nlohmann::json& jsonConfig);
+};
+
+} // namespace ppx
+
+#endif // ppx_options_new_h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,6 +167,7 @@ list(
     ${INC_DIR}/ppx/metrics.h
     ${INC_DIR}/ppx/mipmap.h
     ${INC_DIR}/ppx/obj_ptr.h
+    ${INC_DIR}/ppx/options_new.h
     ${INC_DIR}/ppx/platform.h
     ${INC_DIR}/ppx/ppx.h
     ${INC_DIR}/ppx/ppm_export.h
@@ -203,6 +204,7 @@ list(
     ${SRC_DIR}/ppx/math_config.cpp
     ${SRC_DIR}/ppx/metrics.cpp
     ${SRC_DIR}/ppx/mipmap.cpp
+    ${SRC_DIR}/ppx/options_new.cpp
     ${SRC_DIR}/ppx/platform.cpp
     ${SRC_DIR}/ppx/ppm_export.cpp
     ${SRC_DIR}/ppx/profiler.cpp

--- a/src/ppx/options_new.cpp
+++ b/src/ppx/options_new.cpp
@@ -1,0 +1,253 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <locale>
+#include <vector>
+#include <stdexcept>
+#include <cctype>
+
+#include "ppx/options_new.h"
+
+namespace {
+
+bool StartsWithDoubleDash(std::string_view s)
+{
+    if (s.size() >= 3) {
+        return s.substr(0, 2) == "--";
+    }
+    return false;
+}
+
+} // namespace
+
+namespace ppx {
+
+// -------------------------------------------------------------------------------------------------
+// OptionsNew
+// -------------------------------------------------------------------------------------------------
+void OptionsNew::OverwriteOptions(const OptionsNew& newOptions)
+{
+    for (auto& it : newOptions.mAllOptions) {
+        mAllOptions[it.first] = it.second;
+    }
+}
+
+void OptionsNew::AddOption(std::string_view optionName, std::string_view value)
+{
+    std::string optionNameStr(optionName);
+    std::string valueStr(value);
+    auto        it = mAllOptions.find(optionNameStr);
+    if (it == mAllOptions.cend()) {
+        std::vector<std::string> v{std::move(valueStr)};
+        mAllOptions.emplace(std::move(optionNameStr), std::move(v));
+        return;
+    }
+    it->second.push_back(valueStr);
+}
+
+void OptionsNew::AddOption(std::string_view optionName, const std::vector<std::string>& valueArray)
+{
+    std::string optionNameStr(optionName);
+    auto        it = mAllOptions.find(optionNameStr);
+    if (it == mAllOptions.cend()) {
+        mAllOptions.emplace(std::move(optionNameStr), valueArray);
+        return;
+    }
+    auto storedValueArray = it->second;
+    storedValueArray.insert(storedValueArray.end(), valueArray.cbegin(), valueArray.cend());
+}
+
+// -------------------------------------------------------------------------------------------------
+// CommandLineParserNew
+// -------------------------------------------------------------------------------------------------
+
+Result CommandLineParserNew::ParseOptions(int argc, const char* argv[], OptionsNew& options)
+{
+    // argc should be >= 1 and argv[0] the name of the executable.
+    if (argc < 2) {
+        return SUCCESS;
+    }
+
+    // Initial pass to trim the name of executable and to split any flag and parameters that are connected with '='
+    std::vector<std::string_view> args;
+    for (size_t i = 1; i < argc; ++i) {
+        std::string_view argString(argv[i]);
+        if (argString.find('=') != std::string_view::npos) {
+            if (std::count(argString.cbegin(), argString.cend(), '=') != 1) {
+                PPX_LOG_ERROR("invalid number of '=' in flag: \"" << argString << "\"");
+                return ERROR_FAILED;
+            }
+            std::pair<std::string_view, std::string_view> optionAndValue = ppx::string_util::SplitInTwo(argString, '=');
+            args.emplace_back(optionAndValue.first);
+            args.emplace_back(optionAndValue.second);
+            continue;
+        }
+        args.emplace_back(argString);
+    }
+
+    // Another pass to identify JSON config files, add that option, and remove it from the argument list
+    std::vector<std::string_view> argsFiltered;
+    std::vector<std::string>      jsonConfigFilePaths;
+    for (size_t i = 0; i < args.size(); ++i) {
+        bool nextArgumentIsParameter = (i + 1 < args.size()) && !StartsWithDoubleDash(args[i + 1]);
+        if ((args[i] == "--" + mJsonConfigFlagName) && nextArgumentIsParameter) {
+            jsonConfigFilePaths.emplace_back(ppx::string_util::TrimBothEnds(args[i + 1]));
+            ++i;
+            continue;
+        }
+        argsFiltered.emplace_back(args[i]);
+    }
+    args = argsFiltered;
+    argsFiltered.clear();
+
+    // Flags inside JSON files are processed first
+    // These are always lower priority than flags on the command-line
+    std::vector<std::string> configJsonPaths;
+    JsonConverterNew         jsonConverter;
+    OptionsNew               jsonOptions;
+    for (const auto& jsonPath : jsonConfigFilePaths) {
+        auto res = jsonConverter.ParseOptionsFromFile(jsonPath, jsonOptions);
+        if (Failed(res)) {
+            return res;
+        }
+        options.OverwriteOptions(jsonOptions);
+    }
+
+    OptionsNew commandlineOptions;
+    // Main pass, process arguments into either standalone flags or options with parameters.
+    for (size_t i = 0; i < args.size(); ++i) {
+        std::string_view name = ppx::string_util::TrimBothEnds(args[i]);
+        if (!StartsWithDoubleDash(name)) {
+            PPX_LOG_ERROR("Invalid command-line option: \"" << name << "\"");
+            return ERROR_FAILED;
+        }
+        name = name.substr(2);
+
+        std::string_view value = "";
+        if (i + 1 < args.size()) {
+            auto nextElem = ppx::string_util::TrimBothEnds(args[i + 1]);
+            if (!StartsWithDoubleDash(nextElem)) {
+                // The next element is a parameter for the current option
+                value = nextElem;
+                ++i;
+            }
+        }
+        auto res = AddOption(commandlineOptions, name, value);
+        if (Failed(res)) {
+            return res;
+        }
+    }
+    options.OverwriteOptions(commandlineOptions);
+
+    return SUCCESS;
+}
+
+Result CommandLineParserNew::AddOption(OptionsNew& opts, std::string_view optionName, std::string_view valueStr)
+{
+    if (optionName.length() > 2 && optionName.substr(0, 3) == "no-") {
+        if (valueStr.length() > 0) {
+            PPX_LOG_ERROR("invalid prefix no- for option \"" << optionName << "\" and value \"" << valueStr << "\"");
+            return ERROR_FAILED;
+        }
+        optionName = optionName.substr(3);
+        valueStr   = "0";
+    }
+
+    opts.AddOption(optionName, valueStr);
+    return SUCCESS;
+}
+
+// -------------------------------------------------------------------------------------------------
+// JsonConverterNew
+// -------------------------------------------------------------------------------------------------
+
+Result JsonConverterNew::ParseOptionsFromFile(const std::string& jsonPath, OptionsNew& opts)
+{
+    std::ifstream f(jsonPath);
+    if (f.fail()) {
+        PPX_LOG_ERROR("Cannot locate JSON file : " << jsonPath);
+        return ERROR_FAILED;
+    }
+
+    PPX_LOG_INFO("Parsing JSON config file: " << jsonPath);
+    nlohmann::json data;
+    try {
+        data = nlohmann::json::parse(f);
+    }
+    catch (nlohmann::json::parse_error& e) {
+        PPX_LOG_ERROR("nlohmann::json::parse error: " << e.what() << '\n'
+                                                      << "exception id: " << e.id << '\n'
+                                                      << "byte position of error: " << e.byte);
+    }
+    if (!(data.is_object())) {
+        PPX_LOG_ERROR("The following config file could not be parsed as a JSON object: " << jsonPath);
+        return ERROR_FAILED;
+    }
+
+    ParseOptions(data, opts);
+
+    return SUCCESS;
+}
+
+Result JsonConverterNew::ExportOptionsToFile(const OptionsNew& options, const std::string& jsonPath)
+{
+    std::ofstream f(jsonPath);
+    if (f.fail()) {
+        PPX_LOG_ERROR("Cannot write to JSON file : " << jsonPath);
+        return ERROR_FAILED;
+    }
+
+    nlohmann::json data;
+    ExportOptions(options, data);
+    f << data.dump(0);
+    f.close();
+
+    return SUCCESS;
+}
+
+void JsonConverterNew::ParseOptions(const nlohmann::json& jsonConfig, OptionsNew& opts)
+{
+    std::stringstream ss;
+    for (auto it = jsonConfig.cbegin(); it != jsonConfig.cend(); ++it) {
+        if ((it.value()).is_array()) {
+            // Special case, arrays specified in JSON are added directly to opts to avoid inserting element by element
+            std::vector<std::string> jsonStringArray;
+            for (const auto& elem : it.value()) {
+                ss << elem;
+                jsonStringArray.push_back(std::string(ppx::string_util::TrimBothEnds(ss.str(), " \t\"")));
+                ss.str("");
+            }
+            opts.AddOption(it.key(), jsonStringArray);
+            continue;
+        }
+
+        ss << it.value();
+        std::string value = ss.str();
+        ss.str("");
+        opts.AddOption(it.key(), ppx::string_util::TrimBothEnds(value, " \t\""));
+    }
+}
+
+void JsonConverterNew::ExportOptions(const OptionsNew& options, nlohmann::json& jsonConfig)
+{
+    auto optMap = options.GetMap();
+    for (const auto& iter : optMap) {
+        jsonConfig[iter.first] = ppx::string_util::ToString(iter.second);
+    }
+}
+
+} // namespace ppx

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -54,6 +54,7 @@ list(
     knob_test.cpp
     log_console_test.cpp
     metrics_test.cpp
+    options_new_test.cpp
     ppm_export_test.cpp
     string_util_test.cpp
     transform_test.cpp

--- a/src/test/options_new_test.cpp
+++ b/src/test/options_new_test.cpp
@@ -291,7 +291,7 @@ TEST(JsonConverterTest, ParseOptions_Empty)
 TEST(JsonConverterTest, ParseOptions_Simple)
 {
     JsonConverterNew parser;
-    std::string      jsonText    = R"(
+    std::string      jsonText = R"(
   {
     "a": true,
     "b": false,
@@ -302,7 +302,8 @@ TEST(JsonConverterTest, ParseOptions_Simple)
     "g": "200x300"
   }
 )";
-    OptionsNew       wantOptions = OptionsNew(
+
+    OptionsNew wantOptions = OptionsNew(
         {{"a", std::vector<std::string>{"true"}},
          {"b", std::vector<std::string>{"false"}},
          {"c", std::vector<std::string>{"1.234"}},
@@ -319,7 +320,7 @@ TEST(JsonConverterTest, ParseOptions_Simple)
 TEST(JsonConverterTest, ParseOptions_NestedStructureFlattened)
 {
     JsonConverterNew parser;
-    std::string      jsonText    = R"(
+    std::string      jsonText = R"(
   {
     "a": true,
     "b": {
@@ -328,7 +329,8 @@ TEST(JsonConverterTest, ParseOptions_NestedStructureFlattened)
     }
   }
 )";
-    OptionsNew       wantOptions = OptionsNew(
+
+    OptionsNew wantOptions = OptionsNew(
         {{"a", std::vector<std::string>{"true"}},
          {"b", std::vector<std::string>{"{\"c\":1,\"d\":2}"}}});
     OptionsNew     gotOptions = {};
@@ -340,13 +342,14 @@ TEST(JsonConverterTest, ParseOptions_NestedStructureFlattened)
 TEST(JsonConverterTest, ParseOptions_IntArray)
 {
     JsonConverterNew parser;
-    std::string      jsonText    = R"(
+    std::string      jsonText = R"(
   {
     "a": true,
     "b": [1, 2, 3]
   }
 )";
-    OptionsNew       wantOptions = OptionsNew(
+
+    OptionsNew wantOptions = OptionsNew(
         {{"a", std::vector<std::string>{"true"}},
          {"b", std::vector<std::string>{"1", "2", "3"}}});
     OptionsNew     gotOptions = {};
@@ -358,13 +361,14 @@ TEST(JsonConverterTest, ParseOptions_IntArray)
 TEST(JsonConverterTest, ParseOptions_HeterogeneousArray)
 {
     JsonConverterNew parser;
-    std::string      jsonText    = R"(
+    std::string      jsonText = R"(
   {
     "a": true,
     "b": [1, "2", {"c" : 3}, 4.0]
   }
 )";
-    OptionsNew       wantOptions = OptionsNew(
+
+    OptionsNew wantOptions = OptionsNew(
         {{"a", std::vector<std::string>{"true"}},
          {"b", std::vector<std::string>{"1", "2", "{\"c\":3}", "4.0"}}});
     OptionsNew     gotOptions = {};

--- a/src/test/options_new_test.cpp
+++ b/src/test/options_new_test.cpp
@@ -1,0 +1,377 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "ppx/options_new.h"
+
+namespace ppx {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(OptionsNewTest, NoOptions)
+{
+    OptionsNew gotOptions;
+    EXPECT_FALSE(gotOptions.HasOption("test"));
+    EXPECT_EQ(gotOptions.GetNumUniqueOptions(), 0);
+}
+
+TEST(OptionsNewTest, AddOption_OneValue)
+{
+    OptionsNew wantOptions = OptionsNew({{"name1", std::vector<std::string>{"value1"}}});
+    OptionsNew gotOptions;
+    gotOptions.AddOption("name1", "value1");
+    EXPECT_EQ(gotOptions, wantOptions);
+
+    EXPECT_TRUE(gotOptions.HasOption("name1"));
+    EXPECT_EQ(gotOptions.GetNumUniqueOptions(), 1);
+    std::vector<std::string> gotValue = gotOptions.GetValueStrings("name1");
+    EXPECT_EQ(gotValue.at(0), "value1");
+}
+
+TEST(OptionsNewTest, AddOption_MultipleValues)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"value1", "value2"}}});
+    OptionsNew gotOptions;
+    gotOptions.AddOption("name1", "value1");
+    gotOptions.AddOption("name1", "value2");
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(OptionsNewTest, AddOption_MultipleValuesList)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"value1", "value2"}}});
+    OptionsNew gotOptions;
+    gotOptions.AddOption("name1", std::vector<std::string>{"value1", "value2"});
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(OptionsNewTest, AddOption_MultipleOptions)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"value1"}},
+         {"name2", std::vector<std::string>{"value3"}}});
+    OptionsNew gotOptions;
+    gotOptions.AddOption("name1", "value1");
+    gotOptions.AddOption("name2", "value3");
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(OptionsNewTest, OverwriteOptions_EmptyOverwrite)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"value1", "value2"}},
+         {"name2", std::vector<std::string>{"value3", "value4"}}});
+    OptionsNew gotOptions;
+    OptionsNew overwriteOptions;
+    gotOptions.AddOption("name1", std::vector<std::string>{"value1", "value2"});
+    gotOptions.AddOption("name2", std::vector<std::string>{"value3", "value4"});
+    gotOptions.OverwriteOptions(overwriteOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(OptionsNewTest, OverwriteOptions_EmptyBase)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"value1", "value2"}},
+         {"name2", std::vector<std::string>{"value3", "value4"}}});
+    OptionsNew gotOptions;
+    OptionsNew overwriteOptions;
+    overwriteOptions.AddOption("name1", std::vector<std::string>{"value1", "value2"});
+    overwriteOptions.AddOption("name2", std::vector<std::string>{"value3", "value4"});
+    gotOptions.OverwriteOptions(overwriteOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(OptionsNewTest, OverwriteOptions_Complex)
+{
+    OptionsNew wantOptions = OptionsNew(
+        {{"name1", std::vector<std::string>{"newvalue1"}},
+         {"name2", std::vector<std::string>{"oldvalue3", "oldvalue4"}},
+         {"name3", std::vector<std::string>{"newvalue5", "newvalue6"}}});
+    OptionsNew gotOptions;
+    gotOptions.AddOption("name1", std::vector<std::string>{"oldvalue1", "oldvalue2"});
+    gotOptions.AddOption("name2", std::vector<std::string>{"oldvalue3", "oldvalue4"});
+    OptionsNew overwriteOptions;
+    overwriteOptions.AddOption("name1", std::vector<std::string>{"newvalue1"});
+    overwriteOptions.AddOption("name3", std::vector<std::string>{"newvalue5", "newvalue6"});
+    gotOptions.OverwriteOptions(overwriteOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(CommandLineParserNewTest, Parse_ZeroArguments)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    EXPECT_TRUE(Success(parser.ParseOptions(0, nullptr, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 0);
+}
+
+TEST(CommandLineParserNewTest, Parse_FirstArgumentIgnored)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 0);
+}
+
+TEST(CommandLineParserNewTest, Parse_Booleans)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--b", "1", "--c", "true", "--no-d", "--e", "0", "--f", "false"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 6);
+    auto optsMap = opts.GetMap();
+    EXPECT_EQ(optsMap.at("a"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("b"), std::vector<std::string>{"1"});
+    EXPECT_EQ(optsMap.at("c"), std::vector<std::string>{"true"});
+    EXPECT_EQ(optsMap.at("d"), std::vector<std::string>{"0"}); // no- prefix is interpreted as such
+    EXPECT_EQ(optsMap.at("e"), std::vector<std::string>{"0"});
+    EXPECT_EQ(optsMap.at("f"), std::vector<std::string>{"false"});
+}
+
+TEST(CommandLineParserNewTest, Parse_Values)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] =
+        {"/path/to/executable",
+         "--a",
+         "filename with spaces",
+         "--b",
+         "filenameWithoutSpaces",
+         "--c",
+         "filename,with/.punctuation,",
+         "--d",
+         "",
+         "--e",
+         "--f",
+         "-5",
+         "--g",
+         "10.4",
+         "--h",
+         "-300.0"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 8);
+    auto optsMap = opts.GetMap();
+    EXPECT_EQ(optsMap.at("a"), std::vector<std::string>{"filename with spaces"});
+    EXPECT_EQ(optsMap.at("b"), std::vector<std::string>{"filenameWithoutSpaces"});
+    EXPECT_EQ(optsMap.at("c"), std::vector<std::string>{"filename,with/.punctuation,"});
+    EXPECT_EQ(optsMap.at("d"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("e"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("f"), std::vector<std::string>{"-5"});
+    EXPECT_EQ(optsMap.at("g"), std::vector<std::string>{"10.4"});
+    EXPECT_EQ(optsMap.at("h"), std::vector<std::string>{"-300.0"});
+}
+
+TEST(CommandLineParserNewTest, Parse_StringList)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "some-path", "--a", "some-other-path", "--a", "last-path"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 1);
+    auto gotValues = opts.GetValueStrings("a");
+    EXPECT_EQ(gotValues.size(), 3);
+    if (gotValues.size() == 3) {
+        EXPECT_EQ(gotValues[0], "some-path");
+        EXPECT_EQ(gotValues[1], "some-other-path");
+        EXPECT_EQ(gotValues[2], "last-path");
+    }
+}
+
+TEST(CommandLineParserNewTest, Parse_EqualSigns)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--b=5", "--c", "--d", "11"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 4);
+    auto optsMap = opts.GetMap();
+    EXPECT_EQ(optsMap.at("a"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("b"), std::vector<std::string>{"5"});
+    EXPECT_EQ(optsMap.at("c"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("d"), std::vector<std::string>{"11"});
+}
+
+TEST(CommandLineParserNewTest, Parse_EqualSignsMultipleFail)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--b=5=8", "--c", "--d", "11"};
+    EXPECT_TRUE(Failed(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+}
+
+TEST(CommandLineParserNewTest, Parse_EqualSignsNoNameFail)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--=5", "--c", "--d", "11"};
+    EXPECT_TRUE(Failed(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+}
+
+TEST(CommandLineParserNewTest, Parse_EqualSignsNoFlagFail)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "=5", "--c", "--d", "11"};
+    EXPECT_TRUE(Failed(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+}
+
+TEST(CommandLineParserNewTest, Parse_EqualSignsEmptyValuePass)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--b=", "--c", "--d", "11"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 4);
+    auto optsMap = opts.GetMap();
+    EXPECT_EQ(optsMap.at("a"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("b"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("c"), std::vector<std::string>{""});
+    EXPECT_EQ(optsMap.at("d"), std::vector<std::string>{"11"});
+}
+
+TEST(CommandLineParserNewTest, Parse_LeadingParameterFail)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "10", "--a", "--b", "5", "--c", "--d", "11"};
+    EXPECT_TRUE(Failed(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+}
+
+TEST(CommandLineParserNewTest, Parse_AdjacentParameterFail)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "--b", "5", "8", "--c", "--d", "11"};
+    EXPECT_TRUE(Failed(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+}
+
+TEST(CommandLineParserNewTest, Parse_MultipleUsageFlag)
+{
+    CommandLineParserNew parser;
+    OptionsNew           opts;
+    const char*          args[] = {"/path/to/executable", "--a", "1", "--b", "1", "--a", "2", "--a", "3"};
+    EXPECT_TRUE(Success(parser.ParseOptions(sizeof(args) / sizeof(args[0]), args, opts)));
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 2);
+    auto optsMap = opts.GetMap();
+    EXPECT_EQ(optsMap.at("a").at(0), "1");
+    EXPECT_EQ(optsMap.at("a").at(1), "2");
+    EXPECT_EQ(optsMap.at("a").at(2), "3");
+    EXPECT_EQ(optsMap.at("b"), std::vector<std::string>{"1"});
+}
+
+TEST(JsonConverterTest, ParseOptions_Empty)
+{
+    JsonConverterNew parser;
+    OptionsNew       opts;
+    nlohmann::json   jsonConfig;
+    parser.ParseOptions(jsonConfig, opts);
+    EXPECT_EQ(opts.GetNumUniqueOptions(), 0);
+}
+
+TEST(JsonConverterTest, ParseOptions_Simple)
+{
+    JsonConverterNew parser;
+    std::string      jsonText    = R"(
+  {
+    "a": true,
+    "b": false,
+    "c": 1.234,
+    "d": 5,
+    "e": "helloworld",
+    "f": "hello world",
+    "g": "200x300"
+  }
+)";
+    OptionsNew       wantOptions = OptionsNew(
+        {{"a", std::vector<std::string>{"true"}},
+         {"b", std::vector<std::string>{"false"}},
+         {"c", std::vector<std::string>{"1.234"}},
+         {"d", std::vector<std::string>{"5"}},
+         {"e", std::vector<std::string>{"helloworld"}},
+         {"f", std::vector<std::string>{"hello world"}},
+         {"g", std::vector<std::string>{"200x300"}}});
+    OptionsNew     gotOptions = {};
+    nlohmann::json jsonConfig = nlohmann::json::parse(jsonText);
+    parser.ParseOptions(jsonConfig, gotOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(JsonConverterTest, ParseOptions_NestedStructureFlattened)
+{
+    JsonConverterNew parser;
+    std::string      jsonText    = R"(
+  {
+    "a": true,
+    "b": {
+        "c" : 1,
+        "d" : 2
+    }
+  }
+)";
+    OptionsNew       wantOptions = OptionsNew(
+        {{"a", std::vector<std::string>{"true"}},
+         {"b", std::vector<std::string>{"{\"c\":1,\"d\":2}"}}});
+    OptionsNew     gotOptions = {};
+    nlohmann::json jsonConfig = nlohmann::json::parse(jsonText);
+    parser.ParseOptions(jsonConfig, gotOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(JsonConverterTest, ParseOptions_IntArray)
+{
+    JsonConverterNew parser;
+    std::string      jsonText    = R"(
+  {
+    "a": true,
+    "b": [1, 2, 3]
+  }
+)";
+    OptionsNew       wantOptions = OptionsNew(
+        {{"a", std::vector<std::string>{"true"}},
+         {"b", std::vector<std::string>{"1", "2", "3"}}});
+    OptionsNew     gotOptions = {};
+    nlohmann::json jsonConfig = nlohmann::json::parse(jsonText);
+    parser.ParseOptions(jsonConfig, gotOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+TEST(JsonConverterTest, ParseOptions_HeterogeneousArray)
+{
+    JsonConverterNew parser;
+    std::string      jsonText    = R"(
+  {
+    "a": true,
+    "b": [1, "2", {"c" : 3}, 4.0]
+  }
+)";
+    OptionsNew       wantOptions = OptionsNew(
+        {{"a", std::vector<std::string>{"true"}},
+         {"b", std::vector<std::string>{"1", "2", "{\"c\":3}", "4.0"}}});
+    OptionsNew     gotOptions = {};
+    nlohmann::json jsonConfig = nlohmann::json::parse(jsonText);
+    parser.ParseOptions(jsonConfig, gotOptions);
+    EXPECT_EQ(gotOptions, wantOptions);
+}
+
+} // namespace
+} // namespace ppx


### PR DESCRIPTION
Intermediate format `OptionsNew` is intended to help interface between command line arguments, JSON config files, and (in the future) knobs.