### PR TITLE
Prefer default enableDebug setting

### DIFF
--- a/benchmarks/compute_operations/main.cpp
+++ b/benchmarks/compute_operations/main.cpp
@@ -110,7 +110,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.appName                        = "compute_operations";
     settings.enableImGui                    = false;
     settings.grfx.api                       = kApi;
-    settings.grfx.enableDebug               = false;
     settings.grfx.device.graphicsQueueCount = 1;
     settings.grfx.numFramesInFlight         = 1;
 }

--- a/benchmarks/draw_call/main.cpp
+++ b/benchmarks/draw_call/main.cpp
@@ -85,7 +85,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.appName                        = "draw_call";
     settings.enableImGui                    = false;
     settings.grfx.api                       = kApi;
-    settings.grfx.enableDebug               = false;
     settings.grfx.device.graphicsQueueCount = 1;
     settings.grfx.numFramesInFlight         = 1;
 }

--- a/benchmarks/headless_compute/main.cpp
+++ b/benchmarks/headless_compute/main.cpp
@@ -91,7 +91,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.headless                       = true;
     settings.enableImGui                    = false;
     settings.grfx.api                       = kApi;
-    settings.grfx.enableDebug               = false;
     settings.grfx.device.graphicsQueueCount = 1;
     settings.grfx.numFramesInFlight         = 1;
     settings.grfx.pacedFrameRate            = 0; // Go as fast as possible

--- a/benchmarks/overdraw/main.cpp
+++ b/benchmarks/overdraw/main.cpp
@@ -112,7 +112,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.appName                    = "overdraw";
     settings.enableImGui                = false;
     settings.grfx.api                   = kApi;
-    settings.grfx.enableDebug           = false;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
 }
 

--- a/benchmarks/primitive_assembly/main.cpp
+++ b/benchmarks/primitive_assembly/main.cpp
@@ -83,10 +83,9 @@ private:
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
 {
-    settings.appName          = "primitive_assembly";
-    settings.enableImGui      = false;
-    settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
+    settings.appName     = "primitive_assembly";
+    settings.enableImGui = false;
+    settings.grfx.api    = kApi;
 }
 
 void ProjApp::SaveResultsToFile()

--- a/benchmarks/render_target/main.cpp
+++ b/benchmarks/render_target/main.cpp
@@ -96,7 +96,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.appName                        = "render_target";
     settings.enableImGui                    = false;
     settings.grfx.api                       = kApi;
-    settings.grfx.enableDebug               = false;
     settings.grfx.device.graphicsQueueCount = 1;
     settings.grfx.numFramesInFlight         = 1;
 }

--- a/benchmarks/texture_load/main.cpp
+++ b/benchmarks/texture_load/main.cpp
@@ -90,7 +90,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.appName                        = "texture_load";
     settings.enableImGui                    = false;
     settings.grfx.api                       = kApi;
-    settings.grfx.enableDebug               = false;
     settings.grfx.device.graphicsQueueCount = 1;
 }
 

--- a/benchmarks/texture_sample/main.cpp
+++ b/benchmarks/texture_sample/main.cpp
@@ -102,10 +102,9 @@ private:
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
 {
-    settings.appName          = "texture_sample";
-    settings.enableImGui      = false;
-    settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
+    settings.appName     = "texture_sample";
+    settings.enableImGui = false;
+    settings.grfx.api    = kApi;
 }
 
 void ProjApp::SaveResultsToFile()

--- a/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
+++ b/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
@@ -84,10 +84,9 @@ private:
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
 {
-    settings.appName          = "texture_transfer_cpu_to_gpu";
-    settings.enableImGui      = false;
-    settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
+    settings.appName     = "texture_transfer_cpu_to_gpu";
+    settings.enableImGui = false;
+    settings.grfx.api    = kApi;
 }
 
 void ProjApp::SaveResultsToFile()

--- a/projects/alloc/main.cpp
+++ b/projects/alloc/main.cpp
@@ -38,8 +38,9 @@ private:
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
 {
-    settings.appName          = "alloc";
-    settings.grfx.api         = kApi;
+    settings.appName  = "alloc";
+    settings.grfx.api = kApi;
+    // TODO: #447 - Remove enableDebug = false after validation error is addressed
     settings.grfx.enableDebug = false;
 }
 

--- a/projects/arcball_camera/main.cpp
+++ b/projects/arcball_camera/main.cpp
@@ -74,7 +74,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::SetupEntity(const TriMesh& mesh, const GeometryCreateInfo& createInfo, Entity* pEntity)

--- a/projects/async_compute/main.cpp
+++ b/projects/async_compute/main.cpp
@@ -147,7 +147,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.appName                       = "async_compute";
     settings.enableImGui                   = true;
     settings.grfx.api                      = kApi;
-    settings.grfx.enableDebug              = false;
     settings.window.width                  = 1920;
     settings.window.height                 = 1080;
     settings.grfx.swapchain.imageCount     = mNumFramesInFlight;

--- a/projects/basic_material/main.cpp
+++ b/projects/basic_material/main.cpp
@@ -305,7 +305,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.allowThirdPartyAssets      = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
     settings.enableImGui                = true;
     settings.grfx.numFramesInFlight     = 1;
 }

--- a/projects/camera_fit_scene/main.cpp
+++ b/projects/camera_fit_scene/main.cpp
@@ -75,7 +75,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::SetupEntity(const TriMesh& mesh, const GeometryCreateInfo& createInfo, Entity* pEntity)

--- a/projects/camera_motion/main.cpp
+++ b/projects/camera_motion/main.cpp
@@ -236,7 +236,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::SetupEntity(const TriMesh& mesh, const GeometryCreateInfo& createInfo, Entity* pEntity)

--- a/projects/cube_xr/CubeXr.cpp
+++ b/projects/cube_xr/CubeXr.cpp
@@ -29,7 +29,6 @@ void CubeXrApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
     settings.grfx.pacedFrameRate        = 0;
     settings.xr.enable                  = true;
     settings.xr.enableDebugCapture      = false;

--- a/projects/dynamic_rendering/DynamicRendering.cpp
+++ b/projects/dynamic_rendering/DynamicRendering.cpp
@@ -30,7 +30,6 @@ void DynamicRenderingApp::Config(ApplicationSettings& settings)
     settings.enableImGui                      = true;
     settings.grfx.api                         = kApi;
     settings.grfx.swapchain.depthFormat       = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug                 = false;
     settings.grfx.enableImGuiDynamicRendering = true;
 }
 

--- a/projects/fishtornado/FishTornado.cpp
+++ b/projects/fishtornado/FishTornado.cpp
@@ -133,7 +133,6 @@ void FishTornadoApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.api                   = kApi;
     settings.enableImGui                = true;
     settings.grfx.numFramesInFlight     = 2;
-    settings.grfx.enableDebug           = false;
     settings.grfx.swapchain.imageCount  = 3;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
 

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -144,7 +144,6 @@ void FishTornadoApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.api                   = kApi;
     settings.enableImGui                = true;
     settings.grfx.numFramesInFlight     = 2;
-    settings.grfx.enableDebug           = false;
     settings.grfx.pacedFrameRate        = 0;
     settings.xr.enable                  = true;
     settings.xr.enableDebugCapture      = false;

--- a/projects/gbuffer/main.cpp
+++ b/projects/gbuffer/main.cpp
@@ -123,10 +123,9 @@ protected:
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
 {
-    settings.appName          = "gbuffer";
-    settings.enableImGui      = true;
-    settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
+    settings.appName     = "gbuffer";
+    settings.enableImGui = true;
+    settings.grfx.api    = kApi;
 }
 
 void ProjApp::SetupPerFrame()

--- a/projects/gltf/main.cpp
+++ b/projects/gltf/main.cpp
@@ -164,7 +164,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.window.width               = 1920;
     settings.window.height              = 1080;
     settings.grfx.api                   = kApi;
-    settings.grfx.enableDebug           = false;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
 }
 

--- a/projects/image_filter/main.cpp
+++ b/projects/image_filter/main.cpp
@@ -102,7 +102,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.appName                        = "image_filter";
     settings.enableImGui                    = true;
     settings.grfx.api                       = kApi;
-    settings.grfx.enableDebug               = false;
     settings.grfx.device.graphicsQueueCount = 1;
     settings.grfx.numFramesInFlight         = 1;
 }

--- a/projects/input/main.cpp
+++ b/projects/input/main.cpp
@@ -60,7 +60,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
 {
     settings.appName          = "input";
     settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
     settings.enableImGui      = true;
     settings.window.resizable = true;
 }

--- a/projects/mipmap_demo/main.cpp
+++ b/projects/mipmap_demo/main.cpp
@@ -76,7 +76,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
     settings.enableImGui                = true;
 }
 

--- a/projects/oit_demo/OITDemoApplication.cpp
+++ b/projects/oit_demo/OITDemoApplication.cpp
@@ -33,7 +33,6 @@ void OITDemoApp::Config(ppx::ApplicationSettings& settings)
 
     settings.allowThirdPartyAssets = true;
     settings.enableImGui           = true;
-    settings.grfx.enableDebug      = false;
 
     settings.grfx.swapchain.colorFormat = grfx::FORMAT_B8G8R8A8_UNORM;
 

--- a/projects/primitives/main.cpp
+++ b/projects/primitives/main.cpp
@@ -73,7 +73,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::SetupEntity(const TriMesh& mesh, const GeometryCreateInfo& createInfo, Entity* pEntity)

--- a/projects/push_constants/PushConstants.cpp
+++ b/projects/push_constants/PushConstants.cpp
@@ -29,7 +29,6 @@ void PushConstantsApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void PushConstantsApp::Setup()

--- a/projects/push_descriptors/PushDescriptors.cpp
+++ b/projects/push_descriptors/PushDescriptors.cpp
@@ -30,7 +30,6 @@ void PushDescriptorsApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = grfx::API_VK_1_1;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void PushDescriptorsApp::Setup()

--- a/projects/push_descriptors_buffers/PushDescriptorsBuffers.cpp
+++ b/projects/push_descriptors_buffers/PushDescriptorsBuffers.cpp
@@ -35,7 +35,6 @@ void PushDescriptorsBuffersApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void PushDescriptorsBuffersApp::Setup()

--- a/projects/sample_01_triangle/Triangle.cpp
+++ b/projects/sample_01_triangle/Triangle.cpp
@@ -27,7 +27,6 @@ void TriangleApp::Config(ApplicationSettings& settings)
     settings.appName          = "sample_01_triangle";
     settings.enableImGui      = true;
     settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
     settings.window.resizable = true;
 }
 

--- a/projects/sample_02_triangle_spinning/TriangleSpinning.cpp
+++ b/projects/sample_02_triangle_spinning/TriangleSpinning.cpp
@@ -24,10 +24,9 @@ const grfx::Api kApi = grfx::API_VK_1_1;
 
 void TriangleSpinningApp::Config(ApplicationSettings& settings)
 {
-    settings.appName          = "sample_02_triangle_spinning";
-    settings.enableImGui      = true;
-    settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
+    settings.appName     = "sample_02_triangle_spinning";
+    settings.enableImGui = true;
+    settings.grfx.api    = kApi;
 }
 
 void TriangleSpinningApp::Setup()

--- a/projects/sample_03_square_textured/SquareTextured.cpp
+++ b/projects/sample_03_square_textured/SquareTextured.cpp
@@ -25,10 +25,9 @@ const grfx::Api kApi = grfx::API_VK_1_1;
 
 void SquareTexturedApp::Config(ApplicationSettings& settings)
 {
-    settings.appName          = "sample_03_square_textured";
-    settings.enableImGui      = true;
-    settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
+    settings.appName     = "sample_03_square_textured";
+    settings.enableImGui = true;
+    settings.grfx.api    = kApi;
 }
 
 void SquareTexturedApp::Setup()

--- a/projects/sample_04_cube/Cube.cpp
+++ b/projects/sample_04_cube/Cube.cpp
@@ -28,7 +28,6 @@ void CubeApp::Config(ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void CubeApp::Setup()

--- a/projects/sample_05_cube_textured/main.cpp
+++ b/projects/sample_05_cube_textured/main.cpp
@@ -62,7 +62,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::Setup()

--- a/projects/sample_06_compute_fill/main.cpp
+++ b/projects/sample_06_compute_fill/main.cpp
@@ -64,10 +64,9 @@ private:
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
 {
-    settings.appName          = "sample_06_compute_fill";
-    settings.enableImGui      = true;
-    settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
+    settings.appName     = "sample_06_compute_fill";
+    settings.enableImGui = true;
+    settings.grfx.api    = kApi;
 }
 
 void ProjApp::Setup()

--- a/projects/sample_07_draw_indexed/main.cpp
+++ b/projects/sample_07_draw_indexed/main.cpp
@@ -59,7 +59,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::Setup()

--- a/projects/sample_08_basic_geometry/main.cpp
+++ b/projects/sample_08_basic_geometry/main.cpp
@@ -76,7 +76,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::SetupEntity(const TriMesh& mesh, const GeometryCreateInfo& createInfo, Entity* pEntity)

--- a/projects/sample_09_obj_geometry/main.cpp
+++ b/projects/sample_09_obj_geometry/main.cpp
@@ -70,7 +70,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::SetupEntity(const TriMesh& mesh, const GeometryCreateInfo& createInfo, Entity* pEntity)

--- a/projects/sample_10_cube_map/main.cpp
+++ b/projects/sample_10_cube_map/main.cpp
@@ -84,7 +84,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.allowThirdPartyAssets      = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::SetupEntity(const TriMesh& mesh, const GeometryCreateInfo& createInfo, Entity* pEntity)

--- a/projects/sample_11_compressed_texture/main.cpp
+++ b/projects/sample_11_compressed_texture/main.cpp
@@ -86,7 +86,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::Setup()

--- a/projects/sample_12_shadows/main.cpp
+++ b/projects/sample_12_shadows/main.cpp
@@ -99,7 +99,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::SetupEntity(

--- a/projects/sample_13_normal_map/main.cpp
+++ b/projects/sample_13_normal_map/main.cpp
@@ -96,7 +96,6 @@ void ProjApp::Config(ppx::ApplicationSettings& settings)
     settings.enableImGui                = true;
     settings.grfx.api                   = kApi;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
-    settings.grfx.enableDebug           = false;
 }
 
 void ProjApp::SetupEntity(

--- a/projects/text_draw/main.cpp
+++ b/projects/text_draw/main.cpp
@@ -48,10 +48,9 @@ private:
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
 {
-    settings.appName          = "text_draw";
-    settings.enableImGui      = false;
-    settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
+    settings.appName     = "text_draw";
+    settings.enableImGui = false;
+    settings.grfx.api    = kApi;
 }
 
 void ProjApp::Setup()

--- a/projects/timeline_semaphore/main.cpp
+++ b/projects/timeline_semaphore/main.cpp
@@ -52,10 +52,9 @@ private:
 
 void ProjApp::Config(ppx::ApplicationSettings& settings)
 {
-    settings.appName          = "timeline semaphore";
-    settings.enableImGui      = true;
-    settings.grfx.api         = kApi;
-    settings.grfx.enableDebug = false;
+    settings.appName     = "timeline semaphore";
+    settings.enableImGui = true;
+    settings.grfx.api    = kApi;
 }
 
 void ProjApp::Setup()


### PR DESCRIPTION
Since #385, `enableDebug` defaults to `true` for Debug builds and `false` for Release. Code should avoid overriding this default behavior. This allows us catch more validation layer errors sooner both in CI and by developers during development.

Merge after #445