### PR TITLE
Update software_rendering.md

### DIFF
--- a/docs/software_rendering.md
+++ b/docs/software_rendering.md
@@ -13,7 +13,7 @@ bin/bigwheels_application.exe --use-software-renderer
 
 **Note that while WARP already comes with Windows, we use DX12 features that require the latest version of WARP, which is distributed indipendently.
 You can download the latest pre-built WARP DLL [here](https://nuget.info/packages/Microsoft.Direct3D.WARP) (simply double-click `d3d10warp.dll` under `build/native/amd64` to download).
-Place this DLL in the same folder of your executables before running.**
+Place this DLL in the same folder of your executables before running. WARNING: You have to tick "unlock" on the DLL's properties.**
 
 ## SwiftShader (Vulkan)
 BigWheels can use SwiftShader's Vulkan ICD in place of a GPU's ICD using the `VK_ICD_FILENAMES` environment variable, which will instruct the Vulkan loader to load a specific ICD.


### PR DESCRIPTION
Add a note to say the DLL shall be "unlocked".
By default Windows marks some files from remote locations as "locked". In the DLL case, this will prevent the DLL from being loaded, the the samples will fail to initialize.