### PR TITLE
Declare support for UINT8 index buffer

### DIFF
--- a/include/ppx/grfx/dx12/dx12_device.h
+++ b/include/ppx/grfx/dx12/dx12_device.h
@@ -67,6 +67,7 @@ public:
     virtual bool FragmentStoresAndAtomicsSupported() const override;
     virtual bool PartialDescriptorBindingsSupported() const override;
     virtual bool MultiViewSupported() const override;
+    bool         IndexTypeUint8Supported() const override;
 
 protected:
     virtual Result AllocateObject(grfx::Buffer** ppObject) override;

--- a/include/ppx/grfx/grfx_device.h
+++ b/include/ppx/grfx/grfx_device.h
@@ -196,6 +196,7 @@ public:
     virtual bool   IndependentBlendingSupported() const       = 0;
     virtual bool   FragmentStoresAndAtomicsSupported() const  = 0;
     virtual bool   PartialDescriptorBindingsSupported() const = 0;
+    virtual bool   IndexTypeUint8Supported() const            = 0;
 
 protected:
     virtual Result Create(const grfx::DeviceCreateInfo* pCreateInfo) override;

--- a/include/ppx/grfx/vk/vk_device.h
+++ b/include/ppx/grfx/vk/vk_device.h
@@ -47,6 +47,7 @@ public:
     virtual bool IndependentBlendingSupported() const override;
     virtual bool FragmentStoresAndAtomicsSupported() const override;
     virtual bool PartialDescriptorBindingsSupported() const override;
+    bool         IndexTypeUint8Supported() const override;
 
     void ResetQueryPoolEXT(
         VkQueryPool queryPool,
@@ -124,6 +125,7 @@ private:
     bool                                           mHasDepthClipEnabled                        = false;
     bool                                           mHasMultiView                               = false;
     bool                                           mHasDynamicRendering                        = false;
+    bool                                           mIndexTypeUint8Supported                    = false;
     PFN_vkResetQueryPoolEXT                        mFnResetQueryPoolEXT                        = nullptr;
     PFN_vkWaitSemaphores                           mFnWaitSemaphores                           = nullptr;
     PFN_vkSignalSemaphore                          mFnSignalSemaphore                          = nullptr;

--- a/src/ppx/grfx/dx12/dx12_device.cpp
+++ b/src/ppx/grfx/dx12/dx12_device.cpp
@@ -657,6 +657,13 @@ bool Device::PartialDescriptorBindingsSupported() const
     return true;
 }
 
+bool Device::IndexTypeUint8Supported() const
+{
+    // R8_UINT is not supported for "Input Assembler Index Buffer", only R16_UINT and R32_UINT
+    // https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/hardware-support-for-direct3d-12-0-formats
+    return false;
+}
+
 } // namespace dx12
 } // namespace grfx
 } // namespace ppx

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -235,6 +235,11 @@ Result Device::ConfigureExtensions(const grfx::DeviceCreateInfo* pCreateInfo)
     }
 #endif
 
+    // 8 bit index buffer
+    if (ElementExists(std::string(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME), mFoundExtensions)) {
+        mExtensions.push_back(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME);
+    }
+
     // Add additional extensions and uniquify
     AppendElements(pCreateInfo->vulkanExtensions, mExtensions);
     Unique(mExtensions);
@@ -626,6 +631,17 @@ Result Device::CreateApiObjects(const grfx::DeviceCreateInfo* pCreateInfo)
         fragmentShadingRateFeature.pipelineFragmentShadingRate   = VK_TRUE;
         fragmentShadingRateFeature.attachmentFragmentShadingRate = VK_TRUE;
         extensionStructs.push_back(reinterpret_cast<VkBaseOutStructure*>(&fragmentShadingRateFeature));
+    }
+
+    // VK_EXT_index_type_uint8
+    VkPhysicalDeviceIndexTypeUint8FeaturesEXT indexTypeUint8Features = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT};
+    if (ElementExists(std::string(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME), mExtensions)) {
+        VkPhysicalDeviceFeatures2 foundFeatures{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, &indexTypeUint8Features};
+        vkGetPhysicalDeviceFeatures2(ToApi(pCreateInfo->pGpu)->GetVkGpu(), &foundFeatures);
+        if (indexTypeUint8Features.indexTypeUint8 == VK_TRUE) {
+            mIndexTypeUint8Supported = true;
+            extensionStructs.push_back(reinterpret_cast<VkBaseOutStructure*>(&indexTypeUint8Features));
+        }
     }
 
     // Chain pNexts
@@ -1082,6 +1098,11 @@ bool Device::FragmentStoresAndAtomicsSupported() const
 bool Device::PartialDescriptorBindingsSupported() const
 {
     return mDescriptorIndexingFeatures.descriptorBindingPartiallyBound;
+}
+
+bool Device::IndexTypeUint8Supported() const
+{
+    return mIndexTypeUint8Supported;
 }
 
 void Device::ResetQueryPoolEXT(


### PR DESCRIPTION
For Vulkan, we must ask for the VK_EXT_index_type_uint8 device extension and enable the indexTypeUint8 feature.

For DX12, the docs claim that there is no support: https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/hardware-support-for-direct3d-12-0-formats

This is required to load uint8 index buffers from glTF files more efficiently. See #453