### PR TITLE
Update GitHub Actions to Vulkan 1.4.321.1

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -25,14 +25,14 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Setup Vulkan SDK
         run: |
-          wget -q https://sdk.lunarg.com/sdk/download/1.4.313.0/linux/vulkansdk-linux-x86_64-1.4.313.0.tar.xz
-          if ! echo "4e957b66ade85eeaee95932aa7e3b45aea64db373c58a5eaefc8228cc71445c2 vulkansdk-linux-x86_64-1.4.313.0.tar.xz" | sha256sum -c --status; then
+          wget -q https://sdk.lunarg.com/sdk/download/1.4.321.1/linux/vulkansdk-linux-x86_64-1.4.321.1.tar.xz
+          if ! echo "f22a3625bd4d7a32e7a0d926ace16d5278c149e938dac63cecc00537626cbf73 vulkansdk-linux-x86_64-1.4.321.1.tar.xz" | sha256sum -c --status; then
             echo "Invalid SHA256 for VulkanSDK's binary. Aborting."
             exit 1
           fi
           mkdir "${HOME}/vulkan-sdk"
-          tar -xf vulkansdk-linux-x86_64-1.4.313.0.tar.xz -C "${HOME}/vulkan-sdk"
-          echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.4.313.0/x86_64" >> $GITHUB_ENV
+          tar -xf vulkansdk-linux-x86_64-1.4.321.1.tar.xz -C "${HOME}/vulkan-sdk"
+          echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.4.321.1/x86_64" >> $GITHUB_ENV
       - name: Build all projects
         run: |
           ./gradlew buildRelease -PENABLE_32BIT_ARM=true

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -25,14 +25,14 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Setup Vulkan SDK
         run: |
-          wget -q https://sdk.lunarg.com/sdk/download/1.3.268.0/linux/vulkansdk-linux-x86_64-1.3.268.0.tar.xz
-          if ! echo "d23343736247828ff5b3b6b1b7fd83a72b5df1a54b2527ae3663cebdfee75842 vulkansdk-linux-x86_64-1.3.268.0.tar.xz" | sha256sum -c --status; then
+          wget -q https://sdk.lunarg.com/sdk/download/1.4.313.0/linux/vulkansdk-linux-x86_64-1.4.313.0.tar.xz
+          if ! echo "d23343736247828ff5b3b6b1b7fd83a72b5df1a54b2527ae3663cebdfee75842 vulkansdk-linux-x86_64-1.4.313.0.tar.xz" | sha256sum -c --status; then
             echo "Invalid SHA256 for VulkanSDK's binary. Aborting."
             exit 1
           fi
           mkdir "${HOME}/vulkan-sdk"
-          tar -xf vulkansdk-linux-x86_64-1.3.268.0.tar.xz -C "${HOME}/vulkan-sdk"
-          echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.3.268.0/x86_64" >> $GITHUB_ENV
+          tar -xf vulkansdk-linux-x86_64-1.4.313.0.tar.xz -C "${HOME}/vulkan-sdk"
+          echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.4.313.0/x86_64" >> $GITHUB_ENV
       - name: Build all projects
         run: |
           ./gradlew buildRelease -PENABLE_32BIT_ARM=true

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Vulkan SDK
         run: |
           wget -q https://sdk.lunarg.com/sdk/download/1.4.313.0/linux/vulkansdk-linux-x86_64-1.4.313.0.tar.xz
-          if ! echo "d23343736247828ff5b3b6b1b7fd83a72b5df1a54b2527ae3663cebdfee75842 vulkansdk-linux-x86_64-1.4.313.0.tar.xz" | sha256sum -c --status; then
+          if ! echo "4e957b66ade85eeaee95932aa7e3b45aea64db373c58a5eaefc8228cc71445c2 vulkansdk-linux-x86_64-1.4.313.0.tar.xz" | sha256sum -c --status; then
             echo "Invalid SHA256 for VulkanSDK's binary. Aborting."
             exit 1
           fi

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -22,16 +22,16 @@ jobs:
           mesa-vulkan-drivers imagemagick
       - name: Setup Vulkan SDK
         run: |
-          wget -q https://sdk.lunarg.com/sdk/download/1.3.268.0/linux/vulkansdk-linux-x86_64-1.3.268.0.tar.xz
-          if ! echo "d23343736247828ff5b3b6b1b7fd83a72b5df1a54b2527ae3663cebdfee75842 vulkansdk-linux-x86_64-1.3.268.0.tar.xz" | sha256sum -c --status; then
+          wget -q https://sdk.lunarg.com/sdk/download/1.4.313.0/linux/vulkansdk-linux-x86_64-1.4.313.0.tar.xz
+          if ! echo "d23343736247828ff5b3b6b1b7fd83a72b5df1a54b2527ae3663cebdfee75842 vulkansdk-linux-x86_64-1.4.313.0.tar.xz" | sha256sum -c --status; then
             echo "Invalid SHA256 for VulkanSDK's binary. Aborting."
             exit 1
           fi
           mkdir "${HOME}/vulkan-sdk"
-          tar -xf vulkansdk-linux-x86_64-1.3.268.0.tar.xz -C "${HOME}/vulkan-sdk"
-          echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.3.268.0/x86_64" >> $GITHUB_ENV
-          echo "VK_LAYER_PATH=${HOME}/vulkan-sdk/1.3.268.0/x86_64/etc/vulkan/explicit_layer.d" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${HOME}/vulkan-sdk/1.3.268.0/x86_64/lib" >> $GITHUB_ENV
+          tar -xf vulkansdk-linux-x86_64-1.4.313.0.tar.xz -C "${HOME}/vulkan-sdk"
+          echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.4.313.0/x86_64" >> $GITHUB_ENV
+          echo "VK_LAYER_PATH=${HOME}/vulkan-sdk/1.4.313.0/x86_64/etc/vulkan/explicit_layer.d" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${HOME}/vulkan-sdk/1.4.313.0/x86_64/lib" >> $GITHUB_ENV
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -30,7 +30,7 @@ jobs:
           mkdir "${HOME}/vulkan-sdk"
           tar -xf vulkansdk-linux-x86_64-1.4.321.1.tar.xz -C "${HOME}/vulkan-sdk"
           echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.4.321.1/x86_64" >> $GITHUB_ENV
-          echo "VK_LAYER_PATH=${HOME}/vulkan-sdk/1.4.321.1/x86_64/etc/vulkan/explicit_layer.d" >> $GITHUB_ENV
+          echo "VK_LAYER_PATH=${HOME}/vulkan-sdk/1.4.321.1/x86_64/share/vulkan/explicit_layer.d" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=${HOME}/vulkan-sdk/1.4.321.1/x86_64/lib" >> $GITHUB_ENV
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -22,16 +22,16 @@ jobs:
           mesa-vulkan-drivers imagemagick
       - name: Setup Vulkan SDK
         run: |
-          wget -q https://sdk.lunarg.com/sdk/download/1.4.313.0/linux/vulkansdk-linux-x86_64-1.4.313.0.tar.xz
-          if ! echo "4e957b66ade85eeaee95932aa7e3b45aea64db373c58a5eaefc8228cc71445c2 vulkansdk-linux-x86_64-1.4.313.0.tar.xz" | sha256sum -c --status; then
+          wget -q https://sdk.lunarg.com/sdk/download/1.4.321.1/linux/vulkansdk-linux-x86_64-1.4.321.1.tar.xz
+          if ! echo "f22a3625bd4d7a32e7a0d926ace16d5278c149e938dac63cecc00537626cbf73 vulkansdk-linux-x86_64-1.4.321.1.tar.xz" | sha256sum -c --status; then
             echo "Invalid SHA256 for VulkanSDK's binary. Aborting."
             exit 1
           fi
           mkdir "${HOME}/vulkan-sdk"
-          tar -xf vulkansdk-linux-x86_64-1.4.313.0.tar.xz -C "${HOME}/vulkan-sdk"
-          echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.4.313.0/x86_64" >> $GITHUB_ENV
-          echo "VK_LAYER_PATH=${HOME}/vulkan-sdk/1.4.313.0/x86_64/etc/vulkan/explicit_layer.d" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${HOME}/vulkan-sdk/1.4.313.0/x86_64/lib" >> $GITHUB_ENV
+          tar -xf vulkansdk-linux-x86_64-1.4.321.1.tar.xz -C "${HOME}/vulkan-sdk"
+          echo "VULKAN_SDK=${HOME}/vulkan-sdk/1.4.321.1/x86_64" >> $GITHUB_ENV
+          echo "VK_LAYER_PATH=${HOME}/vulkan-sdk/1.4.321.1/x86_64/etc/vulkan/explicit_layer.d" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${HOME}/vulkan-sdk/1.4.321.1/x86_64/lib" >> $GITHUB_ENV
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Vulkan SDK
         run: |
           wget -q https://sdk.lunarg.com/sdk/download/1.4.313.0/linux/vulkansdk-linux-x86_64-1.4.313.0.tar.xz
-          if ! echo "d23343736247828ff5b3b6b1b7fd83a72b5df1a54b2527ae3663cebdfee75842 vulkansdk-linux-x86_64-1.4.313.0.tar.xz" | sha256sum -c --status; then
+          if ! echo "4e957b66ade85eeaee95932aa7e3b45aea64db373c58a5eaefc8228cc71445c2 vulkansdk-linux-x86_64-1.4.313.0.tar.xz" | sha256sum -c --status; then
             echo "Invalid SHA256 for VulkanSDK's binary. Aborting."
             exit 1
           fi

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -21,17 +21,17 @@ jobs:
           sdk-version: 22621
       - name: Setup Vulkan SDK
         run: |
-          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.3.268.0/windows/VulkanSDK-1.3.268.0-Installer.exe
-          if ((Get-FileHash .\VulkanSDK-1.3.268.0-Installer.exe).Hash -ne "8459ef49bd06b697115ddd3d97c9aec729e849cd775f5be70897718a9b3b9db5") {
+          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/VulkanSDK-1.4.313.0-Installer.exe
+          if ((Get-FileHash .\VulkanSDK-1.4.313.0-Installer.exe).Hash -ne "8459ef49bd06b697115ddd3d97c9aec729e849cd775f5be70897718a9b3b9db5") {
             exit 1
           }
-          .\VulkanSDK-1.3.268.0-Installer.exe install --accept-licenses --default-answer --confirm-command --root "$HOME\vulkan-sdk"
+          .\VulkanSDK-1.4.313.0-Installer.exe install --accept-licenses --default-answer --confirm-command --root "$HOME\vulkan-sdk"
           "VULKAN_SDK=${HOME}\vulkan-sdk" >> $env:GITHUB_ENV
 
           # Get the vulkan-1.dll and add it to the PATH, which is required when we execute binaries.
-          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.3.268.0/windows/VulkanRT-1.3.268.0-Components.zip
-          Expand-Archive VulkanRT-1.3.268.0-Components.zip -DestinationPath "$HOME\vulkan-sdk\RTComponents"
-          "$HOME\vulkan-sdk\RTComponents\VulkanRT-1.3.268.0-Components\x64" >> $env:GITHUB_PATH
+          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/VulkanRT-1.4.313.0-Components.zip
+          Expand-Archive VulkanRT-1.4.313.0-Components.zip -DestinationPath "$HOME\vulkan-sdk\RTComponents"
+          "$HOME\vulkan-sdk\RTComponents\VulkanRT-1.4.313.0-Components\x64" >> $env:GITHUB_PATH
       - name: Setup software renderer (WARP)
         run: |
           # We download the latest version of WARP instead of using the one provided by Windows

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -21,17 +21,17 @@ jobs:
           sdk-version: 22621
       - name: Setup Vulkan SDK
         run: |
-          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.313.2/windows/vulkansdk-windows-X64-1.4.313.2.exe
-          if ((Get-FileHash .\vulkansdk-windows-X64-1.4.313.2.exe).Hash -ne "34a921d951858274ca8e470e9d0a3b7624db41216b3908ccea9f73c8a1b7500e") {
+          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.321.1/windows/vulkansdk-windows-X64-1.4.321.1.exe
+          if ((Get-FileHash .\vulkansdk-windows-X64-1.4.321.1.exe).Hash -ne "baaa4f7ca11ed3d82aa1c102b21208915485bbaa473068c763daa425cca468bd") {
             exit 1
           }
-          .\vulkansdk-windows-X64-1.4.313.2.exe install --accept-licenses --default-answer --confirm-command --root "$HOME\vulkan-sdk"
+          .\vulkansdk-windows-X64-1.4.321.1.exe install --accept-licenses --default-answer --confirm-command --root "$HOME\vulkan-sdk"
           "VULKAN_SDK=${HOME}\vulkan-sdk" >> $env:GITHUB_ENV
 
           # Get the vulkan-1.dll and add it to the PATH, which is required when we execute binaries.
-          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/VulkanRT-X64-1.4.313.0-Components.zip
-          Expand-Archive VulkanRT-X64-1.4.313.0-Components.zip -DestinationPath "$HOME\vulkan-sdk\RTComponents"
-          "$HOME\vulkan-sdk\RTComponents\VulkanRT-X64-1.4.313.0-Components\x64" >> $env:GITHUB_PATH
+          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.321.0/windows/VulkanRT-X64-1.4.321.0-Components.zip
+          Expand-Archive VulkanRT-X64-1.4.321.0-Components.zip -DestinationPath "$HOME\vulkan-sdk\RTComponents"
+          "$HOME\vulkan-sdk\RTComponents\VulkanRT-X64-1.4.321.0-Components\x64" >> $env:GITHUB_PATH
       - name: Setup software renderer (WARP)
         run: |
           # We download the latest version of WARP instead of using the one provided by Windows

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -21,17 +21,17 @@ jobs:
           sdk-version: 22621
       - name: Setup Vulkan SDK
         run: |
-          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/VulkanSDK-1.4.313.0-Installer.exe
-          if ((Get-FileHash .\VulkanSDK-1.4.313.0-Installer.exe).Hash -ne "8459ef49bd06b697115ddd3d97c9aec729e849cd775f5be70897718a9b3b9db5") {
+          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.313.2/windows/vulkansdk-windows-X64-1.4.313.2.exe
+          if ((Get-FileHash .\vulkansdk-windows-X64-1.4.313.2.exe).Hash -ne "34a921d951858274ca8e470e9d0a3b7624db41216b3908ccea9f73c8a1b7500e") {
             exit 1
           }
-          .\VulkanSDK-1.4.313.0-Installer.exe install --accept-licenses --default-answer --confirm-command --root "$HOME\vulkan-sdk"
+          .\vulkansdk-windows-X64-1.4.313.2.exe install --accept-licenses --default-answer --confirm-command --root "$HOME\vulkan-sdk"
           "VULKAN_SDK=${HOME}\vulkan-sdk" >> $env:GITHUB_ENV
 
           # Get the vulkan-1.dll and add it to the PATH, which is required when we execute binaries.
-          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/VulkanRT-1.4.313.0-Components.zip
+          Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/VulkanRT-X64-1.4.313.0-Components.zip
           Expand-Archive VulkanRT-1.4.313.0-Components.zip -DestinationPath "$HOME\vulkan-sdk\RTComponents"
-          "$HOME\vulkan-sdk\RTComponents\VulkanRT-1.4.313.0-Components\x64" >> $env:GITHUB_PATH
+          "$HOME\vulkan-sdk\RTComponents\VulkanRT-X64-1.4.313.0-Components\x64" >> $env:GITHUB_PATH
       - name: Setup software renderer (WARP)
         run: |
           # We download the latest version of WARP instead of using the one provided by Windows

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -30,7 +30,7 @@ jobs:
 
           # Get the vulkan-1.dll and add it to the PATH, which is required when we execute binaries.
           Start-BitsTransfer -Source https://sdk.lunarg.com/sdk/download/1.4.313.0/windows/VulkanRT-X64-1.4.313.0-Components.zip
-          Expand-Archive VulkanRT-1.4.313.0-Components.zip -DestinationPath "$HOME\vulkan-sdk\RTComponents"
+          Expand-Archive VulkanRT-X64-1.4.313.0-Components.zip -DestinationPath "$HOME\vulkan-sdk\RTComponents"
           "$HOME\vulkan-sdk\RTComponents\VulkanRT-X64-1.4.313.0-Components\x64" >> $env:GITHUB_PATH
       - name: Setup software renderer (WARP)
         run: |


### PR DESCRIPTION
Use the latest validation layers in CI to take advantage of the additional checks (e.g. https://github.com/google/bigwheels/issues/562)