### PR TITLE
Testcase: Viewport (ALU) and Viewport (mem-fetch)

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -196,6 +196,14 @@ void GraphicsBenchmarkApp::InitKnobs()
     GetKnobManager().InitKnob(&pKnobDisablePsOutput, "disable-ps-output", false);
     pKnobDisablePsOutput->SetDisplayName("Disable PS output");
     pKnobDisablePsOutput->SetFlagDescription("Disable PS output.");
+
+    GetKnobManager().InitKnob(&pKnobViewportHeightScale, "viewport_height_scale", 0, kAvailableViewportScales);
+    pKnobViewportHeightScale->SetDisplayName("Scale viewport height");
+    pKnobViewportHeightScale->SetFlagDescription("Scale viewport height to 1, 1/2, 1/4");
+
+    GetKnobManager().InitKnob(&pKnobViewportWidthScale, "viewport_width_scale", 0, kAvailableViewportScales);
+    pKnobViewportWidthScale->SetDisplayName("Scale viewport width");
+    pKnobViewportWidthScale->SetFlagDescription("Scale viewport width to 1, 1/2, 1/4");
 }
 
 void GraphicsBenchmarkApp::Config(ppx::ApplicationSettings& settings)
@@ -1575,7 +1583,13 @@ void GraphicsBenchmarkApp::RecordCommandBuffer(PerFrame& frame, const RenderPass
     frame.cmd->WriteTimestamp(frame.timestampQuery, grfx::PIPELINE_STAGE_TOP_OF_PIPE_BIT, /* queryIndex = */ 0);
     if (!pRenderOffscreen->GetValue()) {
         frame.cmd->SetScissors(GetScissor());
-        frame.cmd->SetViewports(GetViewport());
+        grfx::Viewport    viewport     = GetViewport();
+        QuadViewportScale height_scale = pKnobViewportHeightScale->GetValue();
+        QuadViewportScale width_scale  = pKnobViewportWidthScale->GetValue();
+        viewport.height *= height_scale.scale;
+        viewport.width *= width_scale.scale;
+
+        frame.cmd->SetViewports(viewport);
     }
     else {
         uint32_t width  = mOffscreenFrame.back().width;

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -220,6 +220,17 @@ static constexpr std::array<std::pair<int, int>, 8 + 9> kVRPerEyeResolutions = {
     {3680, 3140}, // Vision Pro, estimation from Wikipedia
 }};
 
+struct QuadViewportScale
+{
+    float scale;
+};
+
+static constexpr std::array<DropdownEntry<QuadViewportScale>, 3> kAvailableViewportScales = {{
+    {"1", 1.0},    // No scale
+    {"1/2", 0.5},  // scale to 1/2
+    {"1/4", 0.25}, // scale to 1/4
+}};
+
 class GraphicsBenchmarkApp
     : public ppx::Application
 {
@@ -531,9 +542,11 @@ private:
     std::shared_ptr<KnobDropdown<grfx::Format>>        pFramebufferFormat;
     std::shared_ptr<KnobDropdown<std::pair<int, int>>> pResolution;
 
-    std::shared_ptr<KnobFlag<int>> pKnobAluCount;
-    std::shared_ptr<KnobFlag<int>> pKnobTextureCount;
-    std::shared_ptr<KnobCheckbox>  pKnobDisablePsOutput;
+    std::shared_ptr<KnobFlag<int>>                   pKnobAluCount;
+    std::shared_ptr<KnobFlag<int>>                   pKnobTextureCount;
+    std::shared_ptr<KnobCheckbox>                    pKnobDisablePsOutput;
+    std::shared_ptr<KnobDropdown<QuadViewportScale>> pKnobViewportHeightScale;
+    std::shared_ptr<KnobDropdown<QuadViewportScale>> pKnobViewportWidthScale;
 
 private:
     // =====================================================================


### PR DESCRIPTION
Added new knob `viewport_height_scale` and `viewport_width_scale`, avaiable values are "1", "1/2", "1/4".

Full knob list 
```
{
    "deterministic": true,
    "enable-skybox": false,
    "enable-spheres": false,
    "enable-metrics": false,
    "fullscreen-quads-count": 1,
    "fullscreen-quads-type": "Solid_Color",  // "Texture" for mem-fetch
    "fullscreen-quads-single-renderpass": true,
    "vs-alu-instruction-count": 100,
    "texture-count": 2,
    "disable-ps-output": false,
    "fullscreen-quads-texture-path": "benchmarks/textures/tiger_2364x2880.jpg",
    "viewport_height_scale": "1/2",
    "viewport_width_scale": "1/4"
}
```
