### PR TITLE
Remove VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT bit from image creation.

### DIFF
--- a/src/ppx/grfx/vk/vk_image.cpp
+++ b/src/ppx/grfx/vk/vk_image.cpp
@@ -35,7 +35,7 @@ Result Image::CreateApiObjects(const grfx::ImageCreateInfo* pCreateInfo)
             extent.height     = pCreateInfo->height;
             extent.depth      = pCreateInfo->depth;
 
-            VkImageCreateFlags createFlags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
+            VkImageCreateFlags createFlags = 0;
             if (pCreateInfo->type == grfx::IMAGE_TYPE_CUBE) {
                 createFlags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
             }


### PR DESCRIPTION
No sample mismatch the image format and imageview format, meaning this feature is not used. In addition, specifying this bit prevents the driver to make some assumptions, and this can degrade performances