### PR TITLE
Require UINT32 type in Geometry::AppendIndicesU32

### DIFF
--- a/include/ppx/grfx/grfx_util.h
+++ b/include/ppx/grfx/grfx_util.h
@@ -26,6 +26,7 @@ namespace grfx {
 const char* ToString(grfx::Api value);
 const char* ToString(grfx::DescriptorType value);
 const char* ToString(grfx::VertexSemantic value);
+const char* ToString(grfx::IndexType value);
 
 uint32_t     IndexTypeSize(grfx::IndexType value);
 grfx::Format VertexSemanticFormat(grfx::VertexSemantic value);

--- a/src/ppx/geometry.cpp
+++ b/src/ppx/geometry.cpp
@@ -1122,7 +1122,7 @@ void Geometry::AppendIndicesEdge(uint32_t idx0, uint32_t idx1)
 void Geometry::AppendIndicesU32(uint32_t count, const uint32_t* pIndices)
 {
     if (mCreateInfo.indexType != grfx::INDEX_TYPE_UINT32) {
-        PPX_ASSERT_MSG(false, "Can't append UINT32 data to buffer of type:" << ToString(mCreateInfo.indexType));
+        PPX_ASSERT_MSG(false, "Can't append UINT32 indices to buffer of type: " << ToString(mCreateInfo.indexType));
         return;
     }
     mIndexBuffer.Append(count, pIndices);

--- a/src/ppx/geometry.cpp
+++ b/src/ppx/geometry.cpp
@@ -1121,8 +1121,8 @@ void Geometry::AppendIndicesEdge(uint32_t idx0, uint32_t idx1)
 
 void Geometry::AppendIndicesU32(uint32_t count, const uint32_t* pIndices)
 {
-    if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT16) {
-        PPX_ASSERT_MSG(false, "Invalid geometry index type, trying to append UINT32 data to UINT16 indices");
+    if (mCreateInfo.indexType != grfx::INDEX_TYPE_UINT32) {
+        PPX_ASSERT_MSG(false, "Can't append UINT32 data to buffer of type:" << ToString(mCreateInfo.indexType));
         return;
     }
     mIndexBuffer.Append(count, pIndices);

--- a/src/ppx/grfx/grfx_util.cpp
+++ b/src/ppx/grfx/grfx_util.cpp
@@ -90,6 +90,17 @@ const char* ToString(grfx::VertexSemantic value)
     return "";
 }
 
+const char* ToString(grfx::IndexType value)
+{
+    switch (value) {
+        default: break;
+        case grfx::INDEX_TYPE_UNDEFINED: return "INDEX_TYPE_UNDEFINED";
+        case grfx::INDEX_TYPE_UINT16: return "INDEX_TYPE_UINT16";
+        case grfx::INDEX_TYPE_UINT32: return "INDEX_TYPE_UINT32";
+    }
+    return "<unknown grfx::IndexType>";
+}
+
 uint32_t IndexTypeSize(grfx::IndexType value)
 {
     // clang-format off

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -50,15 +50,16 @@ add_custom_target(run-tests
 list(
     APPEND TEST_SOURCES
     command_line_parser_test.cpp
+    filesystem_test.cpp
+    filesystem_util_test.cpp
     format_test.cpp
+    geometry_test.cpp
     knob_test.cpp
     log_console_test.cpp
     metrics_test.cpp
     ppm_export_test.cpp
     string_util_test.cpp
     transform_test.cpp
-    filesystem_test.cpp
-    filesystem_util_test.cpp
     vk_shading_rate_test.cpp
 )
 package_add_test(ppx_tests ${TEST_SOURCES})

--- a/src/test/geometry_test.cpp
+++ b/src/test/geometry_test.cpp
@@ -19,13 +19,6 @@
 #include "ppx/grfx/grfx_util.h"
 
 namespace ppx {
-
-std::ostream& operator<<(std::ostream& o, const grfx::IndexType& indexType)
-{
-    o << ToString(indexType);
-    return o;
-}
-
 namespace {
 
 using ::testing::IsNull;
@@ -70,7 +63,9 @@ TEST_P(GeometryDeathTest, AppendIndicesU32DiesIfIndexTypeIsNotU32)
     ASSERT_DEATH(geometry.AppendIndicesU32(indices.size(), indices.data()), "AppendIndicesU32");
 }
 
-INSTANTIATE_TEST_SUITE_P(GeometryDeathTest, GeometryDeathTest, testing::Values(grfx::INDEX_TYPE_UINT16, grfx::INDEX_TYPE_UNDEFINED));
+INSTANTIATE_TEST_SUITE_P(GeometryDeathTest, GeometryDeathTest, testing::Values(grfx::INDEX_TYPE_UINT16, grfx::INDEX_TYPE_UNDEFINED), [](const testing::TestParamInfo<GeometryDeathTest::ParamType>& info) {
+    return ToString(info.param);
+});
 
 } // namespace
 } // namespace ppx

--- a/src/test/geometry_test.cpp
+++ b/src/test/geometry_test.cpp
@@ -41,6 +41,7 @@ TEST(GeometryTest, AppendIndicesU32PacksDataAsUint32)
     EXPECT_EQ(indexBuffer->GetSize(), 12);
 
     const uint32_t* indexBufferData = reinterpret_cast<const uint32_t*>(indexBuffer->GetData());
+    ASSERT_THAT(indexBufferData, NotNull());
     EXPECT_EQ(indexBufferData[0], 0);
     EXPECT_EQ(indexBufferData[1], 1);
     EXPECT_EQ(indexBufferData[2], 2);

--- a/src/test/geometry_test.cpp
+++ b/src/test/geometry_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/geometry_test.cpp
+++ b/src/test/geometry_test.cpp
@@ -33,15 +33,15 @@ using ::testing::NotNull;
 
 TEST(GeometryTest, AppendIndicesU32PacksDataAsUint32)
 {
-    Geometry planeGeometry;
-    EXPECT_EQ(Geometry::Create(GeometryCreateInfo{}.IndexType(grfx::INDEX_TYPE_UINT32).AddPosition(), &planeGeometry), ppx::SUCCESS);
-    EXPECT_EQ(planeGeometry.GetIndexType(), grfx::INDEX_TYPE_UINT32);
+    Geometry geometry;
+    EXPECT_EQ(Geometry::Create(GeometryCreateInfo{}.IndexType(grfx::INDEX_TYPE_UINT32).AddPosition(), &geometry), ppx::SUCCESS);
+    EXPECT_EQ(geometry.GetIndexType(), grfx::INDEX_TYPE_UINT32);
 
     const std::array<uint32_t, 3> indices = {0, 1, 2};
-    planeGeometry.AppendIndicesU32(indices.size(), indices.data());
-    EXPECT_EQ(planeGeometry.GetIndexCount(), 3);
+    geometry.AppendIndicesU32(indices.size(), indices.data());
+    EXPECT_EQ(geometry.GetIndexCount(), 3);
 
-    const Geometry::Buffer* indexBuffer = planeGeometry.GetIndexBuffer();
+    const Geometry::Buffer* indexBuffer = geometry.GetIndexBuffer();
     ASSERT_THAT(indexBuffer, NotNull());
     EXPECT_EQ(indexBuffer->GetElementSize(), sizeof(uint32_t));
     EXPECT_EQ(indexBuffer->GetElementCount(), 3);
@@ -62,12 +62,12 @@ using GeometryDeathTest = GeometryTestWithIndexTypeParam;
 TEST_P(GeometryDeathTest, AppendIndicesU32DiesIfIndexTypeIsNotU32)
 {
     grfx::IndexType indexType = GetParam();
-    Geometry        planeGeometry;
-    EXPECT_EQ(Geometry::Create(GeometryCreateInfo{}.IndexType(indexType).AddPosition(), &planeGeometry), ppx::SUCCESS);
-    EXPECT_NE(planeGeometry.GetIndexType(), grfx::INDEX_TYPE_UINT32);
+    Geometry        geometry;
+    EXPECT_EQ(Geometry::Create(GeometryCreateInfo{}.IndexType(indexType).AddPosition(), &geometry), ppx::SUCCESS);
+    EXPECT_NE(geometry.GetIndexType(), grfx::INDEX_TYPE_UINT32);
 
     const std::array<uint32_t, 3> indices = {0, 1, 2};
-    ASSERT_DEATH(planeGeometry.AppendIndicesU32(indices.size(), indices.data()), "AppendIndicesU32");
+    ASSERT_DEATH(geometry.AppendIndicesU32(indices.size(), indices.data()), "AppendIndicesU32");
 }
 
 INSTANTIATE_TEST_SUITE_P(GeometryDeathTest, GeometryDeathTest, testing::Values(grfx::INDEX_TYPE_UINT16, grfx::INDEX_TYPE_UNDEFINED));

--- a/src/test/geometry_test.cpp
+++ b/src/test/geometry_test.cpp
@@ -21,6 +21,12 @@
 namespace ppx {
 namespace {
 
+// The death tests will always fail with NDEBUG (i.e. Release builds).
+// PPX_ASSERT_MSG relies on assert() for death but assert is a no-op with NDEBUG.
+#if !defined(NDEBUG)
+#define PERFORM_DEATH_TESTS
+#endif
+
 using ::testing::IsNull;
 using ::testing::NotNull;
 
@@ -51,6 +57,7 @@ class GeometryTestWithIndexTypeParam : public testing::TestWithParam<grfx::Index
 {
 };
 
+#if defined(PERFORM_DEATH_TESTS)
 using GeometryDeathTest = GeometryTestWithIndexTypeParam;
 
 TEST_P(GeometryDeathTest, AppendIndicesU32DiesIfIndexTypeIsNotU32)
@@ -61,12 +68,13 @@ TEST_P(GeometryDeathTest, AppendIndicesU32DiesIfIndexTypeIsNotU32)
     EXPECT_NE(geometry.GetIndexType(), grfx::INDEX_TYPE_UINT32);
 
     const std::array<uint32_t, 3> indices = {0, 1, 2};
-    ASSERT_DEATH(geometry.AppendIndicesU32(indices.size(), indices.data()), "AppendIndicesU32");
+    ASSERT_DEATH(geometry.AppendIndicesU32(indices.size(), indices.data()), "Assertion.*failed");
 }
 
 INSTANTIATE_TEST_SUITE_P(GeometryDeathTest, GeometryDeathTest, testing::Values(grfx::INDEX_TYPE_UINT16, grfx::INDEX_TYPE_UNDEFINED), [](const testing::TestParamInfo<GeometryDeathTest::ParamType>& info) {
     return ToString(info.param);
 });
+#endif
 
 } // namespace
 } // namespace ppx

--- a/src/test/geometry_test.cpp
+++ b/src/test/geometry_test.cpp
@@ -1,0 +1,93 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "ppx/geometry.h"
+#include "ppx/grfx/grfx_util.h"
+
+namespace ppx {
+
+const char* ToString(GeometryVertexAttributeLayout value)
+{
+    switch (value) {
+        default: break;
+        case GEOMETRY_VERTEX_ATTRIBUTE_LAYOUT_INTERLEAVED: return "GEOMETRY_VERTEX_ATTRIBUTE_LAYOUT_INTERLEAVED";
+        case GEOMETRY_VERTEX_ATTRIBUTE_LAYOUT_PLANAR: return "GEOMETRY_VERTEX_ATTRIBUTE_LAYOUT_PLANAR";
+        case GEOMETRY_VERTEX_ATTRIBUTE_LAYOUT_POSITION_PLANAR: return "GEOMETRY_VERTEX_ATTRIBUTE_LAYOUT_POSITION_PLANAR";
+    }
+
+    return "<unknown GeometryVertexAttributeLayout>";
+}
+
+std::ostream& operator<<(std::ostream& o, const GeometryCreateInfo& info)
+{
+    o << "GeometryCreateInfo{" << ToString(info.indexType) << ", " << ToString(info.vertexAttributeLayout) << "}";
+    return o;
+}
+
+namespace {
+
+using ::testing::IsNull;
+using ::testing::NotNull;
+
+class GeometryTestWithGeometryCreateInfoParam : public testing::TestWithParam<GeometryCreateInfo>
+{
+};
+
+using GeometryU32Test = GeometryTestWithGeometryCreateInfoParam;
+
+TEST_P(GeometryU32Test, AppendIndicesU32PacksDataAsUint32)
+{
+    GeometryCreateInfo geometryCreateInfo = GetParam();
+    Geometry           planeGeometry;
+    EXPECT_EQ(Geometry::Create(geometryCreateInfo, &planeGeometry), ppx::SUCCESS);
+    EXPECT_EQ(planeGeometry.GetIndexType(), grfx::INDEX_TYPE_UINT32);
+
+    const std::array<uint32_t, 3> indices = {0, 1, 2};
+    planeGeometry.AppendIndicesU32(indices.size(), indices.data());
+    EXPECT_EQ(planeGeometry.GetIndexCount(), 3);
+
+    const Geometry::Buffer* indexBuffer = planeGeometry.GetIndexBuffer();
+    ASSERT_THAT(indexBuffer, NotNull());
+    EXPECT_EQ(indexBuffer->GetElementSize(), sizeof(uint32_t));
+    EXPECT_EQ(indexBuffer->GetElementCount(), 3);
+    EXPECT_EQ(indexBuffer->GetSize(), 12);
+
+    const uint32_t* indexBufferData = reinterpret_cast<const uint32_t*>(indexBuffer->GetData());
+    EXPECT_EQ(indexBufferData[0], 0);
+    EXPECT_EQ(indexBufferData[1], 1);
+    EXPECT_EQ(indexBufferData[2], 2);
+}
+
+INSTANTIATE_TEST_SUITE_P(GeometryU32Test, GeometryU32Test, testing::Values(GeometryCreateInfo::PlanarU32(), GeometryCreateInfo::PositionPlanarU32(), GeometryCreateInfo::InterleavedU32()));
+
+using GeometryDeathTest = GeometryTestWithGeometryCreateInfoParam;
+
+TEST_P(GeometryDeathTest, AppendIndicesU32DiesIfIndexTypeIsNotU32)
+{
+    GeometryCreateInfo geometryCreateInfo = GetParam();
+    Geometry           planeGeometry;
+    EXPECT_EQ(Geometry::Create(geometryCreateInfo, &planeGeometry), ppx::SUCCESS);
+    EXPECT_NE(planeGeometry.GetIndexType(), grfx::INDEX_TYPE_UINT32);
+
+    const std::array<uint32_t, 3> indices = {0, 1, 2};
+    ASSERT_DEATH(planeGeometry.AppendIndicesU32(indices.size(), indices.data()), "AppendIndicesU32");
+}
+
+INSTANTIATE_TEST_SUITE_P(GeometryDeathTest, GeometryDeathTest, testing::Values(GeometryCreateInfo::Planar(), GeometryCreateInfo::PositionPlanar(), GeometryCreateInfo::Interleaved(), GeometryCreateInfo::PlanarU16(), GeometryCreateInfo::PositionPlanarU16(), GeometryCreateInfo::InterleavedU16()));
+
+} // namespace
+} // namespace ppx


### PR DESCRIPTION
Unlike `AppendIndex` and friends, `AppendIndicesU32` doesn't account for `INDEX_TYPE_UNDEFINED`. Consider:

```c++
Geometry geometry;
Geometry::Create(GeometryCreateInfo{}.IndexType(grfx::INDEX_TYPE_UNDEFINED).AddPosition(), &geometry);
std::array<uint32_t, 3> data = {0, 1, 2)
geometry.AppendIndicesU32(data.size(), data.data());
EXPECT_EQ(geometry.GetIndexBuffer()->GetSize(), 0);
```

This test would fail since the data would be written to the index buffer!

This seems like an oversight. The condition has been fixed and tests have been added.