### PR TITLE
Include additional header

### DIFF
--- a/include/ppx/grfx/vk/vk_shading_rate.h
+++ b/include/ppx/grfx/vk/vk_shading_rate.h
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include "ppx/grfx/vk/vk_config.h"
+#include "ppx/grfx/vk/vk_device.h"
 #include "ppx/grfx/grfx_shading_rate.h"
 
 namespace ppx {


### PR DESCRIPTION
Otherwise with certain flags it fails to build because of ToApi() function convertiong vk::Device to Device as it does not know that vk::Device inherits from Device.