### PR TITLE
Remove debug capture setting

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -186,9 +186,8 @@ void GraphicsBenchmarkApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
 #if defined(PPX_BUILD_XR)
     // XR specific settings
-    settings.grfx.pacedFrameRate   = 0;
-    settings.xr.enable             = false; // Change this to true to enable the XR mode
-    settings.xr.enableDebugCapture = false;
+    settings.grfx.pacedFrameRate = 0;
+    settings.xr.enable           = false; // Change this to true to enable the XR mode
 #endif
     settings.standardKnobsDefaultValue.enableMetrics        = true;
     settings.standardKnobsDefaultValue.overwriteMetricsFile = true;
@@ -1162,19 +1161,7 @@ void GraphicsBenchmarkApp::Render()
 
 #if defined(PPX_BUILD_XR)
     // No need to present when XR is enabled.
-    if (IsXrEnabled()) {
-        if (GetSettings()->xr.enableDebugCapture && (currentViewIndex == 1)) {
-            // We could use semaphore to sync to have better performance,
-            // but this requires modifying the submission code.
-            // For debug capture we don't care about the performance,
-            // so use existing fence to sync for simplicity.
-            grfx::SwapchainPtr debugSwapchain = GetDebugCaptureSwapchain();
-            PPX_CHECKED_CALL(debugSwapchain->AcquireNextImage(UINT64_MAX, nullptr, frame.imageAcquiredFence, &imageIndex));
-            frame.imageAcquiredFence->WaitAndReset();
-            PPX_CHECKED_CALL(debugSwapchain->Present(imageIndex, 0, nullptr));
-        }
-    }
-    else
+    if (!IsXrEnabled())
 #endif
     {
         PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));

--- a/include/ppx/application.h
+++ b/include/ppx/application.h
@@ -385,11 +385,6 @@ public:
         return mXrComponent;
     }
 
-    grfx::SwapchainPtr GetDebugCaptureSwapchain() const
-    {
-        return GetSwapchain(mDebugCaptureSwapchainIndex);
-    }
-
     grfx::SwapchainPtr GetUISwapchain() const
     {
         return GetSwapchain(mUISwapchainIndex);
@@ -520,7 +515,6 @@ private:
 
 #if defined(PPX_BUILD_XR)
     XrComponent mXrComponent;
-    uint32_t    mDebugCaptureSwapchainIndex = 0;
     uint32_t    mUISwapchainIndex           = 0;
     uint32_t    mStereoscopicSwapchainIndex = 0;
     ImVec2      lastImGuiWindowSize         = {};

--- a/projects/cube_xr/CubeXr.cpp
+++ b/projects/cube_xr/CubeXr.cpp
@@ -31,7 +31,6 @@ void CubeXrApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
     settings.grfx.pacedFrameRate        = 0;
     settings.xr.enable                  = true;
-    settings.xr.enableDebugCapture      = false;
 }
 
 void CubeXrApp::Setup()
@@ -349,17 +348,5 @@ void CubeXrApp::Render()
     // No need to present when XR is enabled.
     if (!IsXrEnabled()) {
         PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
-    }
-    else {
-        if (GetSettings()->xr.enableDebugCapture && (currentViewIndex == 1)) {
-            // We could use semaphore to sync to have better performance,
-            // but this requires modifying the submission code.
-            // For debug capture we don't care about the performance,
-            // so use existing fence to sync for simplicity.
-            grfx::SwapchainPtr debugSwapchain = GetDebugCaptureSwapchain();
-            PPX_CHECKED_CALL(debugSwapchain->AcquireNextImage(UINT64_MAX, nullptr, frame.imageAcquiredFence, &imageIndex));
-            frame.imageAcquiredFence->WaitAndReset();
-            PPX_CHECKED_CALL(debugSwapchain->Present(imageIndex, 0, nullptr));
-        }
     }
 }

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -146,7 +146,6 @@ void FishTornadoApp::Config(ppx::ApplicationSettings& settings)
     settings.grfx.numFramesInFlight     = 2;
     settings.grfx.pacedFrameRate        = 0;
     settings.xr.enable                  = true;
-    settings.xr.enableDebugCapture      = false;
     settings.grfx.swapchain.imageCount  = 3;
     settings.grfx.swapchain.depthFormat = grfx::FORMAT_D32_FLOAT;
 
@@ -1125,18 +1124,6 @@ void FishTornadoApp::Render()
     // No need to present when XR is enabled.
     if (!IsXrEnabled()) {
         PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.frameCompleteSemaphore));
-    }
-    else {
-        if (GetSettings()->xr.enableDebugCapture && (currentViewIndex == 1)) {
-            // We could use semaphore to sync to have better performance,
-            // but this requires modifying the submission code.
-            // For debug capture we don't care about the performance,
-            // so use existing fence to sync for simplicity.
-            grfx::SwapchainPtr debugSwapchain = GetDebugCaptureSwapchain();
-            PPX_CHECKED_CALL(debugSwapchain->AcquireNextImage(UINT64_MAX, nullptr, frame.imageAcquiredFence, &imageIndex));
-            frame.imageAcquiredFence->WaitAndReset();
-            PPX_CHECKED_CALL(debugSwapchain->Present(imageIndex, 0, nullptr));
-        }
     }
 }
 


### PR DESCRIPTION
Remove debug capture option, tools like RenderDoc can capture directly, and it makes code more complicated.
Also use IsXrEnabled instead of settings.xr.enable, that way we can switch how that is controled in the function.

Fixes https://github.com/google/bigwheels/issues/464