### PR TITLE
Add support for partial bindings (vk only)

### DIFF
--- a/include/ppx/grfx/dx12/dx12_device.h
+++ b/include/ppx/grfx/dx12/dx12_device.h
@@ -65,6 +65,7 @@ public:
     virtual bool DynamicRenderingSupported() const override;
     virtual bool IndependentBlendingSupported() const override;
     virtual bool FragmentStoresAndAtomicsSupported() const override;
+    virtual bool PartialDescriptorBindingsSupported() const override;
 
 protected:
     virtual Result AllocateObject(grfx::Buffer** ppObject) override;

--- a/include/ppx/grfx/grfx_descriptor.h
+++ b/include/ppx/grfx/grfx_descriptor.h
@@ -31,22 +31,25 @@ namespace grfx {
 //!
 struct DescriptorBinding
 {
-    uint32_t              binding         = PPX_VALUE_IGNORED;               //
-    grfx::DescriptorType  type            = grfx::DESCRIPTOR_TYPE_UNDEFINED; //
-    uint32_t              arrayCount      = 1;                               // WARNING: Not VkDescriptorSetLayoutBinding::descriptorCount
-    grfx::ShaderStageBits shaderVisiblity = grfx::SHADER_STAGE_ALL;          // Single value not set of flags (see note above)
+    uint32_t               binding         = PPX_VALUE_IGNORED;               //
+    grfx::DescriptorType   type            = grfx::DESCRIPTOR_TYPE_UNDEFINED; //
+    uint32_t               arrayCount      = 1;                               // WARNING: Not VkDescriptorSetLayoutBinding::descriptorCount
+    grfx::ShaderStageBits  shaderVisiblity = grfx::SHADER_STAGE_ALL;          // Single value not set of flags (see note above)
+    DescriptorBindingFlags flags;
 
     DescriptorBinding() {}
 
     DescriptorBinding(
-        uint32_t              binding_,
-        grfx::DescriptorType  type_,
-        uint32_t              arrayCount_      = 1,
-        grfx::ShaderStageBits shaderVisiblity_ = grfx::SHADER_STAGE_ALL)
+        uint32_t               binding_,
+        grfx::DescriptorType   type_,
+        uint32_t               arrayCount_      = 1,
+        grfx::ShaderStageBits  shaderVisiblity_ = grfx::SHADER_STAGE_ALL,
+        DescriptorBindingFlags flags_           = 0)
         : binding(binding_),
           type(type_),
           arrayCount(arrayCount_),
-          shaderVisiblity(shaderVisiblity_) {}
+          shaderVisiblity(shaderVisiblity_),
+          flags(flags_) {}
 };
 
 struct WriteDescriptor

--- a/include/ppx/grfx/grfx_device.h
+++ b/include/ppx/grfx/grfx_device.h
@@ -187,10 +187,11 @@ public:
 
     virtual Result WaitIdle() = 0;
 
-    virtual bool PipelineStatsAvailable() const            = 0;
-    virtual bool DynamicRenderingSupported() const         = 0;
-    virtual bool IndependentBlendingSupported() const      = 0;
-    virtual bool FragmentStoresAndAtomicsSupported() const = 0;
+    virtual bool PipelineStatsAvailable() const             = 0;
+    virtual bool DynamicRenderingSupported() const          = 0;
+    virtual bool IndependentBlendingSupported() const       = 0;
+    virtual bool FragmentStoresAndAtomicsSupported() const  = 0;
+    virtual bool PartialDescriptorBindingsSupported() const = 0;
 
 protected:
     virtual Result Create(const grfx::DeviceCreateInfo* pCreateInfo) override;

--- a/include/ppx/grfx/grfx_helper.h
+++ b/include/ppx/grfx/grfx_helper.h
@@ -115,7 +115,7 @@ struct DescriptorBindingFlags
     {
         struct
         {
-            bool updatable : 1;
+            bool updatable      : 1;
             bool partiallyBound : 1;
         } bits;
         uint32_t flags;

--- a/include/ppx/grfx/grfx_helper.h
+++ b/include/ppx/grfx/grfx_helper.h
@@ -109,6 +109,38 @@ struct ColorComponentFlags
 
 // -------------------------------------------------------------------------------------------------
 
+struct DescriptorBindingFlags
+{
+    union
+    {
+        struct
+        {
+            bool updatable : 1;
+            bool partiallyBound : 1;
+        } bits;
+        uint32_t flags;
+    };
+
+    DescriptorBindingFlags()
+        : flags(0) {}
+
+    DescriptorBindingFlags(uint32_t flags_)
+        : flags(flags_) {}
+
+    DescriptorBindingFlags& operator=(uint32_t rhs)
+    {
+        this->flags = rhs;
+        return *this;
+    }
+
+    operator uint32_t() const
+    {
+        return flags;
+    }
+};
+
+// -------------------------------------------------------------------------------------------------
+
 struct DescriptorSetLayoutFlags
 {
     union

--- a/include/ppx/grfx/vk/vk_descriptor.h
+++ b/include/ppx/grfx/vk/vk_descriptor.h
@@ -87,6 +87,8 @@ protected:
     virtual void   DestroyApiObjects() override;
 
 private:
+    Result ValidateDescriptorBindingFlags(const grfx::DescriptorBindingFlags& flags) const;
+
     VkDescriptorSetLayoutPtr mDescriptorSetLayout;
 };
 

--- a/include/ppx/grfx/vk/vk_device.h
+++ b/include/ppx/grfx/vk/vk_device.h
@@ -112,7 +112,7 @@ private:
     std::vector<std::string>                       mFoundExtensions;
     std::vector<std::string>                       mExtensions;
     VkDevicePtr                                    mDevice;
-    VkPhysicalDeviceFeatures                       mDeviceFeatures = {};
+    VkPhysicalDeviceFeatures                       mDeviceFeatures             = {};
     VkPhysicalDeviceDescriptorIndexingFeatures     mDescriptorIndexingFeatures = {};
     VmaAllocatorPtr                                mVmaAllocator;
     bool                                           mHasTimelineSemaphore                       = false;

--- a/include/ppx/grfx/vk/vk_device.h
+++ b/include/ppx/grfx/vk/vk_device.h
@@ -44,6 +44,7 @@ public:
     virtual bool DynamicRenderingSupported() const override;
     virtual bool IndependentBlendingSupported() const override;
     virtual bool FragmentStoresAndAtomicsSupported() const override;
+    virtual bool PartialDescriptorBindingsSupported() const override;
 
     void ResetQueryPoolEXT(
         VkQueryPool queryPool,
@@ -95,6 +96,7 @@ private:
     Result ConfigureQueueInfo(const grfx::DeviceCreateInfo* pCreateInfo, std::vector<float>& queuePriorities, std::vector<VkDeviceQueueCreateInfo>& queueCreateInfos);
     Result ConfigureExtensions(const grfx::DeviceCreateInfo* pCreateInfo);
     Result ConfigureFeatures(const grfx::DeviceCreateInfo* pCreateInfo, VkPhysicalDeviceFeatures& features);
+    Result ConfigureDescriptorIndexingFeatures(const grfx::DeviceCreateInfo* pCreateInfo, VkPhysicalDeviceDescriptorIndexingFeatures& diFeatures);
     void   ConfigureShadingRateCapabilities(
           const grfx::DeviceCreateInfo*  pCreateInfo,
           grfx::ShadingRateCapabilities* pShadingRateCapabilities);
@@ -111,6 +113,7 @@ private:
     std::vector<std::string>                       mExtensions;
     VkDevicePtr                                    mDevice;
     VkPhysicalDeviceFeatures                       mDeviceFeatures = {};
+    VkPhysicalDeviceDescriptorIndexingFeatures     mDescriptorIndexingFeatures = {};
     VmaAllocatorPtr                                mVmaAllocator;
     bool                                           mHasTimelineSemaphore                       = false;
     bool                                           mHasExtendedDynamicState                    = false;

--- a/include/ppx/grfx/vk/vk_device.h
+++ b/include/ppx/grfx/vk/vk_device.h
@@ -34,6 +34,7 @@ public:
 
     const VkPhysicalDeviceFeatures& GetDeviceFeatures() const { return mDeviceFeatures; }
 
+    bool HasDescriptorIndexingFeatures() const { return mHasDescriptorIndexingFeatures; }
     bool HasTimelineSemaphore() const { return mHasTimelineSemaphore; }
     bool HasExtendedDynamicState() const { return mHasExtendedDynamicState; }
     bool HasDepthClipEnabled() const { return mHasDepthClipEnabled; }
@@ -115,6 +116,7 @@ private:
     VkPhysicalDeviceFeatures                       mDeviceFeatures             = {};
     VkPhysicalDeviceDescriptorIndexingFeatures     mDescriptorIndexingFeatures = {};
     VmaAllocatorPtr                                mVmaAllocator;
+    bool                                           mHasDescriptorIndexingFeatures              = false;
     bool                                           mHasTimelineSemaphore                       = false;
     bool                                           mHasExtendedDynamicState                    = false;
     bool                                           mHasDepthClipEnabled                        = false;

--- a/include/ppx/grfx/vk/vk_util.h
+++ b/include/ppx/grfx/vk/vk_util.h
@@ -39,6 +39,7 @@ VkCompareOp                ToVkCompareOp(grfx::CompareOp value);
 VkComponentSwizzle         ToVkComponentSwizzle(grfx::ComponentSwizzle value);
 VkComponentMapping         ToVkComponentMapping(const grfx::ComponentMapping& value);
 VkCullModeFlagBits         ToVkCullMode(grfx::CullMode value);
+VkDescriptorBindingFlags   ToVkDescriptorBindingFlags(const grfx::DescriptorBindingFlags& value);
 VkDescriptorType           ToVkDescriptorType(grfx::DescriptorType value);
 VkFilter                   ToVkFilter(grfx::Filter value);
 VkFormat                   ToVkFormat(grfx::Format value);

--- a/src/ppx/grfx/dx12/dx12_descriptor.cpp
+++ b/src/ppx/grfx/dx12/dx12_descriptor.cpp
@@ -394,6 +394,12 @@ Result DescriptorSetLayout::CreateApiObjects(const grfx::DescriptorSetLayoutCrea
         if (isUnsupported) {
             return ppx::ERROR_GRFX_UNKNOWN_DESCRIPTOR_TYPE;
         }
+
+        if (binding.flags.bits.partiallyBound) {
+            PPX_LOG_WARN(
+                "Partially bound descriptors enabled for DX12, but we have not "
+                "confirmed that this is allowed in DX12.");
+        }
     }
 
     // Build descriptor ranges

--- a/src/ppx/grfx/dx12/dx12_device.cpp
+++ b/src/ppx/grfx/dx12/dx12_device.cpp
@@ -640,7 +640,10 @@ bool Device::FragmentStoresAndAtomicsSupported() const
 
 bool Device::PartialDescriptorBindingsSupported() const
 {
-    return false;
+    PPX_LOG_WARN(
+        "Partial descriptor bindings may be in use in DX12, but we have not "
+        "confirmed that this feature is supported.");
+    return true;
 }
 
 } // namespace dx12

--- a/src/ppx/grfx/dx12/dx12_device.cpp
+++ b/src/ppx/grfx/dx12/dx12_device.cpp
@@ -638,6 +638,11 @@ bool Device::FragmentStoresAndAtomicsSupported() const
     return true;
 }
 
+bool Device::PartialDescriptorBindingsSupported() const
+{
+    return false;
+}
+
 } // namespace dx12
 } // namespace grfx
 } // namespace ppx

--- a/src/ppx/grfx/vk/vk_descriptor.cpp
+++ b/src/ppx/grfx/vk/vk_descriptor.cpp
@@ -265,6 +265,7 @@ Result DescriptorSetLayout::CreateApiObjects(const grfx::DescriptorSetLayoutCrea
     }
 
     std::vector<VkDescriptorSetLayoutBinding> vkBindings;
+    std::vector<VkDescriptorBindingFlags> vkBindingFlags;
     for (size_t i = 0; i < pCreateInfo->bindings.size(); ++i) {
         const grfx::DescriptorBinding& baseBinding = pCreateInfo->bindings[i];
 
@@ -275,11 +276,20 @@ Result DescriptorSetLayout::CreateApiObjects(const grfx::DescriptorSetLayoutCrea
         vkBinding.stageFlags                   = ToVkShaderStageFlags(baseBinding.shaderVisiblity);
         vkBinding.pImmutableSamplers           = nullptr;
         vkBindings.push_back(vkBinding);
+
+        VkDescriptorBindingFlags vkBindingFlag = ToVkDescriptorBindingFlags(baseBinding.flags);
+        vkBindingFlags.push_back(vkBindingFlag);
     }
+
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT vkBindingWrapper = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT};
+    vkBindingWrapper.bindingCount                                   = CountU32(vkBindingFlags);
+    vkBindingWrapper.pBindingFlags                                  = DataPtr(vkBindingFlags);
+    vkBindingWrapper.pNext                                          = nullptr;
 
     VkDescriptorSetLayoutCreateInfo vkci = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
     vkci.bindingCount                    = CountU32(vkBindings);
     vkci.pBindings                       = DataPtr(vkBindings);
+    vkci.pNext                           = &vkBindingWrapper;
 
     if (pCreateInfo->flags.bits.pushable) {
         vkci.flags |= VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR;

--- a/src/ppx/grfx/vk/vk_descriptor.cpp
+++ b/src/ppx/grfx/vk/vk_descriptor.cpp
@@ -265,7 +265,7 @@ Result DescriptorSetLayout::CreateApiObjects(const grfx::DescriptorSetLayoutCrea
     }
 
     std::vector<VkDescriptorSetLayoutBinding> vkBindings;
-    std::vector<VkDescriptorBindingFlags> vkBindingFlags;
+    std::vector<VkDescriptorBindingFlags>     vkBindingFlags;
     for (size_t i = 0; i < pCreateInfo->bindings.size(); ++i) {
         const grfx::DescriptorBinding& baseBinding = pCreateInfo->bindings[i];
 

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -336,18 +336,10 @@ Result Device::ConfigureDescriptorIndexingFeatures(
 
     // Verify that any asserted features were actually found to be
     // supported.
-    std::vector<std::string_view> missingFeatures;
     if (!foundDiFeatures.runtimeDescriptorArray) {
-        missingFeatures.push_back("runtimeDescriptorArray");
-    }
-
-    if (!missingFeatures.empty()) {
-        std::stringstream ss;
-        ss << "Device does not support required features:" << PPX_LOG_ENDL;
-        for (const auto& elem : missingFeatures) {
-            ss << " " << elem << PPX_LOG_ENDL;
-        }
-        PPX_ASSERT_MSG(false, ss.str());
+        PPX_ASSERT_MSG(
+            false,
+            "RuntimeDescriptorArray feature expected, but was not enabled.");
         return ppx::ERROR_REQUIRED_FEATURE_UNAVAILABLE;
     }
 

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -302,10 +302,8 @@ Result Device::ConfigureDescriptorIndexingFeatures(
 {
     vk::Gpu* pGpu = ToApi(pCreateInfo->pGpu);
 
-    VkPhysicalDeviceDescriptorIndexingFeatures foundDiFeatures
-        {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES};
-    VkPhysicalDeviceFeatures2 foundFeatures
-        {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &foundDiFeatures};
+    VkPhysicalDeviceDescriptorIndexingFeatures foundDiFeatures{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES};
+    VkPhysicalDeviceFeatures2                  foundFeatures{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &foundDiFeatures};
     vkGetPhysicalDeviceFeatures2(pGpu->GetVkGpu(), &foundFeatures);
 
     //

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -542,6 +542,7 @@ Result Device::CreateApiObjects(const grfx::DeviceCreateInfo* pCreateInfo)
     // VK_EXT_descriptor_indexing
     mDescriptorIndexingFeatures = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES};
     if ((GetInstance()->GetApi() >= grfx::API_VK_1_2) || ElementExists(std::string(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME), mExtensions)) {
+        mHasDescriptorIndexingFeatures = true;
         ConfigureDescriptorIndexingFeatures(pCreateInfo, mDescriptorIndexingFeatures);
         extensionStructs.push_back(reinterpret_cast<VkBaseOutStructure*>(&mDescriptorIndexingFeatures));
     }

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -1015,8 +1015,7 @@ bool Device::FragmentStoresAndAtomicsSupported() const
 
 bool Device::PartialDescriptorBindingsSupported() const
 {
-    return mDescriptorIndexingFeatures.descriptorBindingPartiallyBound &&
-           mDescriptorIndexingFeatures.runtimeDescriptorArray;
+    return mDescriptorIndexingFeatures.descriptorBindingPartiallyBound;
 }
 
 void Device::ResetQueryPoolEXT(

--- a/src/ppx/grfx/vk/vk_util.cpp
+++ b/src/ppx/grfx/vk/vk_util.cpp
@@ -350,6 +350,18 @@ VkCullModeFlagBits ToVkCullMode(grfx::CullMode value)
     return ppx::InvalidValue<VkCullModeFlagBits>();
 }
 
+VkDescriptorBindingFlags ToVkDescriptorBindingFlags(const grfx::DescriptorBindingFlags& value)
+{
+    VkDescriptorBindingFlags flags = 0;
+    if (value.bits.updatable) {
+        flags |= VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT;
+    }
+    if (value.bits.partiallyBound) {
+        flags |= VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT;
+    }
+    return flags;
+}
+
 VkDescriptorType ToVkDescriptorType(grfx::DescriptorType value)
 {
     // clang-format off


### PR DESCRIPTION
DX12 support may be added later. Adds supports for partially bound descriptors, which allows us to create arrays for textures where only a subset of the allotted slots are used.