### PR TITLE
Testcase: Vertex Fetch

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -221,7 +221,7 @@ void GraphicsBenchmarkApp::Config(ppx::ApplicationSettings& settings)
 #if defined(PPX_ANDROID)
     settings.xr.enable = true;
 #else
-    settings.xr.enable = false; // Change this to true to enable the XR mode
+    settings.xr.enable = false; // Change this to true to enable the XR mode on PC.
 #endif
 #endif
     settings.standardKnobsDefaultValue.enableMetrics        = true;
@@ -614,15 +614,14 @@ void GraphicsBenchmarkApp::SetupSphereMeshes()
         }
     }
 
-    const uint32_t requiredSphereCount = std::max<uint32_t>(pSphereInstanceCount->GetValue(), kDefaultSphereInstanceCount);
-    const uint32_t initSphereCount     = std::min<uint32_t>(kMaxSphereInstanceCount, 2 * std::max(requiredSphereCount, mInitializedSpheres));
+    const uint32_t initSphereCount = std::min<uint32_t>(kMaxSphereInstanceCount, pSphereInstanceCount->GetValue());
 
     // Create the meshes
     OrderedGrid grid(initSphereCount, kSeed);
     uint32_t    meshIndex = 0;
     for (const auto& lod : kAvailableLODs) {
         PPX_LOG_INFO("LOD: " << lod.name);
-        SphereMesh sphereMesh(/* radius = */ 1, lod.value.longitudeSegments, lod.value.latitudeSegments);
+        SphereMesh sphereMesh(/* radius = */ 1, lod.value.longitudeSegments, lod.value.latitudeSegments, GetSettings()->xr.enable);
         sphereMesh.ApplyGrid(grid);
         // Create a giant vertex buffer for each vb type to accommodate all copies of the sphere mesh
         PPX_CHECKED_CALL(grfx_util::CreateMeshFromGeometry(GetGraphicsQueue(), sphereMesh.GetLowPrecisionInterleaved(), &mSphereMeshes[meshIndex++]));
@@ -1573,8 +1572,9 @@ ppx::grfx::Format GraphicsBenchmarkApp::RenderFormat()
 void GraphicsBenchmarkApp::CreateColorsForDrawCalls()
 {
     // Create colors randomly.
-    mColorsForDrawCalls.resize(kMaxSphereInstanceCount);
-    for (size_t i = 0; i < kMaxSphereInstanceCount; i++) {
+    uint32_t sphereCount = pSphereInstanceCount->GetValue();
+    mColorsForDrawCalls.resize(sphereCount);
+    for (size_t i = 0; i < sphereCount; i++) {
         mColorsForDrawCalls[i] = float4(mRandom.Float(), mRandom.Float(), mRandom.Float(), 0.5f);
     }
 }

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -32,7 +32,7 @@
 #include <unordered_map>
 
 static constexpr uint32_t kMaxSphereInstanceCount     = 5000;
-static constexpr uint32_t kDefaultSphereInstanceCount = 50;
+static constexpr uint32_t kDefaultSphereInstanceCount = 1;
 static constexpr uint32_t kSeed                       = 89977;
 static constexpr uint32_t kMaxFullscreenQuadsCount    = 1000;
 static constexpr uint32_t kMaxTextureCount            = 10;

--- a/benchmarks/graphics_pipeline/SphereMesh.cpp
+++ b/benchmarks/graphics_pipeline/SphereMesh.cpp
@@ -38,20 +38,21 @@ OrderedGrid::OrderedGrid(uint32_t count, uint32_t randomSeed)
     Shuffle(mOrderedPointIndices.begin(), mOrderedPointIndices.end(), std::mt19937(randomSeed));
 }
 
-float4x4 OrderedGrid::GetModelMatrix(uint32_t sphereIndex) const
+float4x4 OrderedGrid::GetModelMatrix(uint32_t sphereIndex, bool isXR) const
 {
     uint32_t id = mOrderedPointIndices[sphereIndex];
     float    x  = static_cast<float>((id % (mSizeX * mSizeY)) / mSizeY);
     float    y  = static_cast<float>(id % mSizeY);
     float    z  = static_cast<float>(id / (mSizeX * mSizeY));
 
-    // Put it in the center of the scree
+    // Put it in the center of the screen.
     x -= static_cast<float>(mSizeX - 1) / 2.0;
     y -= static_cast<float>(mSizeY - 1) / 2.0;
     z += static_cast<float>(mSizeZ);
-#if defined(PPX_ANDROID)
-    z *= -1.0;
-#endif
+    if (isXR) {
+        z *= -1.0;
+    }
+
     return glm::translate(float3(x * mStep, y * mStep, z * mStep));
 }
 
@@ -209,7 +210,7 @@ void SphereMesh::RepeatGeometryNonPositionVertexData(const Geometry& srcGeom, Ve
 
 void SphereMesh::WriteSpherePosition(const OrderedGrid& grid, uint32_t sphereIndex)
 {
-    float4x4 modelMatrix = grid.GetModelMatrix(sphereIndex);
+    float4x4 modelMatrix = grid.GetModelMatrix(sphereIndex, IsXR());
 
     for (uint32_t j = 0; j < mSingleSphereVertexCount; ++j) {
         TriMeshVertexData vertexData = {};

--- a/benchmarks/graphics_pipeline/SphereMesh.h
+++ b/benchmarks/graphics_pipeline/SphereMesh.h
@@ -34,7 +34,7 @@ public:
     uint32_t GetCount() const { return static_cast<uint32_t>(mOrderedPointIndices.size()); }
 
     // Get model matrix that can be applied to move a model space object to this point
-    float4x4 GetModelMatrix(uint32_t pointIndex) const;
+    float4x4 GetModelMatrix(uint32_t pointIndex, bool isXR) const;
 
 private:
     uint32_t              mSizeX;
@@ -83,11 +83,12 @@ public:
     };
 
     // Creates a SphereMesh and populates info for one sphere
-    SphereMesh(float radius, uint32_t longitudeSegments, uint32_t latitudeSegments)
+    SphereMesh(float radius, uint32_t longitudeSegments, uint32_t latitudeSegments, bool isXR)
     {
         mSingleSphereMesh        = TriMesh::CreateSphere(radius, longitudeSegments, latitudeSegments, TriMeshOptions().Indices().TexCoords().Normals().Tangents());
         mSingleSphereVertexCount = mSingleSphereMesh.GetCountPositions();
         mSingleSphereTriCount    = mSingleSphereMesh.GetCountTriangles();
+        mIsXR                    = isXR;
 
         PPX_LOG_INFO("Creating SphereMesh:");
         PPX_LOG_INFO("  Sphere vertex count: " << mSingleSphereVertexCount << " | triangle count: " << mSingleSphereTriCount);
@@ -101,6 +102,8 @@ public:
     const Geometry* GetLowPrecisionPositionPlanar() const { return &mLowPlanar; }
     const Geometry* GetHighPrecisionInterleaved() const { return &mHighInterleaved; }
     const Geometry* GetHighPrecisionPositionPlanar() const { return &mHighPlanar; }
+
+    bool IsXR() const { return mIsXR; }
 
 private:
     // Create all single sphere and full geometries
@@ -143,6 +146,8 @@ private:
     Geometry mLowPlanar;
     Geometry mHighInterleaved;
     Geometry mHighPlanar;
+
+    bool mIsXR;
 };
 
 // Overwrite the position data within a position buffer with vtx.position, at vertex elementIndex only


### PR DESCRIPTION
`sphere-count` and `drawcall-count` are used to define the number of sphere and drawcalls.
```
    "deterministic": true,
    "enable-skybox": false,
    "enable-spheres": true,
    "enable-metrics": false,
    "vs-alu-instruction-count": 1,
    "texture-count": 1,
    "fullscreen-quads-texture-path": "benchmarks/textures/tiger_2364x2880.jpg",
    "viewport_height_scale": "1",
    "viewport_width_scale": "1",
    "quad_blend_mode": "none",
    "sphere-count": 125,
    "drawcall-count": 1
}
```