### PR TITLE
Add instructions for generating code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ To build tests (without running them), use `ninja build-tests`. Test binaries ar
 
 To run tests (they will be built if needed), use `ninja run-tests`.
 
+To generate code coverage, consult our additional [documentation](docs/code_coverage.md).
+
 # Benchmarks
 BigWheels includes a variety of benchmarks that test graphics fundamentals under the `benchmarks` folder. See the [documentation](docs/benchmarks.md) for benchmarks on how to build and run them.
 

--- a/docs/code_coverage.md
+++ b/docs/code_coverage.md
@@ -1,0 +1,38 @@
+# Code Coverage
+
+## Linux GCC (gcov)
+
+Prerequisites:
+
+- Install a gcov report tool, e.g. gcovr: `sudo apt install gcovr`
+
+First, compile with coverage enabled. For GCC, this means providing `-fprofile-arcs -ftest-coverage` to both the compiler and linker. In addition, compile with debug information for more accurate results. With CMake, we can do that like so:
+
+```sh
+cmake . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage" -DCMAKE_C_FLAGS="-fprofile-arcs -ftest-coverage" -DCMAKE_EXE_LINKER_FLAGS="-fprofile-arcs -ftest-coverage"
+```
+
+Then, build:
+
+```sh
+ninja -C build
+```
+
+NOTE: It is recommended to do a full build. Otherwise, coverage for files not included in the unit tests will be ommitted. This results in inaccurate reports. We can filter later with gcov to pare down the information in the report.
+
+Next, run the unit tests to determine lines exercised:
+
+```sh
+ninja -C build run-tests
+```
+
+Finally, run the report. This filters for only BigWheels source files:
+
+```sh
+cd build
+gcovr --gcov-ignore-parse-errors all --html-details coverage.html -f '.*/include/ppx/.*' -f '.*/src/ppx/.*' -j $(nproc) -r ..
+```
+
+Open `coverage.html` with your browser.
+
+For more information -- including details about how gcov generates and tracks coverage -- read the [gcov docs](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html).

--- a/docs/code_coverage.md
+++ b/docs/code_coverage.md
@@ -18,7 +18,7 @@ Then, build:
 ninja -C build
 ```
 
-NOTE: It is recommended to do a full build. Otherwise, coverage for files not included in the unit tests will be ommitted. This results in inaccurate reports. We can filter later with gcov to pare down the information in the report.
+NOTE: It is recommended to do a full build. Otherwise, coverage for files not included in the unit tests will be missing. This results in inaccurate reports. We can filter later with gcov to pare down the information in the report.
 
 Next, run the unit tests to determine lines exercised:
 


### PR DESCRIPTION
I find code coverage metrics useful to identify missing tests. I only provided GCC instructions since that's the toolchain that I'm used to working with.