### PR TITLE
Replace ALooper_pollAll with ALooper_pollOnce

### DIFF
--- a/src/ppx/window_android.cpp
+++ b/src/ppx/window_android.cpp
@@ -18,6 +18,7 @@
 #include "ppx/window.h"
 #include "ppx/grfx/grfx_swapchain.h"
 
+#include <android/looper.h>
 #include <android_native_app_glue.h>
 
 #include "backends/imgui_impl_android.h"
@@ -115,12 +116,18 @@ bool WindowImplAndroid::IsRunning() const
 
 void WindowImplAndroid::ProcessEvent()
 {
-    int                  events;
-    android_poll_source* pSource;
-    if (ALooper_pollAll(0, nullptr, &events, (void**)&pSource) >= 0) {
-        if (pSource) {
-            pSource->process(mAndroidApp, pSource);
-        }
+    android_poll_source* pSource = nullptr;
+    auto                 result  = ALooper_pollOnce(
+        /* timeoutMillis= */ 0,
+        /* outFd= */ nullptr,
+        /* outEvents= */ nullptr,
+        /* outData= */ (void**)&pSource);
+    if (result == ALOOPER_POLL_ERROR) {
+        PPX_ASSERT_MSG(false, "ALooper_pollOnce returned an error.");
+        return;
+    }
+    if (pSource) {
+        pSource->process(mAndroidApp, pSource);
     }
 }
 


### PR DESCRIPTION
This commit is sourced from a downstream patch.

The incoming NDK r27 removes `ALooper_pollAll` as it can't be called safely.

See https://github.com/android/ndk/discussions/2020 for more context.

While this change strives to introduce as little behavior change as possible, Some behavior changes might be happening.
  1. We are failing more explicitly when `ALooper_pollOnce` returns `ALOOPER_POLL_ERROR`. When this error is returned, there is no point in retrying polling in the current thread.
  2. Compared with `ALooper_pollAll`, `ALooper_pollOnce` can return more frequently with `ALOOPER_POLL_CALLBACK`. This can lead to "on_idle" logic being executed more frequently.