### PR TITLE
Revert "Draw half screen triangle instead of full screen quad (#519)"

### DIFF
--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -650,8 +650,8 @@ void GraphicsBenchmarkApp::SetupFullscreenQuadsMeshes()
         // one large triangle covering entire screen area
         // position
         -1.0f, -1.0f, 0.0f,
-        -1.0f,  1.0f, 0.0f,
-         1.0f, -1.0f, 0.0f,
+        -1.0f,  3.0f, 0.0f,
+         3.0f, -1.0f, 0.0f,
     };
     // clang-format on
     uint32_t dataSize = SizeInBytesU32(vertexData);


### PR DESCRIPTION
This reverts commit 2e3639dc00902b93b520f17d0fbe42ea20edd9f5.