### PR TITLE
Add UINT8 index buffer support to Geometry

### DIFF
--- a/include/ppx/geometry.h
+++ b/include/ppx/geometry.h
@@ -60,13 +60,16 @@ struct GeometryCreateInfo
     grfx::VertexBinding           vertexBindings[PPX_MAX_VERTEX_BINDINGS] = {};
     grfx::PrimitiveTopology       primitiveTopology                       = grfx::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
-    // Creates a create info objects with a UINT16 or UINT32 index
+    // Creates a create info objects with UINT8, UINT16 or UINT32 index
     // type and position vertex attribute.
     //
+    static GeometryCreateInfo InterleavedU8(grfx::Format format = grfx::FORMAT_R32G32B32_FLOAT);
     static GeometryCreateInfo InterleavedU16(grfx::Format format = grfx::FORMAT_R32G32B32_FLOAT);
     static GeometryCreateInfo InterleavedU32(grfx::Format format = grfx::FORMAT_R32G32B32_FLOAT);
+    static GeometryCreateInfo PlanarU8(grfx::Format format = grfx::FORMAT_R32G32B32_FLOAT);
     static GeometryCreateInfo PlanarU16(grfx::Format format = grfx::FORMAT_R32G32B32_FLOAT);
     static GeometryCreateInfo PlanarU32(grfx::Format format = grfx::FORMAT_R32G32B32_FLOAT);
+    static GeometryCreateInfo PositionPlanarU8(grfx::Format format = grfx::FORMAT_R32G32B32_FLOAT);
     static GeometryCreateInfo PositionPlanarU16(grfx::Format format = grfx::FORMAT_R32G32B32_FLOAT);
     static GeometryCreateInfo PositionPlanarU32(grfx::Format format = grfx::FORMAT_R32G32B32_FLOAT);
 
@@ -77,6 +80,7 @@ struct GeometryCreateInfo
     static GeometryCreateInfo PositionPlanar();
 
     GeometryCreateInfo& IndexType(grfx::IndexType indexType_);
+    GeometryCreateInfo& IndexTypeU8();
     GeometryCreateInfo& IndexTypeU16();
     GeometryCreateInfo& IndexTypeU32();
 
@@ -242,6 +246,7 @@ public:
     // Appends single index, triangle, or edge vertex indices to index buffer
     //
     // Will cast to uint16_t if geometry index type is UINT16.
+    // Will cast to uint8_t if geometry index type is UINT8.
     // NOOP if index type is UNDEFINED (geometry does not have index data).
     //
     void AppendIndex(uint32_t idx);

--- a/include/ppx/grfx/grfx_enums.h
+++ b/include/ppx/grfx/grfx_enums.h
@@ -322,6 +322,9 @@ enum IndexType
     INDEX_TYPE_UNDEFINED = 0,
     INDEX_TYPE_UINT16    = 1,
     INDEX_TYPE_UINT32    = 2,
+    // Vulkan: UINT8 requires VK_EXT_index_type_uint8
+    // DX12: UINT8 is not supported
+    INDEX_TYPE_UINT8     = 3,
 };
 
 enum LogicOp

--- a/include/ppx/grfx/grfx_enums.h
+++ b/include/ppx/grfx/grfx_enums.h
@@ -324,7 +324,7 @@ enum IndexType
     INDEX_TYPE_UINT32    = 2,
     // Vulkan: UINT8 requires VK_EXT_index_type_uint8
     // DX12: UINT8 is not supported
-    INDEX_TYPE_UINT8     = 3,
+    INDEX_TYPE_UINT8 = 3,
 };
 
 enum LogicOp

--- a/src/ppx/geometry.cpp
+++ b/src/ppx/geometry.cpp
@@ -206,6 +206,7 @@ public:
         const uint32_t vertexBindingCount = this->GetVertexBindingCount(pGeom);
         if (vertexBindingCount != 1) {
             PPX_ASSERT_MSG(false, "interleaved layout must have 1 binding");
+            return false;
         }
         return true;
     }
@@ -304,6 +305,7 @@ public:
         const uint32_t vertexBindingCount = this->GetVertexBindingCount(pGeom);
         if (vertexBindingCount != 2) {
             PPX_ASSERT_MSG(false, "position planar layout must have 2 bindings");
+            return false;
         }
         return true;
     }
@@ -413,6 +415,16 @@ static VertexDataProcessorPositionPlanar<TriMeshVertexDataCompressed> sVDProcess
 // -------------------------------------------------------------------------------------------------
 // GeometryCreateInfo
 // -------------------------------------------------------------------------------------------------
+GeometryCreateInfo GeometryCreateInfo::InterleavedU8(grfx::Format format)
+{
+    GeometryCreateInfo ci    = {};
+    ci.vertexAttributeLayout = GEOMETRY_VERTEX_ATTRIBUTE_LAYOUT_INTERLEAVED;
+    ci.indexType             = grfx::INDEX_TYPE_UINT8;
+    ci.vertexBindingCount    = 1; // Interleave attribute layout always has 1 vertex binding
+    ci.AddPosition(format);
+    return ci;
+}
+
 GeometryCreateInfo GeometryCreateInfo::InterleavedU16(grfx::Format format)
 {
     GeometryCreateInfo ci    = {};
@@ -433,6 +445,15 @@ GeometryCreateInfo GeometryCreateInfo::InterleavedU32(grfx::Format format)
     return ci;
 }
 
+GeometryCreateInfo GeometryCreateInfo::PlanarU8(grfx::Format format)
+{
+    GeometryCreateInfo ci    = {};
+    ci.vertexAttributeLayout = GEOMETRY_VERTEX_ATTRIBUTE_LAYOUT_PLANAR;
+    ci.indexType             = grfx::INDEX_TYPE_UINT8;
+    ci.AddPosition(format);
+    return ci;
+}
+
 GeometryCreateInfo GeometryCreateInfo::PlanarU16(grfx::Format format)
 {
     GeometryCreateInfo ci    = {};
@@ -447,6 +468,15 @@ GeometryCreateInfo GeometryCreateInfo::PlanarU32(grfx::Format format)
     GeometryCreateInfo ci    = {};
     ci.vertexAttributeLayout = GEOMETRY_VERTEX_ATTRIBUTE_LAYOUT_PLANAR;
     ci.indexType             = grfx::INDEX_TYPE_UINT32;
+    ci.AddPosition(format);
+    return ci;
+}
+
+GeometryCreateInfo GeometryCreateInfo::PositionPlanarU8(grfx::Format format)
+{
+    GeometryCreateInfo ci    = {};
+    ci.vertexAttributeLayout = GEOMETRY_VERTEX_ATTRIBUTE_LAYOUT_POSITION_PLANAR;
+    ci.indexType             = grfx::INDEX_TYPE_UINT8;
     ci.AddPosition(format);
     return ci;
 }
@@ -501,6 +531,11 @@ GeometryCreateInfo& GeometryCreateInfo::IndexType(grfx::IndexType indexType_)
 {
     indexType = indexType_;
     return *this;
+}
+
+GeometryCreateInfo& GeometryCreateInfo::IndexTypeU8()
+{
+    return IndexType(grfx::INDEX_TYPE_UINT8);
 }
 
 GeometryCreateInfo& GeometryCreateInfo::IndexTypeU16()
@@ -676,20 +711,6 @@ Result Geometry::Create(const GeometryCreateInfo& createInfo, Geometry* pGeometr
     if (createInfo.primitiveTopology != grfx::PRIMITIVE_TOPOLOGY_TRIANGLE_LIST) {
         PPX_ASSERT_MSG(false, "only triangle list is supported");
         return ppx::ERROR_INVALID_CREATE_ARGUMENT;
-    }
-
-    if (createInfo.indexType != grfx::INDEX_TYPE_UNDEFINED) {
-        uint32_t elementSize = 0;
-        if (createInfo.indexType == grfx::INDEX_TYPE_UINT16) {
-            elementSize = sizeof(uint16_t);
-        }
-        else if (createInfo.indexType == grfx::INDEX_TYPE_UINT32) {
-            elementSize = sizeof(uint32_t);
-        }
-        else {
-            PPX_ASSERT_MSG(false, "invalid index type");
-            return ppx::ERROR_INVALID_CREATE_ARGUMENT;
-        }
     }
 
     if (createInfo.vertexBindingCount == 0) {
@@ -1091,6 +1112,9 @@ void Geometry::AppendIndex(uint32_t idx)
     else if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT32) {
         mIndexBuffer.Append(idx);
     }
+    else if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT8) {
+        mIndexBuffer.Append(static_cast<uint8_t>(idx));
+    }
 }
 
 void Geometry::AppendIndicesTriangle(uint32_t idx0, uint32_t idx1, uint32_t idx2)
@@ -1105,6 +1129,11 @@ void Geometry::AppendIndicesTriangle(uint32_t idx0, uint32_t idx1, uint32_t idx2
         mIndexBuffer.Append(idx1);
         mIndexBuffer.Append(idx2);
     }
+    else if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT8) {
+        mIndexBuffer.Append(static_cast<uint8_t>(idx0));
+        mIndexBuffer.Append(static_cast<uint8_t>(idx1));
+        mIndexBuffer.Append(static_cast<uint8_t>(idx2));
+    }
 }
 
 void Geometry::AppendIndicesEdge(uint32_t idx0, uint32_t idx1)
@@ -1116,6 +1145,10 @@ void Geometry::AppendIndicesEdge(uint32_t idx0, uint32_t idx1)
     else if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT32) {
         mIndexBuffer.Append(idx0);
         mIndexBuffer.Append(idx1);
+    }
+    else if (mCreateInfo.indexType == grfx::INDEX_TYPE_UINT8) {
+        mIndexBuffer.Append(static_cast<uint8_t>(idx0));
+        mIndexBuffer.Append(static_cast<uint8_t>(idx1));
     }
 }
 

--- a/src/ppx/grfx/grfx_util.cpp
+++ b/src/ppx/grfx/grfx_util.cpp
@@ -97,6 +97,7 @@ const char* ToString(grfx::IndexType value)
         case grfx::INDEX_TYPE_UNDEFINED: return "INDEX_TYPE_UNDEFINED";
         case grfx::INDEX_TYPE_UINT16: return "INDEX_TYPE_UINT16";
         case grfx::INDEX_TYPE_UINT32: return "INDEX_TYPE_UINT32";
+        case grfx::INDEX_TYPE_UINT8: return "INDEX_TYPE_UINT8";
     }
     return "<unknown grfx::IndexType>";
 }
@@ -108,6 +109,7 @@ uint32_t IndexTypeSize(grfx::IndexType value)
         default: break;
         case grfx::INDEX_TYPE_UINT16: return sizeof(uint16_t); break;
         case grfx::INDEX_TYPE_UINT32: return sizeof(uint32_t); break;
+        case grfx::INDEX_TYPE_UINT8:  return sizeof(uint8_t);  break;
     }
     // clang-format on
     return 0;

--- a/src/ppx/grfx/vk/vk_util.cpp
+++ b/src/ppx/grfx/vk/vk_util.cpp
@@ -614,6 +614,7 @@ VkIndexType ToVkIndexType(grfx::IndexType value)
         default: break;
         case grfx::INDEX_TYPE_UINT16 : return VK_INDEX_TYPE_UINT16; break;
         case grfx::INDEX_TYPE_UINT32 : return VK_INDEX_TYPE_UINT32; break;
+        case grfx::INDEX_TYPE_UINT8  : return VK_INDEX_TYPE_UINT8_EXT; break;
     }
     // clang-format on
     return ppx::InvalidValue<VkIndexType>();

--- a/src/ppx/tri_mesh.cpp
+++ b/src/ppx/tri_mesh.cpp
@@ -28,6 +28,8 @@ TriMesh::TriMesh()
 TriMesh::TriMesh(grfx::IndexType indexType)
     : mIndexType(indexType)
 {
+    // TODO: #514 - Remove assert when UINT8 is supported
+    PPX_ASSERT_MSG(mIndexType != grfx::INDEX_TYPE_UINT8, "INDEX_TYPE_UINT8 unsupported in TriMesh");
 }
 
 TriMesh::TriMesh(TriMeshAttributeDim texCoordDim)
@@ -38,6 +40,8 @@ TriMesh::TriMesh(TriMeshAttributeDim texCoordDim)
 TriMesh::TriMesh(grfx::IndexType indexType, TriMeshAttributeDim texCoordDim)
     : mIndexType(indexType), mTexCoordDim(texCoordDim)
 {
+    // TODO: #514 - Remove assert when UINT8 is supported
+    PPX_ASSERT_MSG(mIndexType != grfx::INDEX_TYPE_UINT8, "INDEX_TYPE_UINT8 unsupported in TriMesh");
 }
 
 TriMesh::~TriMesh()

--- a/src/ppx/wire_mesh.cpp
+++ b/src/ppx/wire_mesh.cpp
@@ -25,6 +25,8 @@ WireMesh::WireMesh()
 WireMesh::WireMesh(grfx::IndexType indexType)
     : mIndexType(indexType)
 {
+    // TODO: #514 - Remove assert when UINT8 is supported
+    PPX_ASSERT_MSG(mIndexType != grfx::INDEX_TYPE_UINT8, "INDEX_TYPE_UINT8 unsupported in WireMesh");
 }
 
 WireMesh::~WireMesh()

--- a/src/test/geometry_test.cpp
+++ b/src/test/geometry_test.cpp
@@ -97,7 +97,7 @@ TEST_P(GeometryDeathTest, AppendIndicesU32DiesIfIndexTypeIsNotU32)
     ASSERT_DEATH(geometry.AppendIndicesU32(indices.size(), indices.data()), "");
 }
 
-INSTANTIATE_TEST_SUITE_P(GeometryDeathTest, GeometryDeathTest, testing::Values(grfx::INDEX_TYPE_UINT16, grfx::INDEX_TYPE_UNDEFINED), [](const testing::TestParamInfo<GeometryDeathTest::ParamType>& info) {
+INSTANTIATE_TEST_SUITE_P(GeometryDeathTest, GeometryDeathTest, testing::Values(grfx::INDEX_TYPE_UINT16, grfx::INDEX_TYPE_UNDEFINED, grfx::INDEX_TYPE_UINT8), [](const testing::TestParamInfo<GeometryDeathTest::ParamType>& info) {
     return ToString(info.param);
 });
 #endif
@@ -214,6 +214,44 @@ TEST(GeometryUndefinedIndexTest, AppendIndicesEdgeDoesNothing)
     EXPECT_EQ(geometry.GetIndexCount(), 0);
     ASSERT_THAT(geometry.GetIndexBuffer(), NotNull());
     EXPECT_THAT(*geometry.GetIndexBuffer(), BufferIsEmpty());
+}
+
+TEST(GeometryUint8IndexTest, AppendIndexPacksDataAsUint8)
+{
+    Geometry geometry;
+    EXPECT_EQ(Geometry::Create(GeometryCreateInfo{}.IndexType(grfx::INDEX_TYPE_UINT8).AddPosition(), &geometry), ppx::SUCCESS);
+    EXPECT_EQ(geometry.GetIndexType(), grfx::INDEX_TYPE_UINT8);
+
+    geometry.AppendIndex(0);
+    geometry.AppendIndex(1);
+    geometry.AppendIndex(2);
+    EXPECT_EQ(geometry.GetIndexCount(), 3);
+    ASSERT_THAT(geometry.GetIndexBuffer(), NotNull());
+    EXPECT_THAT(*geometry.GetIndexBuffer(), BufferEq(std::vector<uint8_t>({0, 1, 2})));
+}
+
+TEST(GeometryUint8IndexTest, AppendIndicesTrianglePacksDataAsUint8)
+{
+    Geometry geometry;
+    EXPECT_EQ(Geometry::Create(GeometryCreateInfo{}.IndexType(grfx::INDEX_TYPE_UINT8).AddPosition(), &geometry), ppx::SUCCESS);
+    EXPECT_EQ(geometry.GetIndexType(), grfx::INDEX_TYPE_UINT8);
+
+    geometry.AppendIndicesTriangle(0, 1, 2);
+    EXPECT_EQ(geometry.GetIndexCount(), 3);
+    ASSERT_THAT(geometry.GetIndexBuffer(), NotNull());
+    EXPECT_THAT(*geometry.GetIndexBuffer(), BufferEq(std::vector<uint8_t>({0, 1, 2})));
+}
+
+TEST(GeometryUint8IndexTest, AppendIndicesEdgePacksDataAsUint8)
+{
+    Geometry geometry;
+    EXPECT_EQ(Geometry::Create(GeometryCreateInfo{}.IndexType(grfx::INDEX_TYPE_UINT8).AddPosition(), &geometry), ppx::SUCCESS);
+    EXPECT_EQ(geometry.GetIndexType(), grfx::INDEX_TYPE_UINT8);
+
+    geometry.AppendIndicesEdge(0, 1);
+    EXPECT_EQ(geometry.GetIndexCount(), 2);
+    ASSERT_THAT(geometry.GetIndexBuffer(), NotNull());
+    EXPECT_THAT(*geometry.GetIndexBuffer(), BufferEq(std::vector<uint8_t>({0, 1})));
 }
 
 } // namespace


### PR DESCRIPTION
Add support for creating buffers that the GPU can accept if IndexTypeUint8Supported(). The client must decide which index type to use depending on the supported features of the API and GPU; it is possible to create a Uint8 buffer which i.e. is not accepted by DX12.

This is required for #453