### PR TITLE
Remove unused clang-format install in workflow

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -15,9 +15,6 @@ jobs:
     name: clang-format
     runs-on: "ubuntu-24.04"
     steps:
-      - name: Setup clang-format
-        run: |
-          sudo apt-get install -yqq clang-format-14
       - name: Checkout repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
clang-format-check uses DoozyX/clang-format-lint-action, which provides their own clang-format binaries. So the explicit clang-format install is not needed. Additionally, it's confusing that we install 14 but DoozyX/clang-format-lint-action uses 16