### PR TITLE
build: fix warning in upstream GLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,10 +156,8 @@ else()
 
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-        -Wno-missing-template-arg-list-after-template-kw \
-    ")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.0)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-template-arg-list-after-template-kw")
 endif()
 
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,12 @@ else()
 
 endif()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -Wno-missing-template-arg-list-after-template-kw \
+    ")
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This warning seems to only impact clang.