### PR TITLE
Update mViewProjectionMatrix in ArcballCamera::UpdateCamera

### DIFF
--- a/src/ppx/camera.cpp
+++ b/src/ppx/camera.cpp
@@ -299,8 +299,9 @@ ArcballCamera::ArcballCamera(
 
 void ArcballCamera::UpdateCamera()
 {
-    mViewMatrix        = mTranslationMatrix * glm::mat4_cast(mRotationQuat) * mCenterTranslationMatrix;
-    mInverseViewMatrix = glm::inverse(mViewMatrix);
+    mViewMatrix           = mTranslationMatrix * glm::mat4_cast(mRotationQuat) * mCenterTranslationMatrix;
+    mInverseViewMatrix    = glm::inverse(mViewMatrix);
+    mViewProjectionMatrix = mProjectionMatrix * mViewMatrix;
 
     // Transform the view space origin into world space for eye position
     mEyePosition = mInverseViewMatrix * float4(0, 0, 0, 1);


### PR DESCRIPTION
I added an ArcballCamera to #428 and noticed that it wasn't working as expected.

ArcballCamera wasn't updating `mViewProjectionMatrix` after modifying `mViewMatrix`. This was causing the ArcballCamera to not work correctly when combined with the classes introduced in #426.