### PR TITLE
Upgrade Linux job runner to Ubuntu 24.04

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   android-build:
     name: Check Android build with gradle
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     strategy:
       fail-fast: true
     steps:

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   clang-format-check:
     name: clang-format
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - name: Setup clang-format
         run: |

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Setup clang-format
         run: |
-          sudo apt-get install -yqq clang-format-12
+          sudo apt-get install -yqq clang-format-13
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Setup clang-format
         run: |
-          sudo apt-get install -yqq clang-format-13
+          sudo apt-get install -yqq clang-format-14
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   linux-build:
     name: Build and run tests on Linux
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     steps:
       - name: Setup necessary packages
         run: |

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:kisak/kisak-mesa -y
           sudo apt update && sudo apt install libxrandr-dev libxinerama-dev libx11-dev libxcursor-dev libxi-dev libx11-xcb-dev clang \
-          mesa-vulkan-drivers
+          mesa-vulkan-drivers imagemagick
       - name: Setup Vulkan SDK
         run: |
           wget -q https://sdk.lunarg.com/sdk/download/1.3.268.0/linux/vulkansdk-linux-x86_64-1.3.268.0.tar.xz


### PR DESCRIPTION
Ubuntu 20.04 has been removed as a runner, causing checks to fail on PRs.

Ubuntu 24.04 was chosen in the hopes that we won't have to think about it for a few more years than if we were to choose Ubuntu 22.04.

This required additional changes:

- Linux build requires `convert` so make sure imagemagick is installed.
- clang-format was pinned to `clang-format-12` but this package is not in 24.04. The oldest version that 24.04 offers is `clang-format-14`. I'm worried about pushing this too high, having it change how it wants code formatted, and creating churn for PR authors. Though maybe I'm overthinking this.

Fixes #555 