### PR TITLE
Small fixes: platform name, cmake warning

### DIFF
--- a/projects/timeline_semaphore/CMakeLists.txt
+++ b/projects/timeline_semaphore/CMakeLists.txt
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(timeline_semaphore)
 

--- a/src/ppx/platform.cpp
+++ b/src/ppx/platform.cpp
@@ -149,6 +149,8 @@ const char* Platform::GetPlatformString()
     return "Linux";
 #elif defined(PPX_MSW)
     return "Windows";
+#elif defined(PPX_ANDROID)
+    return "Android";
 #endif
     return "<unknown platform>";
 }


### PR DESCRIPTION
- Add "Android" platform name
- Remove the cmake version line from timeline_semaphore it was a relatively new project