### PR TITLE
fix sanitize-enum finding

### DIFF
--- a/include/ppx/grfx/grfx_enums.h
+++ b/include/ppx/grfx/grfx_enums.h
@@ -507,8 +507,9 @@ enum VendorId
 
 enum VertexInputRate
 {
-    VERTEX_INPUT_RATE_VERTEX   = 0,
-    VERETX_INPUT_RATE_INSTANCE = 1,
+    INVALID_VERTEX_INPUT_RATE = 0,
+    VERTEX_INPUT_RATE_VERTEX,
+    VERETX_INPUT_RATE_INSTANCE,
 };
 
 enum VertexSemantic

--- a/include/ppx/grfx/grfx_helper.h
+++ b/include/ppx/grfx/grfx_helper.h
@@ -486,11 +486,9 @@ public:
     VertexBinding& operator+=(const grfx::VertexAttribute& rhs);
 
 private:
-    static const grfx::VertexInputRate kInvalidVertexInputRate = static_cast<grfx::VertexInputRate>(~0);
-
     uint32_t                           mBinding   = 0;
     uint32_t                           mStride    = 0;
-    grfx::VertexInputRate              mInputRate = kInvalidVertexInputRate;
+    grfx::VertexInputRate              mInputRate = grfx::INVALID_VERTEX_INPUT_RATE;
     std::vector<grfx::VertexAttribute> mAttributes;
 };
 

--- a/src/ppx/grfx/grfx_helper.cpp
+++ b/src/ppx/grfx/grfx_helper.cpp
@@ -79,7 +79,7 @@ VertexBinding& VertexBinding::AppendAttribute(const grfx::VertexAttribute& attri
 {
     mAttributes.push_back(attribute);
 
-    if (mInputRate == grfx::VertexBinding::kInvalidVertexInputRate) {
+    if (mInputRate == grfx::INVALID_VERTEX_INPUT_RATE) {
         mInputRate = attribute.inputRate;
     }
 


### PR DESCRIPTION
Default enum value was not a valid enum value, which caused issue with asan. This fixed unit tests with this sanitizer enabled.