### PR TITLE
Wait for render complete before image acquisition

### DIFF
--- a/benchmarks/compute_operations/main.cpp
+++ b/benchmarks/compute_operations/main.cpp
@@ -395,14 +395,14 @@ void ProjApp::Render()
     int w = swapchain->GetWidth();
     int h = swapchain->GetHeight();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Read query results
     if (GetFrameCount() > 0) {

--- a/benchmarks/draw_call/main.cpp
+++ b/benchmarks/draw_call/main.cpp
@@ -226,14 +226,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Read query results
     if (GetFrameCount() > 0) {

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -1082,6 +1082,9 @@ void GraphicsBenchmarkApp::Render()
     uint32_t           imageIndex = UINT32_MAX;
     grfx::SwapchainPtr swapchain  = GetSwapchain(currentViewIndex);
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
 #if defined(PPX_BUILD_XR)
     if (IsXrEnabled()) {
         PPX_ASSERT_MSG(swapchain->ShouldSkipExternalSynchronization(), "XRComponent should not be nullptr when XR is enabled!");
@@ -1099,9 +1102,6 @@ void GraphicsBenchmarkApp::Render()
         // Wait for and reset image acquired fence.
         PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
     }
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Read query results
     if (GetFrameCount() > 0) {

--- a/benchmarks/overdraw/main.cpp
+++ b/benchmarks/overdraw/main.cpp
@@ -355,14 +355,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Read query results
     if (GetFrameCount() > 0) {

--- a/benchmarks/primitive_assembly/main.cpp
+++ b/benchmarks/primitive_assembly/main.cpp
@@ -266,14 +266,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Read query results
     if (GetFrameCount() > 0) {

--- a/benchmarks/render_target/main.cpp
+++ b/benchmarks/render_target/main.cpp
@@ -354,14 +354,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Read query results
     if (GetFrameCount() > 0) {

--- a/benchmarks/texture_load/main.cpp
+++ b/benchmarks/texture_load/main.cpp
@@ -283,14 +283,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Read query results
     if (GetFrameCount() > 0) {

--- a/benchmarks/texture_sample/main.cpp
+++ b/benchmarks/texture_sample/main.cpp
@@ -356,14 +356,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Read query results
     if (GetFrameCount() > 0) {

--- a/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
+++ b/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
@@ -304,14 +304,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Change texture every second
     float    seconds        = GetElapsedSeconds();

--- a/projects/arcball_camera/main.cpp
+++ b/projects/arcball_camera/main.cpp
@@ -250,14 +250,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/async_compute/main.cpp
+++ b/projects/async_compute/main.cpp
@@ -750,14 +750,14 @@ void ProjApp::Render()
 
 uint32_t ProjApp::AcquireFrame(PerFrame& frame)
 {
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(GetSwapchain()->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     return imageIndex;
 }

--- a/projects/basic_material/main.cpp
+++ b/projects/basic_material/main.cpp
@@ -1105,14 +1105,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // ---------------------------------------------------------------------------------------------
 

--- a/projects/camera_fit_scene/main.cpp
+++ b/projects/camera_fit_scene/main.cpp
@@ -260,14 +260,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/camera_motion/main.cpp
+++ b/projects/camera_motion/main.cpp
@@ -694,14 +694,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffers
     {

--- a/projects/dynamic_rendering/DynamicRendering.cpp
+++ b/projects/dynamic_rendering/DynamicRendering.cpp
@@ -162,14 +162,14 @@ void DynamicRenderingApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     PPX_CHECKED_CALL(frame.cmd->Begin());
     {

--- a/projects/fishtornado/FishTornado.cpp
+++ b/projects/fishtornado/FishTornado.cpp
@@ -942,14 +942,14 @@ void FishTornadoApp::Render()
         mOcean.Update(frameIndex);
     }
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.frameCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.frameCompleteFence->WaitAndReset());
 
     // Read query results
     if (GetFrameCount() > 0) {

--- a/projects/gbuffer/main.cpp
+++ b/projects/gbuffer/main.cpp
@@ -718,14 +718,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update constants
     UpdateConstants();

--- a/projects/gltf/main.cpp
+++ b/projects/gltf/main.cpp
@@ -712,14 +712,14 @@ void ProjApp::Setup()
 
 void ProjApp::Render()
 {
-    PerFrame&          frame      = mPerFrame[0];
-    grfx::SwapchainPtr swapchain  = GetSwapchain();
-    uint32_t           imageIndex = UINT32_MAX;
+    PerFrame&          frame     = mPerFrame[0];
+    grfx::SwapchainPtr swapchain = GetSwapchain();
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+    uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update camera(s)
     mCamera.LookAt(float3(2, 2, 2), float3(0, 0, 0));

--- a/projects/image_filter/main.cpp
+++ b/projects/image_filter/main.cpp
@@ -416,14 +416,14 @@ void ProjApp::Render()
     int w = swapchain->GetWidth();
     int h = swapchain->GetHeight();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Read query results
     if (GetFrameCount() > 0) {

--- a/projects/input/main.cpp
+++ b/projects/input/main.cpp
@@ -136,14 +136,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Build command buffer
     PPX_CHECKED_CALL(frame.cmd->Begin());

--- a/projects/mipmap_demo/main.cpp
+++ b/projects/mipmap_demo/main.cpp
@@ -255,14 +255,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     float4x4 P = glm::perspective(glm::radians(60.0f), GetWindowAspect(), 1.0f, 4.0f);

--- a/projects/oit_demo/OITDemoApplication.cpp
+++ b/projects/oit_demo/OITDemoApplication.cpp
@@ -601,10 +601,10 @@ void OITDemoApp::RecordComposite(grfx::RenderPassPtr renderPass)
 
 void OITDemoApp::Render()
 {
+    PPX_CHECKED_CALL(mRenderCompleteFence->WaitAndReset());
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(GetSwapchain()->AcquireNextImage(UINT64_MAX, mImageAcquiredSemaphore, mImageAcquiredFence, &imageIndex));
     PPX_CHECKED_CALL(mImageAcquiredFence->WaitAndReset());
-    PPX_CHECKED_CALL(mRenderCompleteFence->WaitAndReset());
 
     // Update state
     Update();

--- a/projects/primitives/main.cpp
+++ b/projects/primitives/main.cpp
@@ -227,14 +227,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/push_constants/PushConstants.cpp
+++ b/projects/push_constants/PushConstants.cpp
@@ -258,14 +258,14 @@ void PushConstantsApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Build command buffer
     PPX_CHECKED_CALL(frame.cmd->Begin());

--- a/projects/push_descriptors/PushDescriptors.cpp
+++ b/projects/push_descriptors/PushDescriptors.cpp
@@ -227,14 +227,14 @@ void PushDescriptorsApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Build command buffer
     PPX_CHECKED_CALL(frame.cmd->Begin());

--- a/projects/push_descriptors_buffers/PushDescriptorsBuffers.cpp
+++ b/projects/push_descriptors_buffers/PushDescriptorsBuffers.cpp
@@ -284,14 +284,14 @@ void PushDescriptorsBuffersApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Build command buffer
     PPX_CHECKED_CALL(frame.cmd->Begin());

--- a/projects/sample_01_triangle/Triangle.cpp
+++ b/projects/sample_01_triangle/Triangle.cpp
@@ -122,14 +122,14 @@ void TriangleApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Build command buffer
     PPX_CHECKED_CALL(frame.cmd->Begin());

--- a/projects/sample_02_triangle_spinning/TriangleSpinning.cpp
+++ b/projects/sample_02_triangle_spinning/TriangleSpinning.cpp
@@ -154,14 +154,14 @@ void TriangleSpinningApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/sample_03_square_textured/SquareTextured.cpp
+++ b/projects/sample_03_square_textured/SquareTextured.cpp
@@ -187,14 +187,14 @@ void SquareTexturedApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/sample_04_cube/Cube.cpp
+++ b/projects/sample_04_cube/Cube.cpp
@@ -218,14 +218,14 @@ void CubeApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/sample_05_cube_textured/main.cpp
+++ b/projects/sample_05_cube_textured/main.cpp
@@ -262,14 +262,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/sample_06_compute_fill/main.cpp
+++ b/projects/sample_06_compute_fill/main.cpp
@@ -268,14 +268,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/sample_07_draw_indexed/main.cpp
+++ b/projects/sample_07_draw_indexed/main.cpp
@@ -251,14 +251,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/sample_08_basic_geometry/main.cpp
+++ b/projects/sample_08_basic_geometry/main.cpp
@@ -225,14 +225,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/sample_09_obj_geometry/main.cpp
+++ b/projects/sample_09_obj_geometry/main.cpp
@@ -190,14 +190,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffer
     {

--- a/projects/sample_10_cube_map/main.cpp
+++ b/projects/sample_10_cube_map/main.cpp
@@ -288,14 +288,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
 #if defined(ENABLE_GPU_QUERIES)
     // Read query results

--- a/projects/sample_11_compressed_texture/main.cpp
+++ b/projects/sample_11_compressed_texture/main.cpp
@@ -293,14 +293,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update uniform buffers.
     for (auto& shape : mShapes) {

--- a/projects/sample_12_shadows/main.cpp
+++ b/projects/sample_12_shadows/main.cpp
@@ -437,14 +437,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update light position
     float t        = GetElapsedSeconds() / 2.0f;

--- a/projects/sample_13_normal_map/main.cpp
+++ b/projects/sample_13_normal_map/main.cpp
@@ -351,14 +351,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Update light position
     float t        = GetElapsedSeconds() / 2.0f;

--- a/projects/text_draw/main.cpp
+++ b/projects/text_draw/main.cpp
@@ -136,14 +136,14 @@ void ProjApp::Render()
 
     grfx::SwapchainPtr swapchain = GetSwapchain();
 
+    // Wait for and reset render complete fence
+    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
+
     uint32_t imageIndex = UINT32_MAX;
     PPX_CHECKED_CALL(swapchain->AcquireNextImage(UINT64_MAX, frame.imageAcquiredSemaphore, frame.imageAcquiredFence, &imageIndex));
 
     // Wait for and reset image acquired fence
     PPX_CHECKED_CALL(frame.imageAcquiredFence->WaitAndReset());
-
-    // Wait for and reset render complete fence
-    PPX_CHECKED_CALL(frame.renderCompleteFence->WaitAndReset());
 
     // Build command buffer
     PPX_CHECKED_CALL(frame.cmd->Begin());


### PR DESCRIPTION
Recent Vulkan validation layers flag that imageAcquiredSemaphore may still be signaled during AcquireNextImage:

```
** VULKAN VALIDATION ERROR MESSAGE ***
Severity : ERROR
Type     : [VALIDATION]
Objects  : [0]: <UNNAMED OBJECT>
Message  : Validation Error: [ VUID-vkAcquireNextImageKHR-semaphore-01779 ] Object 0: handle = 0x27a9e40000000112, type = VK_OBJECT_TYPE_SEMAPHORE; | MessageID = 0x5717e75b | vkAcquireNextImageKHR():  Semaphore must not have any pending operations. The Vulkan spec states: If semaphore is not VK_NULL_HANDLE it must not have any uncompleted signal or wait operations pending (https://vulkan.lunarg.com/doc/view/1.3.275.0/windows/1.3-extensions/vkspec.html#VUID-vkAcquireNextImageKHR-semaphore-01779)
```

Apart from Application frame rate pacing, there is no explicit synchronization between Present for the previous frame and AcquireNextImage for the next frame. As such, applications with no frame pacing or those that cannot hit the target FPS may not have finished rendering the previous frame when it goes to render the next frame.

The fix is to wait for renderCompleteFence before AcquireNextImage. This guarantees that imageAcquiredSemaphore is unsignaled.