### PR TITLE
Add GLTF asset option to gltf_basic_materials

### DIFF
--- a/projects/gltf_basic_materials/GltfBasicMaterials.cpp
+++ b/projects/gltf_basic_materials/GltfBasicMaterials.cpp
@@ -60,7 +60,7 @@ void GltfBasicMaterialsApp::Setup()
     {
         scene::GltfLoader* pLoader = nullptr;
         //
-        PPX_CHECKED_CALL(scene::GltfLoader::Create(GetAssetPath("scene_renderer/scenes/tests/gltf_test_basic_materials.glb"), nullptr, &pLoader));
+        PPX_CHECKED_CALL(scene::GltfLoader::Create(GetAssetPath(mSceneAssetKnob->GetValue()), /*pMaterialSelector=*/nullptr, &pLoader));
 
         PPX_CHECKED_CALL(pLoader->LoadScene(GetDevice(), 0, &mScene));
         PPX_ASSERT_MSG((mScene->GetCameraNodeCount() > 0), "scene doesn't have camera nodes");
@@ -324,4 +324,10 @@ void GltfBasicMaterialsApp::Render()
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
     PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+}
+
+void GltfBasicMaterialsApp::InitKnobs()
+{
+    GetKnobManager().InitKnob(&mSceneAssetKnob, "gltf-scene-asset", "scene_renderer/scenes/tests/gltf_test_basic_materials.glb");
+    mSceneAssetKnob->SetFlagDescription("GLTF asset to load and render");
 }

--- a/projects/gltf_basic_materials/GltfBasicMaterials.h
+++ b/projects/gltf_basic_materials/GltfBasicMaterials.h
@@ -30,6 +30,7 @@ public:
     void Setup() override;
     void Shutdown() override;
     void Render() override;
+    void InitKnobs() override;
 
 private:
     struct PerFrame
@@ -57,6 +58,8 @@ private:
 
     ppx::grfx::TexturePtr mIBLIrrMap;
     ppx::grfx::TexturePtr mIBLEnvMap;
+
+    std::shared_ptr<ppx::KnobFlag<std::string>> mSceneAssetKnob;
 };
 
 #endif // GLTF_BASIC_MATERIALS_H


### PR DESCRIPTION
Introduce a KnobFlag for specifying which GLTF scene to load. This is relative to the asset path. This allows us to load additional scenes without recompiling.