### PR TITLE
vk: fix sync masks for split compute/graphics.

### DIFF
--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -499,6 +499,7 @@ Result Device::CreateQueues(const grfx::DeviceCreateInfo* pCreateInfo)
         uint32_t queueFamilyIndex = ToApi(pCreateInfo->pGpu)->GetGraphicsQueueFamilyIndex();
         for (uint32_t queueIndex = 0; queueIndex < pCreateInfo->graphicsQueueCount; ++queueIndex) {
             grfx::internal::QueueCreateInfo queueCreateInfo = {};
+            queueCreateInfo.commandType                     = grfx::COMMAND_TYPE_GRAPHICS;
             queueCreateInfo.queueFamilyIndex                = queueFamilyIndex;
             queueCreateInfo.queueIndex                      = queueIndex;
 
@@ -514,6 +515,7 @@ Result Device::CreateQueues(const grfx::DeviceCreateInfo* pCreateInfo)
         uint32_t queueFamilyIndex = ToApi(pCreateInfo->pGpu)->GetComputeQueueFamilyIndex();
         for (uint32_t queueIndex = 0; queueIndex < pCreateInfo->computeQueueCount; ++queueIndex) {
             grfx::internal::QueueCreateInfo queueCreateInfo = {};
+            queueCreateInfo.commandType                     = grfx::COMMAND_TYPE_COMPUTE;
             queueCreateInfo.queueFamilyIndex                = queueFamilyIndex;
             queueCreateInfo.queueIndex                      = queueIndex;
 
@@ -529,6 +531,7 @@ Result Device::CreateQueues(const grfx::DeviceCreateInfo* pCreateInfo)
         uint32_t queueFamilyIndex = ToApi(pCreateInfo->pGpu)->GetTransferQueueFamilyIndex();
         for (uint32_t queueIndex = 0; queueIndex < pCreateInfo->transferQueueCount; ++queueIndex) {
             grfx::internal::QueueCreateInfo queueCreateInfo = {};
+            queueCreateInfo.commandType                     = grfx::COMMAND_TYPE_TRANSFER;
             queueCreateInfo.queueFamilyIndex                = queueFamilyIndex;
             queueCreateInfo.queueIndex                      = queueIndex;
 


### PR DESCRIPTION
When the graphics queue was distinct from the compute queue, access & stage bits could be incorrectly computed. This was caused by the command type not being linked to each queue, and some invalid condition in an utility function designed to derive access & stage bits from an access type.

Tested on my local machine, all sampled except one (push_descriptor) passes. This failure already exists on main.