### PR TITLE
Remove unused GLTF materials define

### DIFF
--- a/src/ppx/scene/scene_gltf_loader.cpp
+++ b/src/ppx/scene/scene_gltf_loader.cpp
@@ -23,8 +23,6 @@
 #undef LoadImage
 #endif
 
-#define KHR_MATERIALS_UNLIT_EXTENSION_NAME "KHR_materials_unlit"
-
 namespace ppx {
 namespace scene {
 


### PR DESCRIPTION
The unlit material extension name is unused. This is probably because cgltf already looks for this extension and exposes it as `cgltf_material::unlit`; we don't need to look for the extension ourselves.