### PR TITLE
Safely reuse Present wait semaphore

### DIFF
--- a/benchmarks/compute_operations/main.cpp
+++ b/benchmarks/compute_operations/main.cpp
@@ -47,7 +47,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -171,7 +170,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -449,12 +447,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/compute_operations/main.cpp
+++ b/benchmarks/compute_operations/main.cpp
@@ -170,7 +170,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/benchmarks/draw_call/main.cpp
+++ b/benchmarks/draw_call/main.cpp
@@ -131,7 +131,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/benchmarks/draw_call/main.cpp
+++ b/benchmarks/draw_call/main.cpp
@@ -47,7 +47,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -132,7 +131,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -282,12 +280,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/foveation/FoveationBenchmarkApp.cpp
+++ b/benchmarks/foveation/FoveationBenchmarkApp.cpp
@@ -80,7 +80,6 @@ void FoveationBenchmarkApp::SetupSync()
 {
     grfx::SemaphoreCreateInfo semaCreateInfo = {};
     PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &mSync.imageAcquiredSemaphore));
-    PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &mSync.renderCompleteSemaphore));
     PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &mSync.postCompleteSemaphore));
 
     grfx::FenceCreateInfo fenceCreateInfo = {};
@@ -501,7 +500,7 @@ void FoveationBenchmarkApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &mSync.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &mSync.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = nullptr;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
@@ -510,7 +509,7 @@ void FoveationBenchmarkApp::Render()
     submitInfo.commandBufferCount   = 1;
     submitInfo.ppCommandBuffers     = &mPost.cmd;
     submitInfo.waitSemaphoreCount   = 1;
-    submitInfo.ppWaitSemaphores     = &mSync.renderCompleteSemaphore;
+    submitInfo.ppWaitSemaphores     = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.signalSemaphoreCount = 1;
     submitInfo.ppSignalSemaphores   = &mSync.postCompleteSemaphore;
     submitInfo.pFence               = mSync.postCompleteFence;

--- a/benchmarks/foveation/FoveationBenchmarkApp.h
+++ b/benchmarks/foveation/FoveationBenchmarkApp.h
@@ -160,7 +160,6 @@ private:
     {
         grfx::FencePtr     imageAcquiredFence;
         grfx::SemaphorePtr imageAcquiredSemaphore;
-        grfx::SemaphorePtr renderCompleteSemaphore;
         grfx::SemaphorePtr postCompleteSemaphore;
         grfx::FencePtr     postCompleteFence;
     } mSync;

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -267,7 +267,6 @@ void GraphicsBenchmarkApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -267,7 +267,6 @@ void GraphicsBenchmarkApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -1150,7 +1149,7 @@ void GraphicsBenchmarkApp::Render()
         submitInfo.waitSemaphoreCount   = 1;
         submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+        submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     }
     submitInfo.pFence = frame.renderCompleteFence;
 
@@ -1164,7 +1163,7 @@ void GraphicsBenchmarkApp::Render()
     if (!IsXrEnabled())
 #endif
     {
-        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
     }
 }
 

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -259,7 +259,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
         grfx::QueryPtr         timestampQuery;
 

--- a/benchmarks/overdraw/main.cpp
+++ b/benchmarks/overdraw/main.cpp
@@ -177,7 +177,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/benchmarks/overdraw/main.cpp
+++ b/benchmarks/overdraw/main.cpp
@@ -61,7 +61,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -178,7 +177,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -418,12 +416,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/primitive_assembly/main.cpp
+++ b/benchmarks/primitive_assembly/main.cpp
@@ -41,7 +41,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
         ppx::grfx::QueryPtr         pipelineStatsQuery;
@@ -208,7 +207,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -340,12 +338,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
     if (GetFrameCount() > 0) {
         // Get the gpu timestamp query
         uint64_t frequency = 0;

--- a/benchmarks/primitive_assembly/main.cpp
+++ b/benchmarks/primitive_assembly/main.cpp
@@ -207,7 +207,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/benchmarks/render_target/main.cpp
+++ b/benchmarks/render_target/main.cpp
@@ -163,7 +163,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/benchmarks/render_target/main.cpp
+++ b/benchmarks/render_target/main.cpp
@@ -47,7 +47,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -164,7 +163,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -430,12 +428,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/texture_load/main.cpp
+++ b/benchmarks/texture_load/main.cpp
@@ -132,7 +132,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/benchmarks/texture_load/main.cpp
+++ b/benchmarks/texture_load/main.cpp
@@ -47,7 +47,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -133,7 +132,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -333,12 +331,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/texture_sample/main.cpp
+++ b/benchmarks/texture_sample/main.cpp
@@ -163,7 +163,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/benchmarks/texture_sample/main.cpp
+++ b/benchmarks/texture_sample/main.cpp
@@ -51,7 +51,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -164,7 +163,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -411,12 +409,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
+++ b/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
@@ -284,7 +284,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
+++ b/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
@@ -45,7 +45,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 
@@ -285,7 +284,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -357,12 +355,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 int main(int argc, char** argv)

--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -233,7 +233,7 @@ protected:
     std::vector<grfx::DepthStencilViewPtr> mLoadDepthStencilViews;
     std::vector<grfx::RenderPassPtr>       mClearRenderPasses;
     std::vector<grfx::RenderPassPtr>       mLoadRenderPasses;
-    std::vector<grfx::SemaphorePtr>           mPresentationReadySemaphores;
+    std::vector<grfx::SemaphorePtr>        mPresentationReadySemaphores;
 
 #if defined(PPX_BUILD_XR)
     XrSwapchain mXrColorSwapchain = XR_NULL_HANDLE;

--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -135,12 +135,20 @@ public:
     Result GetRenderTargetView(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::RenderTargetView** ppView) const;
     Result GetDepthStencilView(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::DepthStencilView** ppView) const;
 
+    // Use this semaphore to synchronize submit and present correctly.
+    // See https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html
+    Result GetPresentationReadySemaphore(uint32_t imageIndex, grfx::Semaphore** ppSemaphore) const;
+
     // Convenience functions - returns empty object if index is invalid
     grfx::ImagePtr            GetColorImage(uint32_t imageIndex) const;
     grfx::ImagePtr            GetDepthImage(uint32_t imageIndex) const;
     grfx::RenderPassPtr       GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR) const;
     grfx::RenderTargetViewPtr GetRenderTargetView(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR) const;
     grfx::DepthStencilViewPtr GetDepthStencilView(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR) const;
+
+    // Use this semaphore to synchronize submit and present correctly.
+    // See https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html
+    grfx::SemaphorePtr GetPresentationReadySemaphore(uint32_t imageIndex) const;
 
     Result AcquireNextImage(
         uint64_t         timeout,    // Nanoseconds
@@ -186,6 +194,9 @@ protected:
     void   DestroyRenderPasses();
     Result CreateRenderTargets();
     void   DestroyRenderTargets();
+    // Create a semaphore for each swapchain image used for synchronizing submit with present.
+    Result CreateSemaphores();
+    void   DestroySemaphores();
 
 private:
     virtual Result AcquireNextImageInternal(
@@ -222,6 +233,7 @@ protected:
     std::vector<grfx::DepthStencilViewPtr> mLoadDepthStencilViews;
     std::vector<grfx::RenderPassPtr>       mClearRenderPasses;
     std::vector<grfx::RenderPassPtr>       mLoadRenderPasses;
+    std::vector<grfx::SemaphorePtr>           mPresentationReadySemaphores;
 
 #if defined(PPX_BUILD_XR)
     XrSwapchain mXrColorSwapchain = XR_NULL_HANDLE;

--- a/projects/arcball_camera/main.cpp
+++ b/projects/arcball_camera/main.cpp
@@ -39,7 +39,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -200,7 +199,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -328,12 +326,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/arcball_camera/main.cpp
+++ b/projects/arcball_camera/main.cpp
@@ -199,7 +199,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/async_compute/main.cpp
+++ b/projects/async_compute/main.cpp
@@ -45,7 +45,6 @@ private:
     {
         grfx::SemaphorePtr imageAcquiredSemaphore;
         grfx::FencePtr     imageAcquiredFence;
-        grfx::SemaphorePtr renderCompleteSemaphore;
         grfx::FencePtr     renderCompleteFence;
 
         // Graphics pipeline objects.
@@ -193,7 +192,6 @@ void ProjApp::Setup()
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.imageAcquiredSemaphore));
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         mPerFrame.push_back(frame);
     }
@@ -934,12 +932,12 @@ void ProjApp::BlitAndPresent(PerFrame& frame, uint32_t swapchainImageIndex)
     submitInfo.waitSemaphoreCount   = sizeof(ppWaitSemaphores) / sizeof(ppWaitSemaphores[0]);
     submitInfo.ppWaitSemaphores     = ppWaitSemaphores;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(swapchainImageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(GetSwapchain()->Present(swapchainImageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(GetSwapchain()->Present(swapchainImageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(swapchainImageIndex)));
 }
 
 void ProjApp::DrawGui()

--- a/projects/basic_material/main.cpp
+++ b/projects/basic_material/main.cpp
@@ -86,7 +86,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
 #ifdef ENABLE_GPU_QUERIES
         ppx::grfx::QueryPtr timestampQuery;
@@ -1057,7 +1056,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -1408,12 +1406,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 void ProjApp::DrawGui()

--- a/projects/basic_material/main.cpp
+++ b/projects/basic_material/main.cpp
@@ -1056,7 +1056,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/camera_fit_scene/main.cpp
+++ b/projects/camera_fit_scene/main.cpp
@@ -200,7 +200,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/camera_fit_scene/main.cpp
+++ b/projects/camera_fit_scene/main.cpp
@@ -40,7 +40,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -201,7 +200,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -337,12 +335,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/camera_motion/main.cpp
+++ b/projects/camera_motion/main.cpp
@@ -459,7 +459,6 @@ void ProjApp::SetupPerFrameData(void)
     grfx::FenceCreateInfo fenceCreateInfo = {};
     PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
     fenceCreateInfo = {true};
     PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/camera_motion/main.cpp
+++ b/projects/camera_motion/main.cpp
@@ -197,7 +197,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -460,7 +459,6 @@ void ProjApp::SetupPerFrameData(void)
     grfx::FenceCreateInfo fenceCreateInfo = {};
     PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-    PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
     fenceCreateInfo = {true};
     PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -758,12 +756,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 void ProjApp::DrawGui()

--- a/projects/cube_xr/CubeXr.cpp
+++ b/projects/cube_xr/CubeXr.cpp
@@ -126,7 +126,6 @@ void CubeXrApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -353,7 +352,7 @@ void CubeXrApp::Render()
         submitInfo.waitSemaphoreCount   = 1;
         submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+        submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     }
     submitInfo.pFence = frame.renderCompleteFence;
 
@@ -361,6 +360,6 @@ void CubeXrApp::Render()
 
     // No need to present when XR is enabled.
     if (!IsXrEnabled()) {
-        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
     }
 }

--- a/projects/cube_xr/CubeXr.cpp
+++ b/projects/cube_xr/CubeXr.cpp
@@ -126,7 +126,6 @@ void CubeXrApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/cube_xr/CubeXr.h
+++ b/projects/cube_xr/CubeXr.h
@@ -40,7 +40,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
 
         UniformBufferData uniform_buffer_data = {};

--- a/projects/dynamic_rendering/DynamicRendering.cpp
+++ b/projects/dynamic_rendering/DynamicRendering.cpp
@@ -104,7 +104,6 @@ void DynamicRenderingApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/dynamic_rendering/DynamicRendering.cpp
+++ b/projects/dynamic_rendering/DynamicRendering.cpp
@@ -104,7 +104,6 @@ void DynamicRenderingApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -222,10 +221,10 @@ void DynamicRenderingApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }

--- a/projects/dynamic_rendering/DynamicRendering.h
+++ b/projects/dynamic_rendering/DynamicRendering.h
@@ -32,7 +32,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/fishtornado/FishTornado.cpp
+++ b/projects/fishtornado/FishTornado.cpp
@@ -259,7 +259,6 @@ void FishTornadoApp::SetupPerFrame()
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.copyConstantsSemaphore));
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.flockingCompleteSemaphore));
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.shadowCompleteSemaphore));
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         // Image acquired sync objects
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.imageAcquiredSemaphore));
@@ -871,7 +870,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.waitSemaphoreCount   = waitSemaphoreCount;
         submitInfo.ppWaitSemaphores     = ppWaitSemaphores;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+        submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
 
         PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
     }
@@ -898,7 +897,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.commandBufferCount   = 1;
         submitInfo.ppCommandBuffers     = &frame.gpuEndTimestampCmd;
         submitInfo.waitSemaphoreCount   = 1;
-        submitInfo.ppWaitSemaphores     = &frame.renderCompleteSemaphore;
+        submitInfo.ppWaitSemaphores     = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
         submitInfo.signalSemaphoreCount = 1;
         submitInfo.ppSignalSemaphores   = &frame.frameCompleteSemaphore;
         submitInfo.pFence               = frame.frameCompleteFence;
@@ -910,7 +909,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
     {
         grfx::SubmitInfo submitInfo     = {};
         submitInfo.waitSemaphoreCount   = 1;
-        submitInfo.ppWaitSemaphores     = &frame.renderCompleteSemaphore;
+        submitInfo.ppWaitSemaphores     = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
         submitInfo.signalSemaphoreCount = 1;
         submitInfo.ppSignalSemaphores   = &frame.frameCompleteSemaphore;
         submitInfo.pFence               = frame.frameCompleteFence;

--- a/projects/fishtornado/FishTornado.h
+++ b/projects/fishtornado/FishTornado.h
@@ -103,7 +103,6 @@ private:
         grfx::SemaphorePtr     copyConstantsSemaphore;
         grfx::SemaphorePtr     flockingCompleteSemaphore;
         grfx::SemaphorePtr     shadowCompleteSemaphore;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
         grfx::SemaphorePtr     frameCompleteSemaphore;

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -271,7 +271,6 @@ void FishTornadoApp::SetupPerFrame()
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.copyConstantsSemaphore));
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.flockingCompleteSemaphore));
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.shadowCompleteSemaphore));
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         // Image acquired sync objects
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.imageAcquiredSemaphore));
@@ -937,7 +936,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.waitSemaphoreCount   = waitSemaphoreCount;
         submitInfo.ppWaitSemaphores     = &pWaitSemaphores;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+        submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
 
         PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
     }
@@ -951,7 +950,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.waitSemaphoreCount   = waitSemaphoreCount;
         submitInfo.ppWaitSemaphores     = ppWaitSemaphores;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+        submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
 
         PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
     }
@@ -978,7 +977,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.commandBufferCount   = 1;
         submitInfo.ppCommandBuffers     = &frame.gpuEndTimestampCmd;
         submitInfo.waitSemaphoreCount   = 1;
-        submitInfo.ppWaitSemaphores     = &frame.renderCompleteSemaphore;
+        submitInfo.ppWaitSemaphores     = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
         submitInfo.signalSemaphoreCount = 1;
         submitInfo.ppSignalSemaphores   = &frame.frameCompleteSemaphore;
         submitInfo.pFence               = frame.frameCompleteFence;
@@ -996,7 +995,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
     {
         grfx::SubmitInfo submitInfo     = {};
         submitInfo.waitSemaphoreCount   = 1;
-        submitInfo.ppWaitSemaphores     = &frame.renderCompleteSemaphore;
+        submitInfo.ppWaitSemaphores     = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
         submitInfo.signalSemaphoreCount = 1;
         submitInfo.ppSignalSemaphores   = &frame.frameCompleteSemaphore;
         submitInfo.pFence               = frame.frameCompleteFence;

--- a/projects/fishtornado_xr/FishTornado.h
+++ b/projects/fishtornado_xr/FishTornado.h
@@ -105,7 +105,6 @@ private:
         grfx::SemaphorePtr     copyConstantsSemaphore;
         grfx::SemaphorePtr     flockingCompleteSemaphore;
         grfx::SemaphorePtr     shadowCompleteSemaphore;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
         grfx::SemaphorePtr     frameCompleteSemaphore;

--- a/projects/fluid_simulation/shaders.h
+++ b/projects/fluid_simulation/shaders.h
@@ -31,11 +31,11 @@ struct ComputeDispatchData
 
 struct PerFrame
 {
-    ppx::grfx::CommandBufferPtr      cmd                     = nullptr;
-    ppx::grfx::SemaphorePtr          imageAcquiredSemaphore  = nullptr;
-    ppx::grfx::FencePtr              imageAcquiredFence      = nullptr;
-    ppx::grfx::FencePtr              renderCompleteFence     = nullptr;
-    uint32_t                         dispatchID              = 0;
+    ppx::grfx::CommandBufferPtr      cmd                    = nullptr;
+    ppx::grfx::SemaphorePtr          imageAcquiredSemaphore = nullptr;
+    ppx::grfx::FencePtr              imageAcquiredFence     = nullptr;
+    ppx::grfx::FencePtr              renderCompleteFence    = nullptr;
+    uint32_t                         dispatchID             = 0;
     std::vector<ComputeDispatchData> mDispatchData;
 
     ComputeDispatchData* GetDispatchData()

--- a/projects/fluid_simulation/shaders.h
+++ b/projects/fluid_simulation/shaders.h
@@ -34,7 +34,6 @@ struct PerFrame
     ppx::grfx::CommandBufferPtr      cmd                     = nullptr;
     ppx::grfx::SemaphorePtr          imageAcquiredSemaphore  = nullptr;
     ppx::grfx::FencePtr              imageAcquiredFence      = nullptr;
-    ppx::grfx::SemaphorePtr          renderCompleteSemaphore = nullptr;
     ppx::grfx::FencePtr              renderCompleteFence     = nullptr;
     uint32_t                         dispatchID              = 0;
     std::vector<ComputeDispatchData> mDispatchData;

--- a/projects/fluid_simulation/sim.cpp
+++ b/projects/fluid_simulation/sim.cpp
@@ -207,7 +207,6 @@ void FluidSimulationApp::Setup()
     PPX_CHECKED_CALL(GetDevice()->GetGraphicsQueue()->CreateCommandBuffer(&frame.cmd));
     PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&sci, &frame.imageAcquiredSemaphore));
     PPX_CHECKED_CALL(GetDevice()->CreateFence(&fci, &frame.imageAcquiredFence));
-    PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&sci, &frame.renderCompleteSemaphore));
     fci = {true}; // Create signaled
     PPX_CHECKED_CALL(GetDevice()->CreateFence(&fci, &frame.renderCompleteFence));
     mPerFrame.push_back(frame);
@@ -463,12 +462,12 @@ void FluidSimulationApp::Render()
     submitInfo.waitSemaphoreCount    = 1;
     submitInfo.ppWaitSemaphores      = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount  = 1;
-    submitInfo.ppSignalSemaphores    = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores    = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence                = frame.renderCompleteFence;
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
     // Present and signal.
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 void FluidSimulationApp::UpdateKnobVisibility()

--- a/projects/gbuffer/main.cpp
+++ b/projects/gbuffer/main.cpp
@@ -141,7 +141,6 @@ void ProjApp::SetupPerFrame()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/gbuffer/main.cpp
+++ b/projects/gbuffer/main.cpp
@@ -47,7 +47,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
 #ifdef ENABLE_GPU_QUERIES
         ppx::grfx::QueryPtr timestampQuery;
@@ -142,7 +141,6 @@ void ProjApp::SetupPerFrame()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -862,12 +860,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 void ProjApp::DrawGui()

--- a/projects/gltf/main.cpp
+++ b/projects/gltf/main.cpp
@@ -695,7 +695,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/gltf/main.cpp
+++ b/projects/gltf/main.cpp
@@ -47,7 +47,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -696,7 +695,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -816,12 +814,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/gltf_basic_materials/GltfBasicMaterials.cpp
+++ b/projects/gltf_basic_materials/GltfBasicMaterials.cpp
@@ -80,7 +80,6 @@ void GltfBasicMaterialsApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -360,12 +359,12 @@ void GltfBasicMaterialsApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 void GltfBasicMaterialsApp::InitKnobs()

--- a/projects/gltf_basic_materials/GltfBasicMaterials.cpp
+++ b/projects/gltf_basic_materials/GltfBasicMaterials.cpp
@@ -80,7 +80,6 @@ void GltfBasicMaterialsApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/gltf_basic_materials/GltfBasicMaterials.h
+++ b/projects/gltf_basic_materials/GltfBasicMaterials.h
@@ -40,7 +40,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/image_filter/main.cpp
+++ b/projects/image_filter/main.cpp
@@ -135,7 +135,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/image_filter/main.cpp
+++ b/projects/image_filter/main.cpp
@@ -44,7 +44,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
         grfx::QueryPtr         timestampQuery;
     };
@@ -136,7 +135,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -519,12 +517,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/projects/input/main.cpp
+++ b/projects/input/main.cpp
@@ -45,7 +45,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 
@@ -78,7 +77,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -174,12 +172,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(Present(swapchain, imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(Present(swapchain, imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 void ProjApp::DrawGui()

--- a/projects/input/main.cpp
+++ b/projects/input/main.cpp
@@ -77,7 +77,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/mipmap_demo/main.cpp
+++ b/projects/mipmap_demo/main.cpp
@@ -39,7 +39,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 
@@ -210,7 +209,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -338,12 +336,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 void ProjApp::DrawGui()

--- a/projects/mipmap_demo/main.cpp
+++ b/projects/mipmap_demo/main.cpp
@@ -209,7 +209,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/oit_demo/OITDemoApplication.cpp
+++ b/projects/oit_demo/OITDemoApplication.cpp
@@ -62,8 +62,6 @@ void OITDemoApp::SetupCommon()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &mImageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &mRenderCompleteSemaphore));
-
         fenceCreateInfo.signaled = true;
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &mRenderCompleteFence));
     }
@@ -622,8 +620,8 @@ void OITDemoApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &mImageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &mRenderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = mRenderCompleteFence;
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
-    PPX_CHECKED_CALL(GetSwapchain()->Present(imageIndex, 1, &mRenderCompleteSemaphore));
+    PPX_CHECKED_CALL(GetSwapchain()->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }

--- a/projects/oit_demo/OITDemoApplication.h
+++ b/projects/oit_demo/OITDemoApplication.h
@@ -154,7 +154,6 @@ private:
 
     grfx::SemaphorePtr mImageAcquiredSemaphore;
     grfx::FencePtr     mImageAcquiredFence;
-    grfx::SemaphorePtr mRenderCompleteSemaphore;
     grfx::FencePtr     mRenderCompleteFence;
 
     grfx::CommandBufferPtr  mCommandBuffer;

--- a/projects/primitives/main.cpp
+++ b/projects/primitives/main.cpp
@@ -210,7 +210,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/primitives/main.cpp
+++ b/projects/primitives/main.cpp
@@ -36,7 +36,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -211,7 +210,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -345,12 +343,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/push_constants/PushConstants.cpp
+++ b/projects/push_constants/PushConstants.cpp
@@ -180,7 +180,6 @@ void PushConstantsApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -357,10 +356,10 @@ void PushConstantsApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }

--- a/projects/push_constants/PushConstants.cpp
+++ b/projects/push_constants/PushConstants.cpp
@@ -180,7 +180,6 @@ void PushConstantsApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/push_constants/PushConstants.h
+++ b/projects/push_constants/PushConstants.h
@@ -32,7 +32,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/push_descriptors/PushDescriptors.cpp
+++ b/projects/push_descriptors/PushDescriptors.cpp
@@ -149,7 +149,6 @@ void PushDescriptorsApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/push_descriptors/PushDescriptors.cpp
+++ b/projects/push_descriptors/PushDescriptors.cpp
@@ -149,7 +149,6 @@ void PushDescriptorsApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -357,10 +356,10 @@ void PushDescriptorsApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }

--- a/projects/push_descriptors/PushDescriptors.h
+++ b/projects/push_descriptors/PushDescriptors.h
@@ -32,7 +32,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/push_descriptors_buffers/PushDescriptorsBuffers.cpp
+++ b/projects/push_descriptors_buffers/PushDescriptorsBuffers.cpp
@@ -206,7 +206,6 @@ void PushDescriptorsBuffersApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -399,10 +398,10 @@ void PushDescriptorsBuffersApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }

--- a/projects/push_descriptors_buffers/PushDescriptorsBuffers.cpp
+++ b/projects/push_descriptors_buffers/PushDescriptorsBuffers.cpp
@@ -206,7 +206,6 @@ void PushDescriptorsBuffersApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/push_descriptors_buffers/PushDescriptorsBuffers.h
+++ b/projects/push_descriptors_buffers/PushDescriptorsBuffers.h
@@ -32,7 +32,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/sample_01_triangle/Triangle.cpp
+++ b/projects/sample_01_triangle/Triangle.cpp
@@ -80,12 +80,19 @@ void TriangleApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
         mPerFrame.push_back(frame);
+    }
+
+    uint32_t swapchainImageCount = GetSwapchain()->GetImageCount();
+    mPerSwapchainImage.reserve(swapchainImageCount);
+    for (uint32_t i = 0; i < swapchainImageCount; ++i) {
+        PerSwapchainImage         swapchainImage = {};
+        grfx::SemaphoreCreateInfo createInfo     = {};
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&createInfo, &swapchainImage.renderCompleteSemaphore));
+        mPerSwapchainImage.push_back(swapchainImage);
     }
 
     // Buffer and geometry data
@@ -164,16 +171,18 @@ void TriangleApp::Render()
     }
     PPX_CHECKED_CALL(frame.cmd->End());
 
+    grfx::SemaphorePtr& renderCompleteSemaphore = mPerSwapchainImage[imageIndex].renderCompleteSemaphore;
+
     grfx::SubmitInfo submitInfo     = {};
     submitInfo.commandBufferCount   = 1;
     submitInfo.ppCommandBuffers     = &frame.cmd;
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &renderCompleteSemaphore));
 }

--- a/projects/sample_01_triangle/Triangle.h
+++ b/projects/sample_01_triangle/Triangle.h
@@ -32,17 +32,21 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
+    struct PerSwapchainImage
+    {
+        grfx::SemaphorePtr renderCompleteSemaphore;
+    };
 
-    std::vector<PerFrame>      mPerFrame;
-    grfx::ShaderModulePtr      mVS;
-    grfx::ShaderModulePtr      mPS;
-    grfx::PipelineInterfacePtr mPipelineInterface;
-    grfx::GraphicsPipelinePtr  mPipeline;
-    grfx::BufferPtr            mVertexBuffer;
-    grfx::VertexBinding        mVertexBinding;
+    std::vector<PerFrame>          mPerFrame;
+    std::vector<PerSwapchainImage> mPerSwapchainImage;
+    grfx::ShaderModulePtr          mVS;
+    grfx::ShaderModulePtr          mPS;
+    grfx::PipelineInterfacePtr     mPipelineInterface;
+    grfx::GraphicsPipelinePtr      mPipeline;
+    grfx::BufferPtr                mVertexBuffer;
+    grfx::VertexBinding            mVertexBinding;
 };
 
 #endif // TRIANGLE_H

--- a/projects/sample_01_triangle/Triangle.h
+++ b/projects/sample_01_triangle/Triangle.h
@@ -34,19 +34,14 @@ private:
         grfx::FencePtr         imageAcquiredFence;
         grfx::FencePtr         renderCompleteFence;
     };
-    struct PerSwapchainImage
-    {
-        grfx::SemaphorePtr renderCompleteSemaphore;
-    };
 
-    std::vector<PerFrame>          mPerFrame;
-    std::vector<PerSwapchainImage> mPerSwapchainImage;
-    grfx::ShaderModulePtr          mVS;
-    grfx::ShaderModulePtr          mPS;
-    grfx::PipelineInterfacePtr     mPipelineInterface;
-    grfx::GraphicsPipelinePtr      mPipeline;
-    grfx::BufferPtr                mVertexBuffer;
-    grfx::VertexBinding            mVertexBinding;
+    std::vector<PerFrame>      mPerFrame;
+    grfx::ShaderModulePtr      mVS;
+    grfx::ShaderModulePtr      mPS;
+    grfx::PipelineInterfacePtr mPipelineInterface;
+    grfx::GraphicsPipelinePtr  mPipeline;
+    grfx::BufferPtr            mVertexBuffer;
+    grfx::VertexBinding        mVertexBinding;
 };
 
 #endif // TRIANGLE_H

--- a/projects/sample_02_triangle_spinning/TriangleSpinning.cpp
+++ b/projects/sample_02_triangle_spinning/TriangleSpinning.cpp
@@ -113,7 +113,6 @@ void TriangleSpinningApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_02_triangle_spinning/TriangleSpinning.cpp
+++ b/projects/sample_02_triangle_spinning/TriangleSpinning.cpp
@@ -113,7 +113,6 @@ void TriangleSpinningApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -210,10 +209,10 @@ void TriangleSpinningApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }

--- a/projects/sample_02_triangle_spinning/TriangleSpinning.h
+++ b/projects/sample_02_triangle_spinning/TriangleSpinning.h
@@ -32,7 +32,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/sample_03_square_textured/SquareTextured.cpp
+++ b/projects/sample_03_square_textured/SquareTextured.cpp
@@ -142,7 +142,6 @@ void SquareTexturedApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -243,10 +242,10 @@ void SquareTexturedApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }

--- a/projects/sample_03_square_textured/SquareTextured.cpp
+++ b/projects/sample_03_square_textured/SquareTextured.cpp
@@ -142,7 +142,6 @@ void SquareTexturedApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_03_square_textured/SquareTextured.h
+++ b/projects/sample_03_square_textured/SquareTextured.h
@@ -33,7 +33,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/sample_04_cube/Cube.cpp
+++ b/projects/sample_04_cube/Cube.cpp
@@ -115,7 +115,6 @@ void CubeApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -281,10 +280,10 @@ void CubeApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }

--- a/projects/sample_04_cube/Cube.cpp
+++ b/projects/sample_04_cube/Cube.cpp
@@ -115,7 +115,6 @@ void CubeApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_04_cube/Cube.h
+++ b/projects/sample_04_cube/Cube.h
@@ -32,7 +32,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/sample_05_cube_textured/main.cpp
+++ b/projects/sample_05_cube_textured/main.cpp
@@ -36,7 +36,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 
@@ -184,7 +183,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -363,12 +361,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_05_cube_textured/main.cpp
+++ b/projects/sample_05_cube_textured/main.cpp
@@ -183,7 +183,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_06_compute_fill/main.cpp
+++ b/projects/sample_06_compute_fill/main.cpp
@@ -36,7 +36,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -223,7 +222,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -332,12 +330,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_06_compute_fill/main.cpp
+++ b/projects/sample_06_compute_fill/main.cpp
@@ -222,7 +222,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_07_draw_indexed/main.cpp
+++ b/projects/sample_07_draw_indexed/main.cpp
@@ -35,7 +35,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -146,7 +145,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -312,12 +310,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_07_draw_indexed/main.cpp
+++ b/projects/sample_07_draw_indexed/main.cpp
@@ -145,7 +145,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_08_basic_geometry/main.cpp
+++ b/projects/sample_08_basic_geometry/main.cpp
@@ -208,7 +208,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_08_basic_geometry/main.cpp
+++ b/projects/sample_08_basic_geometry/main.cpp
@@ -36,7 +36,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -209,7 +208,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -378,12 +376,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_09_obj_geometry/main.cpp
+++ b/projects/sample_09_obj_geometry/main.cpp
@@ -173,7 +173,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_09_obj_geometry/main.cpp
+++ b/projects/sample_09_obj_geometry/main.cpp
@@ -36,7 +36,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -174,7 +173,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -286,12 +284,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_10_cube_map/main.cpp
+++ b/projects/sample_10_cube_map/main.cpp
@@ -42,7 +42,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
         grfx::QueryPtr         timestampQuery;
     };
@@ -257,7 +256,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -419,12 +417,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 void ProjApp::DrawGui()

--- a/projects/sample_10_cube_map/main.cpp
+++ b/projects/sample_10_cube_map/main.cpp
@@ -256,7 +256,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_11_compressed_texture/main.cpp
+++ b/projects/sample_11_compressed_texture/main.cpp
@@ -53,7 +53,6 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
-        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 
@@ -215,7 +214,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -358,12 +356,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_11_compressed_texture/main.cpp
+++ b/projects/sample_11_compressed_texture/main.cpp
@@ -214,7 +214,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_12_shadows/main.cpp
+++ b/projects/sample_12_shadows/main.cpp
@@ -420,7 +420,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_12_shadows/main.cpp
+++ b/projects/sample_12_shadows/main.cpp
@@ -42,7 +42,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -421,7 +420,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -575,12 +573,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 void ProjApp::DrawGui()

--- a/projects/sample_13_normal_map/main.cpp
+++ b/projects/sample_13_normal_map/main.cpp
@@ -334,7 +334,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/projects/sample_13_normal_map/main.cpp
+++ b/projects/sample_13_normal_map/main.cpp
@@ -40,7 +40,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -335,7 +334,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -456,12 +454,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 void ProjApp::DrawGui()

--- a/projects/text_draw/main.cpp
+++ b/projects/text_draw/main.cpp
@@ -36,7 +36,6 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
-        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
     std::vector<PerFrame> mPerFrame;
@@ -69,7 +68,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -201,12 +199,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
+    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/text_draw/main.cpp
+++ b/projects/text_draw/main.cpp
@@ -68,7 +68,6 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
-
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 

--- a/src/ppx/grfx/dx12/dx12_swapchain.cpp
+++ b/src/ppx/grfx/dx12/dx12_swapchain.cpp
@@ -409,6 +409,7 @@ Result Swapchain::Resize(uint32_t width, uint32_t height)
     }
 
     // Destroy these to make sure there's no reference before resizing
+    DestroySemaphores();
     DestroyRenderPasses();
     DestroyRenderTargets();
     DestroyDepthImages();
@@ -460,6 +461,8 @@ Result Swapchain::Resize(uint32_t width, uint32_t height)
 
     // Create render passes
     CreateRenderPasses();
+
+    CreateSemaphores();
 
     return ppx::SUCCESS;
 }

--- a/src/ppx/grfx/grfx_swapchain.cpp
+++ b/src/ppx/grfx/grfx_swapchain.cpp
@@ -112,8 +112,10 @@ Result Swapchain::Create(const grfx::SwapchainCreateInfo* pCreateInfo)
     }
 
     PPX_LOG_INFO("Swapchain created");
-    PPX_LOG_INFO("   " << "resolution  : " << mCreateInfo.width << "x" << mCreateInfo.height);
-    PPX_LOG_INFO("   " << "image count : " << mCreateInfo.imageCount);
+    PPX_LOG_INFO("   "
+                 << "resolution  : " << mCreateInfo.width << "x" << mCreateInfo.height);
+    PPX_LOG_INFO("   "
+                 << "image count : " << mCreateInfo.imageCount);
 
     return ppx::SUCCESS;
 }

--- a/src/ppx/grfx/grfx_swapchain.cpp
+++ b/src/ppx/grfx/grfx_swapchain.cpp
@@ -363,7 +363,7 @@ Result Swapchain::CreateSemaphores()
     for (size_t i = 0; i < imageCount; ++i) {
         grfx::SemaphorePtr        semaphore;
         grfx::SemaphoreCreateInfo createInfo = {};
-        auto ppxres = GetDevice()->CreateSemaphore(&createInfo, &semaphore);
+        auto                      ppxres     = GetDevice()->CreateSemaphore(&createInfo, &semaphore);
         if (Failed(ppxres)) {
             PPX_ASSERT_MSG(false, "grfx::Swapchain::CreateSemaphores() failed");
             return ppxres;

--- a/src/ppx/grfx/grfx_swapchain.cpp
+++ b/src/ppx/grfx/grfx_swapchain.cpp
@@ -92,6 +92,11 @@ Result Swapchain::Create(const grfx::SwapchainCreateInfo* pCreateInfo)
         return ppxres;
     }
 
+    ppxres = CreateSemaphores();
+    if (Failed(ppxres)) {
+        return ppxres;
+    }
+
     if (IsHeadless()) {
         // Set mCurrentImageIndex to (imageCount - 1) so that the first
         // AcquireNextImage call acquires the first image at index 0.
@@ -107,16 +112,16 @@ Result Swapchain::Create(const grfx::SwapchainCreateInfo* pCreateInfo)
     }
 
     PPX_LOG_INFO("Swapchain created");
-    PPX_LOG_INFO("   "
-                 << "resolution  : " << mCreateInfo.width << "x" << mCreateInfo.height);
-    PPX_LOG_INFO("   "
-                 << "image count : " << mCreateInfo.imageCount);
+    PPX_LOG_INFO("   " << "resolution  : " << mCreateInfo.width << "x" << mCreateInfo.height);
+    PPX_LOG_INFO("   " << "image count : " << mCreateInfo.imageCount);
 
     return ppx::SUCCESS;
 }
 
 void Swapchain::Destroy()
 {
+    DestroySemaphores();
+
     DestroyRenderPasses();
 
     DestroyRenderTargets();
@@ -350,6 +355,35 @@ void Swapchain::DestroyRenderPasses()
     mLoadRenderPasses.clear();
 }
 
+Result Swapchain::CreateSemaphores()
+{
+    uint32_t imageCount = CountU32(mColorImages);
+    PPX_ASSERT_MSG((imageCount > 0), "No color images found for swapchain semaphores");
+
+    for (size_t i = 0; i < imageCount; ++i) {
+        grfx::SemaphorePtr        semaphore;
+        grfx::SemaphoreCreateInfo createInfo = {};
+        auto ppxres = GetDevice()->CreateSemaphore(&createInfo, &semaphore);
+        if (Failed(ppxres)) {
+            PPX_ASSERT_MSG(false, "grfx::Swapchain::CreateSemaphores() failed");
+            return ppxres;
+        }
+        mPresentationReadySemaphores.push_back(semaphore);
+    }
+
+    return ppx::SUCCESS;
+}
+
+void Swapchain::DestroySemaphores()
+{
+    for (auto& elem : mPresentationReadySemaphores) {
+        if (elem) {
+            GetDevice()->DestroySemaphore(elem);
+        }
+    }
+    mPresentationReadySemaphores.clear();
+}
+
 bool Swapchain::IsHeadless() const
 {
 #if defined(PPX_BUILD_XR)
@@ -419,6 +453,15 @@ Result Swapchain::GetDepthStencilView(uint32_t imageIndex, grfx::AttachmentLoadO
     return ppx::SUCCESS;
 }
 
+Result Swapchain::GetPresentationReadySemaphore(uint32_t imageIndex, grfx::Semaphore** ppSemaphore) const
+{
+    if (!IsIndexInRange(imageIndex, mPresentationReadySemaphores)) {
+        return ppx::ERROR_OUT_OF_RANGE;
+    }
+    *ppSemaphore = mPresentationReadySemaphores[imageIndex];
+    return ppx::SUCCESS;
+}
+
 grfx::ImagePtr Swapchain::GetColorImage(uint32_t imageIndex) const
 {
     grfx::ImagePtr object;
@@ -451,6 +494,13 @@ grfx::DepthStencilViewPtr Swapchain::GetDepthStencilView(uint32_t imageIndex, gr
 {
     grfx::DepthStencilViewPtr object;
     GetDepthStencilView(imageIndex, loadOp, &object);
+    return object;
+}
+
+grfx::SemaphorePtr Swapchain::GetPresentationReadySemaphore(uint32_t imageIndex) const
+{
+    grfx::SemaphorePtr object;
+    GetPresentationReadySemaphore(imageIndex, &object);
     return object;
 }
 


### PR DESCRIPTION
A new check was added in SDK 1.4.313 related to the use of semaphores during presentation:

```
*** VULKAN VALIDATION ERROR MESSAGE ***
Severity : ERROR
Type     : [VALIDATION]
Objects  : [0]: <UNNAMED OBJECT>
           [1]: <UNNAMED OBJECT>
Message  : vkQueueSubmit(): pSubmits[0].pSignalSemaphores[0] (VkSemaphore 0x230000000023) is being signaled by VkQueue 0x1acbe8fac60, but it may still be in use by VkSwapchainKHR 0x40000000004.
Here are the most recently acquired image indices: [0], 1.
(brackets mark the last use of VkSemaphore 0x230000000023 in a presentation operation)
Swapchain image 0 was presented but was not re-acquired, so VkSemaphore 0x230000000023 may still be in use and cannot be safely reused with image index 1.
Vulkan insight: One solution is to assign each image its own semaphore. Here are some common methods to ensure that a semaphore passed to vkQueuePresentKHR is not in use and can be safely reused:
        a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
        b) Consider the VK_EXT_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.
The Vulkan spec states: Each binary semaphore element of the pSignalSemaphores member of any element of pSubmits must be unsignaled when the semaphore signal operation it defines is executed on the device (https://vulkan.lunarg.com/doc/view/1.4.313.0/windows/antora/spec/latestchapters/cmdbuffers.html#VUID-vkQueueSubmit-pSignalSemaphores-00067)

Assertion failed: false, file C:\Users\hitchens\Desktop\git\bigwheels\src\ppx\grfx\vk\vk_instance.cpp, line 115
```

Since we wait on the `vkAcquireImageKHR` fence and the fence only guarantees that the just-acquired image index is ready, we need one semaphore for each image. As suggested in
https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html, I created one wait semaphore for each swapchain image.

I fixed most of this by find and replace in my IDE. If there were fewer projects, I'd store the semaphore in a local variable then reference it multiple times, but this requires manual intervention. While not optimal, I don't think this impacts performance significantly.

Fixes #562