### PR TITLE
Support more platforms in Geometry death test

### DIFF
--- a/src/test/geometry_test.cpp
+++ b/src/test/geometry_test.cpp
@@ -68,7 +68,7 @@ TEST_P(GeometryDeathTest, AppendIndicesU32DiesIfIndexTypeIsNotU32)
     EXPECT_NE(geometry.GetIndexType(), grfx::INDEX_TYPE_UINT32);
 
     const std::array<uint32_t, 3> indices = {0, 1, 2};
-    ASSERT_DEATH(geometry.AppendIndicesU32(indices.size(), indices.data()), "Assertion.*failed");
+    ASSERT_DEATH(geometry.AppendIndicesU32(indices.size(), indices.data()), "");
 }
 
 INSTANTIATE_TEST_SUITE_P(GeometryDeathTest, GeometryDeathTest, testing::Values(grfx::INDEX_TYPE_UINT16, grfx::INDEX_TYPE_UNDEFINED), [](const testing::TestParamInfo<GeometryDeathTest::ParamType>& info) {


### PR DESCRIPTION
The assertion text varies based on platform. Since I care more about the assertion rather than the contents of the assertion, it makes sense to leave the matcher generic.

Fixes #496 