### PR TITLE
Fix validation error

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -187,7 +187,7 @@ void GraphicsBenchmarkApp::Config(ppx::ApplicationSettings& settings)
 #if defined(PPX_BUILD_XR)
     // XR specific settings
     settings.grfx.pacedFrameRate = 0;
-    settings.xr.enable           = false; // Change this to true to enable the XR mode
+    settings.xr.enable           = true; // Change this to true to enable the XR mode
 #endif
     settings.standardKnobsDefaultValue.enableMetrics        = true;
     settings.standardKnobsDefaultValue.overwriteMetricsFile = true;
@@ -1393,7 +1393,7 @@ ppx::Result GraphicsBenchmarkApp::CreateOffscreenFrame(OffscreenFrame& frame, gr
     frame = OffscreenFrame{width, height, colorFormat, depthFormat};
     {
         grfx::ImageCreateInfo colorCreateInfo   = grfx::ImageCreateInfo::RenderTarget2D(width, height, colorFormat);
-        colorCreateInfo.initialState            = grfx::RESOURCE_STATE_PRESENT;
+        colorCreateInfo.initialState            = grfx::RESOURCE_STATE_RENDER_TARGET;
         colorCreateInfo.usageFlags.bits.sampled = true;
         ppx::Result ppxres                      = GetDevice()->CreateImage(&colorCreateInfo, &frame.colorImage);
         if (ppxres != ppx::SUCCESS) {


### PR DESCRIPTION
*** VULKAN VALIDATION ERROR MESSAGE ***
Severity : ERROR
Type     : [VALIDATION]
Message  : Validation Error: [ VUID-VkImageMemoryBarrier-newLayout-parameter ] | MessageID = 0x43f5a56f | vkCmdPipelineBarrier(): pImageMemoryBarriers[0].newLayout (1000001002) requires the extensions VK_KHR_swapchain. The Vulkan spec states: newLayout must be a valid VkImageLayout value (https://vulkan.lunarg.com/doc/view/1.3.280.1/linux/1.3-extensions/vkspec.html#VUID-VkImageMemoryBarrier-newLayout-parameter)
