### PR TITLE
cubexr: fix 32bit build

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -35,4 +35,4 @@ jobs:
           echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.3.268.0/x86_64" >> $GITHUB_ENV
       - name: Build all projects
         run: |
-          ./gradlew buildRelease
+          ./gradlew buildRelease -PENABLE_32BIT_ARM=true

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ subprojects {
                 appLabel : "vk_${project.name}"
             ]
 
-            ndk.abiFilters = ['arm64-v8a']
+            ndk.abiFilters = ['armeabi-v7a', 'arm64-v8a']
 
             testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
             externalNativeBuild {

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,12 @@ subprojects {
                 appLabel : "vk_${project.name}"
             ]
 
-            ndk.abiFilters = ['armeabi-v7a', 'arm64-v8a']
+
+            if (project.findProperty('ENABLE_32BIT_ARM')) {
+              ndk.abiFilters = ['armeabi-v7a', 'arm64-v8a']
+            } else {
+              ndk.abiFilters = ['arm64-v8a']
+            }
 
             testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
             externalNativeBuild {

--- a/projects/cube_xr/CubeXr.cpp
+++ b/projects/cube_xr/CubeXr.cpp
@@ -41,7 +41,7 @@ void CubeXrApp::Setup()
     // Uniform buffer
     {
         grfx::BufferCreateInfo bufferCreateInfo        = {};
-        bufferCreateInfo.size                          = std::max(sizeof(UniformBufferData), (uint64_t)PPX_MINIMUM_UNIFORM_BUFFER_SIZE);
+        bufferCreateInfo.size                          = std::max<uint64_t>(sizeof(UniformBufferData), PPX_MINIMUM_UNIFORM_BUFFER_SIZE);
         bufferCreateInfo.usageFlags.bits.uniformBuffer = true;
         bufferCreateInfo.memoryUsage                   = grfx::MEMORY_USAGE_CPU_TO_GPU;
 


### PR DESCRIPTION
The template inference fails on 32bit builds because of sizeof. Making the templated type explicit solves this.