### PR TITLE
Use the IsNull method on ObjPtr instead of operator !=

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -547,9 +547,9 @@ void GraphicsBenchmarkApp::SetupSphereMeshes()
     GetDevice()->WaitIdle();
     // Destroy the meshes if they were created.
     for (auto& mesh : mSphereMeshes) {
-        if (mesh != nullptr) {
+        if (!mesh.IsNull()) {
             GetDevice()->DestroyMesh(mesh);
-            mesh = nullptr;
+            mesh.Reset();
         }
     }
 


### PR DESCRIPTION
When compiled with C++20, the operator != is ambiguous in this case