### PR TITLE
grfx, vk: fix queueCount being zero

### DIFF
--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -70,8 +70,7 @@ Result Device::ConfigureQueueInfo(const grfx::DeviceCreateInfo* pCreateInfo, std
     {
         std::unordered_set<uint32_t> createdQueues;
         // Graphics
-        if (mGraphicsQueueFamilyIndex != PPX_VALUE_IGNORED
-            && pCreateInfo->graphicsQueueCount > 0) {
+        if (mGraphicsQueueFamilyIndex != PPX_VALUE_IGNORED && pCreateInfo->graphicsQueueCount > 0) {
             VkDeviceQueueCreateInfo vkci = {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
             vkci.queueFamilyIndex        = mGraphicsQueueFamilyIndex;
             vkci.queueCount              = pCreateInfo->graphicsQueueCount;
@@ -80,9 +79,7 @@ Result Device::ConfigureQueueInfo(const grfx::DeviceCreateInfo* pCreateInfo, std
             createdQueues.insert(mGraphicsQueueFamilyIndex);
         }
         // Compute
-        if (mComputeQueueFamilyIndex != PPX_VALUE_IGNORED
-            && createdQueues.find(mComputeQueueFamilyIndex) == createdQueues.end()
-            && pCreateInfo->computeQueueCount > 0) {
+        if (mComputeQueueFamilyIndex != PPX_VALUE_IGNORED && createdQueues.find(mComputeQueueFamilyIndex) == createdQueues.end() && pCreateInfo->computeQueueCount > 0) {
             VkDeviceQueueCreateInfo vkci = {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
             vkci.queueFamilyIndex        = mComputeQueueFamilyIndex;
             vkci.queueCount              = pCreateInfo->computeQueueCount;
@@ -94,9 +91,7 @@ Result Device::ConfigureQueueInfo(const grfx::DeviceCreateInfo* pCreateInfo, std
             PPX_LOG_WARN("Graphics queue will be shared with compute queue.");
         }
         // Transfer
-        if (mTransferQueueFamilyIndex != PPX_VALUE_IGNORED
-            && createdQueues.find(mTransferQueueFamilyIndex) == createdQueues.end()
-            && pCreateInfo->transferQueueCount > 0) {
+        if (mTransferQueueFamilyIndex != PPX_VALUE_IGNORED && createdQueues.find(mTransferQueueFamilyIndex) == createdQueues.end() && pCreateInfo->transferQueueCount > 0) {
             VkDeviceQueueCreateInfo vkci = {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
             vkci.queueFamilyIndex        = mTransferQueueFamilyIndex;
             vkci.queueCount              = pCreateInfo->transferQueueCount;

--- a/src/ppx/grfx/vk/vk_device.cpp
+++ b/src/ppx/grfx/vk/vk_device.cpp
@@ -70,7 +70,8 @@ Result Device::ConfigureQueueInfo(const grfx::DeviceCreateInfo* pCreateInfo, std
     {
         std::unordered_set<uint32_t> createdQueues;
         // Graphics
-        if (mGraphicsQueueFamilyIndex != PPX_VALUE_IGNORED) {
+        if (mGraphicsQueueFamilyIndex != PPX_VALUE_IGNORED
+            && pCreateInfo->graphicsQueueCount > 0) {
             VkDeviceQueueCreateInfo vkci = {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
             vkci.queueFamilyIndex        = mGraphicsQueueFamilyIndex;
             vkci.queueCount              = pCreateInfo->graphicsQueueCount;
@@ -79,7 +80,9 @@ Result Device::ConfigureQueueInfo(const grfx::DeviceCreateInfo* pCreateInfo, std
             createdQueues.insert(mGraphicsQueueFamilyIndex);
         }
         // Compute
-        if (mComputeQueueFamilyIndex != PPX_VALUE_IGNORED && createdQueues.find(mComputeQueueFamilyIndex) == createdQueues.end()) {
+        if (mComputeQueueFamilyIndex != PPX_VALUE_IGNORED
+            && createdQueues.find(mComputeQueueFamilyIndex) == createdQueues.end()
+            && pCreateInfo->computeQueueCount > 0) {
             VkDeviceQueueCreateInfo vkci = {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
             vkci.queueFamilyIndex        = mComputeQueueFamilyIndex;
             vkci.queueCount              = pCreateInfo->computeQueueCount;
@@ -91,7 +94,9 @@ Result Device::ConfigureQueueInfo(const grfx::DeviceCreateInfo* pCreateInfo, std
             PPX_LOG_WARN("Graphics queue will be shared with compute queue.");
         }
         // Transfer
-        if (mTransferQueueFamilyIndex != PPX_VALUE_IGNORED && createdQueues.find(mTransferQueueFamilyIndex) == createdQueues.end()) {
+        if (mTransferQueueFamilyIndex != PPX_VALUE_IGNORED
+            && createdQueues.find(mTransferQueueFamilyIndex) == createdQueues.end()
+            && pCreateInfo->transferQueueCount > 0) {
             VkDeviceQueueCreateInfo vkci = {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
             vkci.queueFamilyIndex        = mTransferQueueFamilyIndex;
             vkci.queueCount              = pCreateInfo->transferQueueCount;
@@ -101,6 +106,10 @@ Result Device::ConfigureQueueInfo(const grfx::DeviceCreateInfo* pCreateInfo, std
         }
         else if (createdQueues.find(mTransferQueueFamilyIndex) != createdQueues.end()) {
             PPX_LOG_WARN("Transfer queue will be shared with graphics or compute queue.");
+        }
+
+        if (createdQueues.size() == 0) {
+            PPX_LOG_WARN("No queues were requested. This is probably an error.");
         }
     }
 


### PR DESCRIPTION
Commit 95179ed72654f672dc0680fdb3465f16af5ec036 changed the way queue count were set, meaning we only created queues on demand. This causes validation issues as it is not legal to set the requested queue count to zero when requesting queues.
See: VUID-VkDeviceQueueCreateInfo-queueCount-arraylength