### PR TITLE
Fix GLSL shader build rule in Android

### DIFF
--- a/cmake/ShaderCompile.cmake
+++ b/cmake/ShaderCompile.cmake
@@ -175,7 +175,7 @@ function(generate_rules_for_glsl_shader TARGET_NAME)
     if (PPX_ANDROID)
         # Place the generated files into build directory. They will be copied into the APK
         # assets folder (see build.gradle).
-        set(SHADER_OUTPUT_PATH "${PPX_DIR}/build_android/${PATH_PREFIX}/spv/${BASE_NAME}.${ARG_SHADER_STAGE}.spv")
+        set(SHADER_OUTPUT_PATH "${PPX_DIR}/build_android/${PATH_PREFIX}/spv/${BASE_NAME}.${ARG_STAGE}.spv")
     endif()
 
     add_custom_command(


### PR DESCRIPTION
Fix the cmake rule to build GLSL shaders on Android
I tested doing a local build on a Windows desktop using Android Studio