### PR TITLE
Fixes for Vulkan Validation errors

### DIFF
--- a/include/ppx/grfx/vk/vk_device.h
+++ b/include/ppx/grfx/vk/vk_device.h
@@ -36,7 +36,7 @@ public:
 
     bool HasTimelineSemaphore() const { return mHasTimelineSemaphore; }
     bool HasExtendedDynamicState() const { return mHasExtendedDynamicState; }
-    bool HasUnreistrictedDepthRange() const { return mHasUnrestrictedDepthRange; }
+    bool HasDepthClipEnabled() const { return mHasDepthClipEnabled; }
 
     virtual Result WaitIdle() override;
 
@@ -114,7 +114,7 @@ private:
     VmaAllocatorPtr                                mVmaAllocator;
     bool                                           mHasTimelineSemaphore                       = false;
     bool                                           mHasExtendedDynamicState                    = false;
-    bool                                           mHasUnrestrictedDepthRange                  = false;
+    bool                                           mHasDepthClipEnabled                        = false;
     bool                                           mHasDynamicRendering                        = false;
     PFN_vkResetQueryPoolEXT                        mFnResetQueryPoolEXT                        = nullptr;
     PFN_vkWaitSemaphores                           mFnWaitSemaphores                           = nullptr;

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -196,8 +196,8 @@ Result Device::ConfigureExtensions(const grfx::DeviceCreateInfo* pCreateInfo)
 #endif // defined(PPX_VK_EXTENDED_DYNAMIC_STATE)
 
     // Depth clip
-    if (ElementExists(std::string(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME), mFoundExtensions)) {
-        mExtensions.push_back(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
+    if (ElementExists(std::string(VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME), mFoundExtensions)) {
+        mExtensions.push_back(VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME);
     }
 
     // Push descriptors
@@ -663,7 +663,7 @@ Result Device::CreateApiObjects(const grfx::DeviceCreateInfo* pCreateInfo)
 #endif // defined(PPX_VK_EXTENDED_DYNAMIC_STATE)
 
     // Depth clip enabled
-    mHasUnrestrictedDepthRange = ElementExists(std::string(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME), mExtensions);
+    mHasDepthClipEnabled = ElementExists(std::string(VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME), mExtensions);
 
     // Get maxPushDescriptors property and load function
     if (ElementExists(std::string(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME), mExtensions)) {

--- a/src/ppx/grfx/vk/vk_instance.cpp
+++ b/src/ppx/grfx/vk/vk_instance.cpp
@@ -34,7 +34,7 @@ static VkBool32 VKAPI_PTR DebugUtilsMessengerCallback(
     // Ignore these messages because they're nonsense
     // clang-format off
     if (
-        (pCallbackData->messageIdNumber == 0x3d492883) // vkCreateShaderModule(): The SPIR-V Extension (SPV_GOOGLE_hlsl_functionality1) was declared, but none of the requirements were met to use it. The Vulkan spec states: If pCode declares any of the SPIR-V extensions listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied
+        (std::string(pCallbackData->pMessageIdName) == "VUID-VkShaderModuleCreateInfo-pCode-08742") // vkCreateShaderModule(): The SPIR-V Extension (SPV_GOOGLE_hlsl_functionality1) was declared, but none of the requirements were met to use it. The Vulkan spec states: If pCode declares any of the SPIR-V extensions listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied
     ) {
         return VK_FALSE;
     }

--- a/src/ppx/grfx/vk/vk_pipeline.cpp
+++ b/src/ppx/grfx/vk/vk_pipeline.cpp
@@ -236,7 +236,7 @@ Result GraphicsPipeline::InitializeRasterization(
     stateCreateInfo.lineWidth               = 1.0f;
 
     // Handle depth clip enable
-    if (ToApi(GetDevice())->HasUnreistrictedDepthRange()) {
+    if (ToApi(GetDevice())->HasDepthClipEnabled()) {
         depthClipStateCreateInfo.flags           = 0;
         depthClipStateCreateInfo.depthClipEnable = pCreateInfo->rasterState.depthClipEnable;
         // Set pNext


### PR DESCRIPTION
* VUID-VkShaderModuleCreateInfo-pCode-08742 : Needs to be checked by messageIdName and not messageIdNumber
* VUID-VkPipelineRasterizationStateCreateInfo-pNext-pNext : Need extension VK_EXT_depth_clip_enable rather than VK_EXT_depth_range_unrestricted