### PR TITLE
Remove cmake_minimum_required from gltf_basic_materials

### DIFF
--- a/projects/gltf_basic_materials/CMakeLists.txt
+++ b/projects/gltf_basic_materials/CMakeLists.txt
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-
 project(gltf_basic_materials)
 
 add_samples_for_all_apis(


### PR DESCRIPTION
1. CMake 4.0 stopped supporting CMake 3.5: https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features
2. Remains consistent with other projects. See 11aa8fb18a18d8c39bc688e66a305dfc2c8b0398
3. As mentioned in 11aa8fb18a18d8c39bc688e66a305dfc2c8b0398, the subdirectories are not standalone so ought to inherit the minimum requirements from the parent.