### PR TITLE
Add multisample support for ShadingRatePattern.

### DIFF
--- a/include/ppx/grfx/grfx_image.h
+++ b/include/ppx/grfx/grfx_image.h
@@ -212,6 +212,7 @@ public:
 
     grfx::ImagePtr          GetImage() const { return mCreateInfo.pImage; }
     grfx::Format            GetFormat() const { return mCreateInfo.format; }
+    grfx::SampleCount       GetSampleCount() const { return GetImage()->GetSampleCount(); }
     uint32_t                GetMipLevel() const { return mCreateInfo.mipLevel; }
     uint32_t                GetArrayLayer() const { return mCreateInfo.arrayLayer; }
     grfx::AttachmentLoadOp  GetDepthLoadOp() const { return mCreateInfo.depthLoadOp; }
@@ -230,7 +231,6 @@ struct RenderTargetViewCreateInfo
     grfx::Image*            pImage          = nullptr;
     grfx::ImageViewType     imageViewType   = grfx::IMAGE_VIEW_TYPE_UNDEFINED;
     grfx::Format            format          = grfx::FORMAT_UNDEFINED;
-    grfx::SampleCount       sampleCount     = grfx::SAMPLE_COUNT_1;
     uint32_t                mipLevel        = 0;
     uint32_t                mipLevelCount   = 0;
     uint32_t                arrayLayer      = 0;
@@ -256,7 +256,7 @@ public:
 
     grfx::ImagePtr          GetImage() const { return mCreateInfo.pImage; }
     grfx::Format            GetFormat() const { return mCreateInfo.format; }
-    grfx::SampleCount       GetSampleCount() const { return mCreateInfo.sampleCount; }
+    grfx::SampleCount       GetSampleCount() const { return GetImage()->GetSampleCount(); }
     uint32_t                GetMipLevel() const { return mCreateInfo.mipLevel; }
     uint32_t                GetArrayLayer() const { return mCreateInfo.arrayLayer; }
     grfx::AttachmentLoadOp  GetLoadOp() const { return mCreateInfo.loadOp; }
@@ -299,7 +299,7 @@ public:
     grfx::ImagePtr                GetImage() const { return mCreateInfo.pImage; }
     grfx::ImageViewType           GetImageViewType() const { return mCreateInfo.imageViewType; }
     grfx::Format                  GetFormat() const { return mCreateInfo.format; }
-    grfx::SampleCount             GetSampleCount() const { return mCreateInfo.sampleCount; }
+    grfx::SampleCount             GetSampleCount() const { return GetImage()->GetSampleCount(); }
     uint32_t                      GetMipLevel() const { return mCreateInfo.mipLevel; }
     uint32_t                      GetMipLevelCount() const { return mCreateInfo.mipLevelCount; }
     uint32_t                      GetArrayLayer() const { return mCreateInfo.arrayLayer; }
@@ -341,7 +341,6 @@ struct StorageImageViewCreateInfo
     grfx::Image*           pImage          = nullptr;
     grfx::ImageViewType    imageViewType   = grfx::IMAGE_VIEW_TYPE_UNDEFINED;
     grfx::Format           format          = grfx::FORMAT_UNDEFINED;
-    grfx::SampleCount      sampleCount     = grfx::SAMPLE_COUNT_1;
     uint32_t               mipLevel        = 0;
     uint32_t               mipLevelCount   = 0;
     uint32_t               arrayLayer      = 0;
@@ -366,7 +365,7 @@ public:
     grfx::ImagePtr      GetImage() const { return mCreateInfo.pImage; }
     grfx::ImageViewType GetImageViewType() const { return mCreateInfo.imageViewType; }
     grfx::Format        GetFormat() const { return mCreateInfo.format; }
-    grfx::SampleCount   GetSampleCount() const { return mCreateInfo.sampleCount; }
+    grfx::SampleCount   GetSampleCount() const { return GetImage()->GetSampleCount(); }
     uint32_t            GetMipLevel() const { return mCreateInfo.mipLevel; }
     uint32_t            GetMipLevelCount() const { return mCreateInfo.mipLevelCount; }
     uint32_t            GetArrayLayer() const { return mCreateInfo.arrayLayer; }

--- a/include/ppx/grfx/grfx_shading_rate.h
+++ b/include/ppx/grfx/grfx_shading_rate.h
@@ -22,8 +22,17 @@
 namespace ppx {
 namespace grfx {
 
-// Maximum number of supported shading rates in ShadingRateCapabilities.
-static constexpr size_t kMaxSupportedShadingRateCount = 16;
+// SupportedShadingRate
+//
+// A supported shading rate supported by the device.
+struct SupportedShadingRate
+{
+    // Bit mask of supported sample counts.
+    uint32_t sampleCountMask;
+
+    // Size of the shading rate fragment size.
+    Extent2D fragmentSize;
+};
 
 // ShadingRateCapabilities
 //
@@ -53,8 +62,7 @@ struct ShadingRateCapabilities
         Extent2D maxTexelSize;
 
         // List of supported shading rates.
-        uint32_t supportedRateCount = 0;
-        Extent2D supportedRates[kMaxSupportedShadingRateCount];
+        std::vector<SupportedShadingRate> supportedRates;
     } vrs;
 };
 
@@ -94,6 +102,9 @@ struct ShadingRatePatternCreateInfo
 
     // The shading rate mode (FDM or VRS).
     ShadingRateMode shadingRateMode = SHADING_RATE_NONE;
+
+    // The sample count of the render targets using this shading rate pattern.
+    SampleCount sampleCount;
 };
 
 // ShadingRatePattern
@@ -121,6 +132,9 @@ public:
     uint32_t GetTexelWidth() const { return mTexelSize.width; }
     uint32_t GetTexelHeight() const { return mTexelSize.height; }
 
+    // The sample count of the render targets using this shading rate pattern.
+    SampleCount GetSampleCount() const { return mSampleCount; }
+
     // Create a bitmap suitable for uploading fragment density/size to this pattern.
     std::unique_ptr<Bitmap> CreateBitmap() const;
 
@@ -137,6 +151,7 @@ protected:
     ShadingRateMode mShadingRateMode;
     ImagePtr        mAttachmentImage;
     Extent2D        mTexelSize;
+    SampleCount     mSampleCount;
 };
 
 } // namespace grfx

--- a/include/ppx/grfx/vk/vk_shading_rate.h
+++ b/include/ppx/grfx/vk/vk_shading_rate.h
@@ -46,12 +46,15 @@ private:
 class VRSShadingRateEncoder : public grfx::ShadingRateEncoder
 {
 public:
-    void Initialize(const ShadingRateCapabilities& capabilities);
+    void Initialize(SampleCount sampleCount, const ShadingRateCapabilities& capabilities);
     virtual ~VRSShadingRateEncoder() = default;
     uint32_t EncodeFragmentDensity(uint8_t xDensity, uint8_t yDensity) const override;
     uint32_t EncodeFragmentSize(uint8_t fragmentWidth, uint8_t fragmentHeight) const override;
 
 private:
+    // Maximum encoded value of a shading rate.
+    static constexpr size_t kMaxEncodedShadingRate = (2 << 2) | 2;
+
     uint32_t        EncodeFragmentSizeImpl(uint8_t xDensity, uint8_t yDensity) const;
     static uint32_t RawEncode(uint8_t width, uint8_t height);
 
@@ -62,7 +65,7 @@ private:
     // Ties are broken lexicographically, e.g. if 2x2, 1x4 and 4x1
     // are supported, then 2x4 will be mapped to 2x2 but 4x2 will
     // map to 4x1.
-    std::array<uint8_t, kMaxSupportedShadingRateCount> mMapRateToSupported;
+    std::array<uint8_t, kMaxEncodedShadingRate + 1> mMapRateToSupported;
 };
 } // namespace internal
 

--- a/src/ppx/grfx/grfx_image.cpp
+++ b/src/ppx/grfx/grfx_image.cpp
@@ -158,7 +158,6 @@ grfx::RenderTargetViewCreateInfo RenderTargetViewCreateInfo::GuessFromImage(grfx
     ci.pImage                           = pImage;
     ci.imageViewType                    = pImage->GuessImageViewType();
     ci.format                           = pImage->GetFormat();
-    ci.sampleCount                      = pImage->GetSampleCount();
     ci.mipLevel                         = 0;
     ci.mipLevelCount                    = 1;
     ci.arrayLayer                       = 0;
@@ -179,7 +178,6 @@ grfx::SampledImageViewCreateInfo SampledImageViewCreateInfo::GuessFromImage(grfx
     ci.pImage                           = pImage;
     ci.imageViewType                    = pImage->GuessImageViewType();
     ci.format                           = pImage->GetFormat();
-    ci.sampleCount                      = pImage->GetSampleCount();
     ci.mipLevel                         = 0;
     ci.mipLevelCount                    = pImage->GetMipLevelCount();
     ci.arrayLayer                       = 0;
@@ -198,7 +196,6 @@ grfx::StorageImageViewCreateInfo StorageImageViewCreateInfo::GuessFromImage(grfx
     ci.pImage                           = pImage;
     ci.imageViewType                    = pImage->GuessImageViewType();
     ci.format                           = pImage->GetFormat();
-    ci.sampleCount                      = pImage->GetSampleCount();
     ci.mipLevel                         = 0;
     ci.mipLevelCount                    = pImage->GetMipLevelCount();
     ci.arrayLayer                       = 0;

--- a/src/ppx/grfx/grfx_render_pass.cpp
+++ b/src/ppx/grfx/grfx_render_pass.cpp
@@ -324,7 +324,6 @@ Result RenderPass::CreateImagesAndViewsV2(const grfx::internal::RenderPassCreate
             rtvCreateInfo.pImage                           = image;
             rtvCreateInfo.imageViewType                    = grfx::IMAGE_VIEW_TYPE_2D;
             rtvCreateInfo.format                           = pCreateInfo->V2.renderTargetFormats[i];
-            rtvCreateInfo.sampleCount                      = image->GetSampleCount();
             rtvCreateInfo.mipLevel                         = 0;
             rtvCreateInfo.mipLevelCount                    = 1;
             rtvCreateInfo.arrayLayer                       = 0;
@@ -412,7 +411,6 @@ Result RenderPass::CreateImagesAndViewsV3(const grfx::internal::RenderPassCreate
             rtvCreateInfo.pImage                           = image;
             rtvCreateInfo.imageViewType                    = image->GuessImageViewType();
             rtvCreateInfo.format                           = image->GetFormat();
-            rtvCreateInfo.sampleCount                      = image->GetSampleCount();
             rtvCreateInfo.mipLevel                         = 0;
             rtvCreateInfo.mipLevelCount                    = image->GetMipLevelCount();
             rtvCreateInfo.arrayLayer                       = 0;

--- a/src/ppx/grfx/vk/vk_render_pass.cpp
+++ b/src/ppx/grfx/vk/vk_render_pass.cpp
@@ -147,6 +147,17 @@ Result RenderPass::CreateRenderPass(const grfx::internal::RenderPassCreateInfo* 
     }
 
     if (!IsNull(pCreateInfo->pShadingRatePattern)) {
+        SampleCount shadingRateSampleCount = pCreateInfo->pShadingRatePattern->GetSampleCount();
+        for (uint32_t i = 0; i < rtvCount; ++i) {
+            PPX_ASSERT_MSG(
+                mRenderTargetViews[i]->GetSampleCount() == shadingRateSampleCount,
+                "The sample count for each render target must match the sample count of the shading rate pattern.");
+        }
+        if (hasDepthSencil) {
+            PPX_ASSERT_MSG(
+                mDepthStencilView->GetSampleCount() == shadingRateSampleCount,
+                "The sample count of the depth attachment must match the sample count of the shading rate pattern.");
+        }
         auto     modifiedCreateInfo = ToApi(pCreateInfo->pShadingRatePattern)->GetModifiedRenderPassCreateInfo(vkci);
         VkResult vkres              = vk::CreateRenderPass(
             ToApi(GetDevice())->GetVkDevice(),

--- a/src/test/vk_shading_rate_test.cpp
+++ b/src/test/vk_shading_rate_test.cpp
@@ -22,14 +22,22 @@ namespace ppx {
 namespace grfx {
 namespace vk {
 
+ShadingRateCapabilities CreateTestCapabilities()
+{
+    ShadingRateCapabilities capabilities = {SHADING_RATE_VRS};
+    capabilities.vrs.supportedRates.push_back({SAMPLE_COUNT_1 | SAMPLE_COUNT_4, {2, 2}});
+    capabilities.vrs.supportedRates.push_back({SAMPLE_COUNT_1 | SAMPLE_COUNT_4, {2, 1}});
+    capabilities.vrs.supportedRates.push_back({~0u, {1, 1}});
+    return capabilities;
+}
+
 TEST(VRSShadingRateEncoderTest, Only1x1)
 {
     ShadingRateCapabilities capabilities = {SHADING_RATE_VRS};
-    capabilities.vrs.supportedRateCount  = 1;
-    capabilities.vrs.supportedRates[0]   = {1, 1};
+    capabilities.vrs.supportedRates.push_back({~0u, {1, 1}});
 
     internal::VRSShadingRateEncoder encoder;
-    encoder.Initialize(capabilities);
+    encoder.Initialize(SAMPLE_COUNT_1, capabilities);
 
     EXPECT_EQ(encoder.EncodeFragmentSize(1, 1), 0);
     EXPECT_EQ(encoder.EncodeFragmentSize(1, 2), 0);
@@ -45,13 +53,12 @@ TEST(VRSShadingRateEncoderTest, Only1x1)
 TEST(VRSShadingRateEncoderTest, MultipleSizes)
 {
     ShadingRateCapabilities capabilities = {SHADING_RATE_VRS};
-    capabilities.vrs.supportedRateCount  = 3;
-    capabilities.vrs.supportedRates[0]   = {1, 2};
-    capabilities.vrs.supportedRates[1]   = {2, 1};
-    capabilities.vrs.supportedRates[2]   = {1, 1};
+    capabilities.vrs.supportedRates.push_back({~0u, {1, 2}});
+    capabilities.vrs.supportedRates.push_back({~0u, {2, 1}});
+    capabilities.vrs.supportedRates.push_back({~0u, {1, 1}});
 
     internal::VRSShadingRateEncoder encoder;
-    encoder.Initialize(capabilities);
+    encoder.Initialize(SAMPLE_COUNT_1, capabilities);
 
     EXPECT_EQ(encoder.EncodeFragmentSize(1, 1), 0);
     EXPECT_EQ(encoder.EncodeFragmentSize(1, 2), 1);
@@ -64,16 +71,30 @@ TEST(VRSShadingRateEncoderTest, MultipleSizes)
     EXPECT_EQ(encoder.EncodeFragmentSize(4, 4), 4);
 }
 
+TEST(VRSShadingRateEncoderTest, MultipleSampleCounts)
+{
+    ShadingRateCapabilities capabilities = {SHADING_RATE_VRS};
+    capabilities.vrs.supportedRates.push_back({SAMPLE_COUNT_1, {1, 2}});
+    capabilities.vrs.supportedRates.push_back({SAMPLE_COUNT_1, {2, 1}});
+    capabilities.vrs.supportedRates.push_back({~0u, {1, 1}});
+
+    internal::VRSShadingRateEncoder encoder;
+    encoder.Initialize(SAMPLE_COUNT_2, capabilities);
+
+    EXPECT_EQ(encoder.EncodeFragmentSize(1, 1), 0);
+    EXPECT_EQ(encoder.EncodeFragmentSize(1, 2), 0);
+    EXPECT_EQ(encoder.EncodeFragmentSize(2, 1), 0);
+}
+
 TEST(VRSShadingRateEncoderTest, EncodeFragmentDensity)
 {
     ShadingRateCapabilities capabilities = {SHADING_RATE_VRS};
-    capabilities.vrs.supportedRateCount  = 3;
-    capabilities.vrs.supportedRates[0]   = {1, 2};
-    capabilities.vrs.supportedRates[1]   = {2, 1};
-    capabilities.vrs.supportedRates[2]   = {1, 1};
+    capabilities.vrs.supportedRates.push_back({SAMPLE_COUNT_1, {1, 2}});
+    capabilities.vrs.supportedRates.push_back({SAMPLE_COUNT_1, {2, 1}});
+    capabilities.vrs.supportedRates.push_back({~0u, {1, 1}});
 
     internal::VRSShadingRateEncoder encoder;
-    encoder.Initialize(capabilities);
+    encoder.Initialize(SAMPLE_COUNT_1, capabilities);
 
     EXPECT_EQ(encoder.EncodeFragmentDensity(255, 255), 0);
     EXPECT_EQ(encoder.EncodeFragmentDensity(255, 127), 1);


### PR DESCRIPTION
The fourth of a series of CL that integrates the commits from:
https://github.com/bjoeris/bigwheels/tree/experimental-foveation
into BW main's branch.
The series has 4 CL, this is the last one that integrates the following commit

* Add multisample support for ShadingRatePattern.

Beside the foveation sample app, it also adds the following changes in BW infra:

* ShadingRate’s class add sample count properties, that queries from device
* Modifies gfx View classes to get the sample count from images
* Image class get samples count from createinfo struct
* ShadingRates unit test get modified to account for this changes
