### PR TITLE
Testcase: Alpha blending

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -193,10 +193,6 @@ void GraphicsBenchmarkApp::InitKnobs()
     pKnobTextureCount->SetDisplayName("Number of texture to load in the shader");
     pKnobTextureCount->SetFlagDescription("Select the number of texture to load in the shader.");
 
-    GetKnobManager().InitKnob(&pKnobDisablePsOutput, "disable-ps-output", false);
-    pKnobDisablePsOutput->SetDisplayName("Disable PS output");
-    pKnobDisablePsOutput->SetFlagDescription("Disable PS output.");
-
     GetKnobManager().InitKnob(&pKnobViewportHeightScale, "viewport_height_scale", 0, kAvailableViewportScales);
     pKnobViewportHeightScale->SetDisplayName("Scale viewport height");
     pKnobViewportHeightScale->SetFlagDescription("Scale viewport height to 1, 1/2, 1/4");
@@ -204,6 +200,10 @@ void GraphicsBenchmarkApp::InitKnobs()
     GetKnobManager().InitKnob(&pKnobViewportWidthScale, "viewport_width_scale", 0, kAvailableViewportScales);
     pKnobViewportWidthScale->SetDisplayName("Scale viewport width");
     pKnobViewportWidthScale->SetFlagDescription("Scale viewport width to 1, 1/2, 1/4");
+
+    GetKnobManager().InitKnob(&pKnobQuadBlendMode, "quad_blend_mode", 0, kQuadBlendModes);
+    pKnobQuadBlendMode->SetDisplayName("Blend mode for quad");
+    pKnobQuadBlendMode->SetFlagDescription("Bend mode for quad to none, alpha, disable_output");
 }
 
 void GraphicsBenchmarkApp::Config(ppx::ApplicationSettings& settings)
@@ -787,7 +787,7 @@ Result GraphicsBenchmarkApp::CompilePipeline(const QuadPipelineKey& key)
     gpCreateInfo.frontFace                          = grfx::FRONT_FACE_CW;
     gpCreateInfo.depthReadEnable                    = false;
     gpCreateInfo.depthWriteEnable                   = false;
-    gpCreateInfo.blendModes[0]                      = pKnobDisablePsOutput->GetValue() ? grfx::BLEND_MODE_DISABLE_OUTPUT : grfx::BLEND_MODE_NONE;
+    gpCreateInfo.blendModes[0]                      = pKnobQuadBlendMode->GetValue();
     gpCreateInfo.outputState.renderTargetCount      = 1;
     gpCreateInfo.outputState.renderTargetFormats[0] = key.renderFormat;
     gpCreateInfo.outputState.depthStencilFormat     = GetSwapchain()->GetDepthFormat();

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -19,6 +19,7 @@
 #include "MultiDimensionalIndexer.h"
 
 #include "ppx/grfx/grfx_config.h"
+#include "ppx/grfx/grfx_enums.h"
 #include "ppx/grfx/grfx_format.h"
 #include "ppx/knob.h"
 #include "ppx/math_config.h"
@@ -229,6 +230,12 @@ static constexpr std::array<DropdownEntry<QuadViewportScale>, 3> kAvailableViewp
     {"1", 1.0},    // No scale
     {"1/2", 0.5},  // scale to 1/2
     {"1/4", 0.25}, // scale to 1/4
+}};
+
+static constexpr std::array<DropdownEntry<grfx::BlendMode>, 3> kQuadBlendModes = {{
+    {"none", grfx::BLEND_MODE_NONE},
+    {"alpha", grfx::BLEND_MODE_ALPHA},
+    {"disable_output", grfx::BLEND_MODE_DISABLE_OUTPUT},
 }};
 
 class GraphicsBenchmarkApp
@@ -544,9 +551,9 @@ private:
 
     std::shared_ptr<KnobFlag<int>>                   pKnobAluCount;
     std::shared_ptr<KnobFlag<int>>                   pKnobTextureCount;
-    std::shared_ptr<KnobCheckbox>                    pKnobDisablePsOutput;
     std::shared_ptr<KnobDropdown<QuadViewportScale>> pKnobViewportHeightScale;
     std::shared_ptr<KnobDropdown<QuadViewportScale>> pKnobViewportWidthScale;
+    std::shared_ptr<KnobDropdown<grfx::BlendMode>>   pKnobQuadBlendMode;
 
 private:
     // =====================================================================


### PR DESCRIPTION
Added new knob `quad_blend_mode` with value "none", "alpha", "disable_output". This also replaced the previews knob `disable-ps-output`, which now can be set as `"quad_blend_mode":"disable_output"`


```
{
    "deterministic": true,
    "enable-skybox": false,
    "enable-spheres": false,
    "enable-metrics": false,
    "fullscreen-quads-count": 1,
    "fullscreen-quads-type": "Texture",
    "fullscreen-quads-single-renderpass": true,
    "vs-alu-instruction-count": 100,
    "texture-count": 2,
    "disable-ps-output": false,
    "fullscreen-quads-texture-path": "benchmarks/textures/tiger_2364x2880.jpg",
    "viewport_height_scale": "1",
    "viewport_width_scale": "1",
    "quad_blend_mode": "alpha"
}
```