### PR TITLE
Revert "Safely reuse Present wait semaphore"

### DIFF
--- a/benchmarks/compute_operations/main.cpp
+++ b/benchmarks/compute_operations/main.cpp
@@ -47,6 +47,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -169,6 +170,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -446,12 +449,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/draw_call/main.cpp
+++ b/benchmarks/draw_call/main.cpp
@@ -47,6 +47,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -130,6 +131,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -279,12 +282,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/foveation/FoveationBenchmarkApp.cpp
+++ b/benchmarks/foveation/FoveationBenchmarkApp.cpp
@@ -80,6 +80,7 @@ void FoveationBenchmarkApp::SetupSync()
 {
     grfx::SemaphoreCreateInfo semaCreateInfo = {};
     PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &mSync.imageAcquiredSemaphore));
+    PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &mSync.renderCompleteSemaphore));
     PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &mSync.postCompleteSemaphore));
 
     grfx::FenceCreateInfo fenceCreateInfo = {};
@@ -500,7 +501,7 @@ void FoveationBenchmarkApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &mSync.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &mSync.renderCompleteSemaphore;
     submitInfo.pFence               = nullptr;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
@@ -509,7 +510,7 @@ void FoveationBenchmarkApp::Render()
     submitInfo.commandBufferCount   = 1;
     submitInfo.ppCommandBuffers     = &mPost.cmd;
     submitInfo.waitSemaphoreCount   = 1;
-    submitInfo.ppWaitSemaphores     = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppWaitSemaphores     = &mSync.renderCompleteSemaphore;
     submitInfo.signalSemaphoreCount = 1;
     submitInfo.ppSignalSemaphores   = &mSync.postCompleteSemaphore;
     submitInfo.pFence               = mSync.postCompleteFence;

--- a/benchmarks/foveation/FoveationBenchmarkApp.h
+++ b/benchmarks/foveation/FoveationBenchmarkApp.h
@@ -160,6 +160,7 @@ private:
     {
         grfx::FencePtr     imageAcquiredFence;
         grfx::SemaphorePtr imageAcquiredSemaphore;
+        grfx::SemaphorePtr renderCompleteSemaphore;
         grfx::SemaphorePtr postCompleteSemaphore;
         grfx::FencePtr     postCompleteFence;
     } mSync;

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp
@@ -267,6 +267,8 @@ void GraphicsBenchmarkApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -1148,7 +1150,7 @@ void GraphicsBenchmarkApp::Render()
         submitInfo.waitSemaphoreCount   = 1;
         submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     }
     submitInfo.pFence = frame.renderCompleteFence;
 
@@ -1162,7 +1164,7 @@ void GraphicsBenchmarkApp::Render()
     if (!IsXrEnabled())
 #endif
     {
-        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
     }
 }
 

--- a/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
+++ b/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.h
@@ -259,6 +259,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
         grfx::QueryPtr         timestampQuery;
 

--- a/benchmarks/overdraw/main.cpp
+++ b/benchmarks/overdraw/main.cpp
@@ -61,6 +61,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -176,6 +177,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -415,12 +418,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/render_target/main.cpp
+++ b/benchmarks/render_target/main.cpp
@@ -47,6 +47,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -162,6 +163,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -427,12 +430,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/texture_load/main.cpp
+++ b/benchmarks/texture_load/main.cpp
@@ -47,6 +47,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -131,6 +132,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -330,12 +333,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/texture_sample/main.cpp
+++ b/benchmarks/texture_sample/main.cpp
@@ -51,6 +51,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
         ppx::grfx::QueryPtr         timestampQuery;
     };
@@ -162,6 +163,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -408,12 +411,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
+++ b/benchmarks/texture_transfer_cpu_to_gpu/main.cpp
@@ -45,6 +45,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 
@@ -284,6 +285,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -354,12 +357,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 int main(int argc, char** argv)

--- a/include/ppx/grfx/grfx_swapchain.h
+++ b/include/ppx/grfx/grfx_swapchain.h
@@ -135,20 +135,12 @@ public:
     Result GetRenderTargetView(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::RenderTargetView** ppView) const;
     Result GetDepthStencilView(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp, grfx::DepthStencilView** ppView) const;
 
-    // Use this semaphore to synchronize submit and present correctly.
-    // See https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html
-    Result GetPresentationReadySemaphore(uint32_t imageIndex, grfx::Semaphore** ppSemaphore) const;
-
     // Convenience functions - returns empty object if index is invalid
     grfx::ImagePtr            GetColorImage(uint32_t imageIndex) const;
     grfx::ImagePtr            GetDepthImage(uint32_t imageIndex) const;
     grfx::RenderPassPtr       GetRenderPass(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR) const;
     grfx::RenderTargetViewPtr GetRenderTargetView(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR) const;
     grfx::DepthStencilViewPtr GetDepthStencilView(uint32_t imageIndex, grfx::AttachmentLoadOp loadOp = grfx::ATTACHMENT_LOAD_OP_CLEAR) const;
-
-    // Use this semaphore to synchronize submit and present correctly.
-    // See https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html
-    grfx::SemaphorePtr GetPresentationReadySemaphore(uint32_t imageIndex) const;
 
     Result AcquireNextImage(
         uint64_t         timeout,    // Nanoseconds
@@ -194,9 +186,6 @@ protected:
     void   DestroyRenderPasses();
     Result CreateRenderTargets();
     void   DestroyRenderTargets();
-    // Create a semaphore for each swapchain image used for synchronizing submit with present.
-    Result CreateSemaphores();
-    void   DestroySemaphores();
 
 private:
     virtual Result AcquireNextImageInternal(
@@ -233,7 +222,6 @@ protected:
     std::vector<grfx::DepthStencilViewPtr> mLoadDepthStencilViews;
     std::vector<grfx::RenderPassPtr>       mClearRenderPasses;
     std::vector<grfx::RenderPassPtr>       mLoadRenderPasses;
-    std::vector<grfx::SemaphorePtr>        mPresentationReadySemaphores;
 
 #if defined(PPX_BUILD_XR)
     XrSwapchain mXrColorSwapchain = XR_NULL_HANDLE;

--- a/projects/arcball_camera/main.cpp
+++ b/projects/arcball_camera/main.cpp
@@ -39,6 +39,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -199,6 +200,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -325,12 +328,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/async_compute/main.cpp
+++ b/projects/async_compute/main.cpp
@@ -45,6 +45,7 @@ private:
     {
         grfx::SemaphorePtr imageAcquiredSemaphore;
         grfx::FencePtr     imageAcquiredFence;
+        grfx::SemaphorePtr renderCompleteSemaphore;
         grfx::FencePtr     renderCompleteFence;
 
         // Graphics pipeline objects.
@@ -192,6 +193,7 @@ void ProjApp::Setup()
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.imageAcquiredSemaphore));
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         mPerFrame.push_back(frame);
     }
@@ -932,12 +934,12 @@ void ProjApp::BlitAndPresent(PerFrame& frame, uint32_t swapchainImageIndex)
     submitInfo.waitSemaphoreCount   = sizeof(ppWaitSemaphores) / sizeof(ppWaitSemaphores[0]);
     submitInfo.ppWaitSemaphores     = ppWaitSemaphores;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(swapchainImageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(GetSwapchain()->Present(swapchainImageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(swapchainImageIndex)));
+    PPX_CHECKED_CALL(GetSwapchain()->Present(swapchainImageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void ProjApp::DrawGui()

--- a/projects/basic_material/main.cpp
+++ b/projects/basic_material/main.cpp
@@ -86,6 +86,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
 #ifdef ENABLE_GPU_QUERIES
         ppx::grfx::QueryPtr timestampQuery;
@@ -1056,6 +1057,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -1405,12 +1408,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void ProjApp::DrawGui()

--- a/projects/camera_fit_scene/main.cpp
+++ b/projects/camera_fit_scene/main.cpp
@@ -40,6 +40,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -200,6 +201,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -334,12 +337,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/camera_motion/main.cpp
+++ b/projects/camera_motion/main.cpp
@@ -197,6 +197,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -458,6 +459,8 @@ void ProjApp::SetupPerFrameData(void)
 
     grfx::FenceCreateInfo fenceCreateInfo = {};
     PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+    PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
     fenceCreateInfo = {true};
     PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -755,12 +758,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void ProjApp::DrawGui()

--- a/projects/cube_xr/CubeXr.cpp
+++ b/projects/cube_xr/CubeXr.cpp
@@ -126,6 +126,8 @@ void CubeXrApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -351,7 +353,7 @@ void CubeXrApp::Render()
         submitInfo.waitSemaphoreCount   = 1;
         submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     }
     submitInfo.pFence = frame.renderCompleteFence;
 
@@ -359,6 +361,6 @@ void CubeXrApp::Render()
 
     // No need to present when XR is enabled.
     if (!IsXrEnabled()) {
-        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+        PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
     }
 }

--- a/projects/cube_xr/CubeXr.h
+++ b/projects/cube_xr/CubeXr.h
@@ -40,6 +40,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
 
         UniformBufferData uniform_buffer_data = {};

--- a/projects/dynamic_rendering/DynamicRendering.cpp
+++ b/projects/dynamic_rendering/DynamicRendering.cpp
@@ -104,6 +104,8 @@ void DynamicRenderingApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -220,10 +222,10 @@ void DynamicRenderingApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }

--- a/projects/dynamic_rendering/DynamicRendering.h
+++ b/projects/dynamic_rendering/DynamicRendering.h
@@ -32,6 +32,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/fishtornado/FishTornado.cpp
+++ b/projects/fishtornado/FishTornado.cpp
@@ -259,6 +259,7 @@ void FishTornadoApp::SetupPerFrame()
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.copyConstantsSemaphore));
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.flockingCompleteSemaphore));
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.shadowCompleteSemaphore));
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         // Image acquired sync objects
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.imageAcquiredSemaphore));
@@ -870,7 +871,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.waitSemaphoreCount   = waitSemaphoreCount;
         submitInfo.ppWaitSemaphores     = ppWaitSemaphores;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
 
         PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
     }
@@ -897,7 +898,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.commandBufferCount   = 1;
         submitInfo.ppCommandBuffers     = &frame.gpuEndTimestampCmd;
         submitInfo.waitSemaphoreCount   = 1;
-        submitInfo.ppWaitSemaphores     = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+        submitInfo.ppWaitSemaphores     = &frame.renderCompleteSemaphore;
         submitInfo.signalSemaphoreCount = 1;
         submitInfo.ppSignalSemaphores   = &frame.frameCompleteSemaphore;
         submitInfo.pFence               = frame.frameCompleteFence;
@@ -909,7 +910,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
     {
         grfx::SubmitInfo submitInfo     = {};
         submitInfo.waitSemaphoreCount   = 1;
-        submitInfo.ppWaitSemaphores     = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+        submitInfo.ppWaitSemaphores     = &frame.renderCompleteSemaphore;
         submitInfo.signalSemaphoreCount = 1;
         submitInfo.ppSignalSemaphores   = &frame.frameCompleteSemaphore;
         submitInfo.pFence               = frame.frameCompleteFence;

--- a/projects/fishtornado/FishTornado.h
+++ b/projects/fishtornado/FishTornado.h
@@ -103,6 +103,7 @@ private:
         grfx::SemaphorePtr     copyConstantsSemaphore;
         grfx::SemaphorePtr     flockingCompleteSemaphore;
         grfx::SemaphorePtr     shadowCompleteSemaphore;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
         grfx::SemaphorePtr     frameCompleteSemaphore;

--- a/projects/fishtornado_xr/FishTornado.cpp
+++ b/projects/fishtornado_xr/FishTornado.cpp
@@ -271,6 +271,7 @@ void FishTornadoApp::SetupPerFrame()
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.copyConstantsSemaphore));
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.flockingCompleteSemaphore));
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.shadowCompleteSemaphore));
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         // Image acquired sync objects
         PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.imageAcquiredSemaphore));
@@ -936,7 +937,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.waitSemaphoreCount   = waitSemaphoreCount;
         submitInfo.ppWaitSemaphores     = &pWaitSemaphores;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
 
         PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
     }
@@ -950,7 +951,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.waitSemaphoreCount   = waitSemaphoreCount;
         submitInfo.ppWaitSemaphores     = ppWaitSemaphores;
         submitInfo.signalSemaphoreCount = 1;
-        submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+        submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
 
         PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
     }
@@ -977,7 +978,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
         submitInfo.commandBufferCount   = 1;
         submitInfo.ppCommandBuffers     = &frame.gpuEndTimestampCmd;
         submitInfo.waitSemaphoreCount   = 1;
-        submitInfo.ppWaitSemaphores     = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+        submitInfo.ppWaitSemaphores     = &frame.renderCompleteSemaphore;
         submitInfo.signalSemaphoreCount = 1;
         submitInfo.ppSignalSemaphores   = &frame.frameCompleteSemaphore;
         submitInfo.pFence               = frame.frameCompleteFence;
@@ -995,7 +996,7 @@ void FishTornadoApp::RenderSceneUsingMultipleCommandBuffers(
     {
         grfx::SubmitInfo submitInfo     = {};
         submitInfo.waitSemaphoreCount   = 1;
-        submitInfo.ppWaitSemaphores     = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+        submitInfo.ppWaitSemaphores     = &frame.renderCompleteSemaphore;
         submitInfo.signalSemaphoreCount = 1;
         submitInfo.ppSignalSemaphores   = &frame.frameCompleteSemaphore;
         submitInfo.pFence               = frame.frameCompleteFence;

--- a/projects/fishtornado_xr/FishTornado.h
+++ b/projects/fishtornado_xr/FishTornado.h
@@ -105,6 +105,7 @@ private:
         grfx::SemaphorePtr     copyConstantsSemaphore;
         grfx::SemaphorePtr     flockingCompleteSemaphore;
         grfx::SemaphorePtr     shadowCompleteSemaphore;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
         grfx::SemaphorePtr     frameCompleteSemaphore;

--- a/projects/fluid_simulation/shaders.h
+++ b/projects/fluid_simulation/shaders.h
@@ -31,11 +31,12 @@ struct ComputeDispatchData
 
 struct PerFrame
 {
-    ppx::grfx::CommandBufferPtr      cmd                    = nullptr;
-    ppx::grfx::SemaphorePtr          imageAcquiredSemaphore = nullptr;
-    ppx::grfx::FencePtr              imageAcquiredFence     = nullptr;
-    ppx::grfx::FencePtr              renderCompleteFence    = nullptr;
-    uint32_t                         dispatchID             = 0;
+    ppx::grfx::CommandBufferPtr      cmd                     = nullptr;
+    ppx::grfx::SemaphorePtr          imageAcquiredSemaphore  = nullptr;
+    ppx::grfx::FencePtr              imageAcquiredFence      = nullptr;
+    ppx::grfx::SemaphorePtr          renderCompleteSemaphore = nullptr;
+    ppx::grfx::FencePtr              renderCompleteFence     = nullptr;
+    uint32_t                         dispatchID              = 0;
     std::vector<ComputeDispatchData> mDispatchData;
 
     ComputeDispatchData* GetDispatchData()

--- a/projects/fluid_simulation/sim.cpp
+++ b/projects/fluid_simulation/sim.cpp
@@ -207,6 +207,7 @@ void FluidSimulationApp::Setup()
     PPX_CHECKED_CALL(GetDevice()->GetGraphicsQueue()->CreateCommandBuffer(&frame.cmd));
     PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&sci, &frame.imageAcquiredSemaphore));
     PPX_CHECKED_CALL(GetDevice()->CreateFence(&fci, &frame.imageAcquiredFence));
+    PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&sci, &frame.renderCompleteSemaphore));
     fci = {true}; // Create signaled
     PPX_CHECKED_CALL(GetDevice()->CreateFence(&fci, &frame.renderCompleteFence));
     mPerFrame.push_back(frame);
@@ -462,12 +463,12 @@ void FluidSimulationApp::Render()
     submitInfo.waitSemaphoreCount    = 1;
     submitInfo.ppWaitSemaphores      = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount  = 1;
-    submitInfo.ppSignalSemaphores    = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores    = &frame.renderCompleteSemaphore;
     submitInfo.pFence                = frame.renderCompleteFence;
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
     // Present and signal.
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void FluidSimulationApp::UpdateKnobVisibility()

--- a/projects/gbuffer/main.cpp
+++ b/projects/gbuffer/main.cpp
@@ -47,6 +47,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
 #ifdef ENABLE_GPU_QUERIES
         ppx::grfx::QueryPtr timestampQuery;
@@ -140,6 +141,8 @@ void ProjApp::SetupPerFrame()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -859,12 +862,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void ProjApp::DrawGui()

--- a/projects/gltf/main.cpp
+++ b/projects/gltf/main.cpp
@@ -47,6 +47,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -695,6 +696,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -813,12 +816,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/gltf_basic_materials/GltfBasicMaterials.cpp
+++ b/projects/gltf_basic_materials/GltfBasicMaterials.cpp
@@ -80,6 +80,8 @@ void GltfBasicMaterialsApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -358,12 +360,12 @@ void GltfBasicMaterialsApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void GltfBasicMaterialsApp::InitKnobs()

--- a/projects/gltf_basic_materials/GltfBasicMaterials.h
+++ b/projects/gltf_basic_materials/GltfBasicMaterials.h
@@ -40,6 +40,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/image_filter/main.cpp
+++ b/projects/image_filter/main.cpp
@@ -44,6 +44,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
         grfx::QueryPtr         timestampQuery;
     };
@@ -134,6 +135,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -516,12 +519,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
     if (GetFrameCount() > 0) {
         uint64_t frequency = 0;
         GetGraphicsQueue()->GetTimestampFrequency(&frequency);

--- a/projects/input/main.cpp
+++ b/projects/input/main.cpp
@@ -45,6 +45,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 
@@ -76,6 +77,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -171,12 +174,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(Present(swapchain, imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(Present(swapchain, imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void ProjApp::DrawGui()

--- a/projects/mipmap_demo/main.cpp
+++ b/projects/mipmap_demo/main.cpp
@@ -39,6 +39,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 
@@ -209,6 +210,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -335,12 +338,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void ProjApp::DrawGui()

--- a/projects/oit_demo/OITDemoApplication.cpp
+++ b/projects/oit_demo/OITDemoApplication.cpp
@@ -62,6 +62,8 @@ void OITDemoApp::SetupCommon()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &mImageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &mRenderCompleteSemaphore));
+
         fenceCreateInfo.signaled = true;
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &mRenderCompleteFence));
     }
@@ -620,8 +622,8 @@ void OITDemoApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &mImageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &mRenderCompleteSemaphore;
     submitInfo.pFence               = mRenderCompleteFence;
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
-    PPX_CHECKED_CALL(GetSwapchain()->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(GetSwapchain()->Present(imageIndex, 1, &mRenderCompleteSemaphore));
 }

--- a/projects/oit_demo/OITDemoApplication.h
+++ b/projects/oit_demo/OITDemoApplication.h
@@ -154,6 +154,7 @@ private:
 
     grfx::SemaphorePtr mImageAcquiredSemaphore;
     grfx::FencePtr     mImageAcquiredFence;
+    grfx::SemaphorePtr mRenderCompleteSemaphore;
     grfx::FencePtr     mRenderCompleteFence;
 
     grfx::CommandBufferPtr  mCommandBuffer;

--- a/projects/primitives/main.cpp
+++ b/projects/primitives/main.cpp
@@ -36,6 +36,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -210,6 +211,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -342,12 +345,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/push_constants/PushConstants.cpp
+++ b/projects/push_constants/PushConstants.cpp
@@ -180,6 +180,8 @@ void PushConstantsApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -355,10 +357,10 @@ void PushConstantsApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }

--- a/projects/push_constants/PushConstants.h
+++ b/projects/push_constants/PushConstants.h
@@ -32,6 +32,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/push_descriptors/PushDescriptors.cpp
+++ b/projects/push_descriptors/PushDescriptors.cpp
@@ -149,6 +149,8 @@ void PushDescriptorsApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -355,10 +357,10 @@ void PushDescriptorsApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }

--- a/projects/push_descriptors/PushDescriptors.h
+++ b/projects/push_descriptors/PushDescriptors.h
@@ -32,6 +32,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/push_descriptors_buffers/PushDescriptorsBuffers.cpp
+++ b/projects/push_descriptors_buffers/PushDescriptorsBuffers.cpp
@@ -206,6 +206,8 @@ void PushDescriptorsBuffersApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -397,10 +399,10 @@ void PushDescriptorsBuffersApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }

--- a/projects/push_descriptors_buffers/PushDescriptorsBuffers.h
+++ b/projects/push_descriptors_buffers/PushDescriptorsBuffers.h
@@ -32,6 +32,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/sample_01_triangle/Triangle.cpp
+++ b/projects/sample_01_triangle/Triangle.cpp
@@ -80,6 +80,8 @@ void TriangleApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -162,18 +164,16 @@ void TriangleApp::Render()
     }
     PPX_CHECKED_CALL(frame.cmd->End());
 
-    grfx::SemaphorePtr presentationReadySemaphore = swapchain->GetPresentationReadySemaphore(imageIndex);
-
     grfx::SubmitInfo submitInfo     = {};
     submitInfo.commandBufferCount   = 1;
     submitInfo.ppCommandBuffers     = &frame.cmd;
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &presentationReadySemaphore;
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &presentationReadySemaphore));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }

--- a/projects/sample_01_triangle/Triangle.h
+++ b/projects/sample_01_triangle/Triangle.h
@@ -32,6 +32,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/sample_02_triangle_spinning/TriangleSpinning.cpp
+++ b/projects/sample_02_triangle_spinning/TriangleSpinning.cpp
@@ -113,6 +113,8 @@ void TriangleSpinningApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -208,10 +210,10 @@ void TriangleSpinningApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }

--- a/projects/sample_02_triangle_spinning/TriangleSpinning.h
+++ b/projects/sample_02_triangle_spinning/TriangleSpinning.h
@@ -32,6 +32,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/sample_03_square_textured/SquareTextured.cpp
+++ b/projects/sample_03_square_textured/SquareTextured.cpp
@@ -142,6 +142,8 @@ void SquareTexturedApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -241,10 +243,10 @@ void SquareTexturedApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }

--- a/projects/sample_03_square_textured/SquareTextured.h
+++ b/projects/sample_03_square_textured/SquareTextured.h
@@ -33,6 +33,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/sample_04_cube/Cube.cpp
+++ b/projects/sample_04_cube/Cube.cpp
@@ -115,6 +115,8 @@ void CubeApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -279,10 +281,10 @@ void CubeApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }

--- a/projects/sample_04_cube/Cube.h
+++ b/projects/sample_04_cube/Cube.h
@@ -32,6 +32,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 

--- a/projects/sample_05_cube_textured/main.cpp
+++ b/projects/sample_05_cube_textured/main.cpp
@@ -36,6 +36,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 
@@ -182,6 +183,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -360,12 +363,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_06_compute_fill/main.cpp
+++ b/projects/sample_06_compute_fill/main.cpp
@@ -36,6 +36,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -222,6 +223,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -329,12 +332,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_07_draw_indexed/main.cpp
+++ b/projects/sample_07_draw_indexed/main.cpp
@@ -35,6 +35,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -144,6 +145,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -309,12 +312,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_08_basic_geometry/main.cpp
+++ b/projects/sample_08_basic_geometry/main.cpp
@@ -36,6 +36,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -208,6 +209,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -375,12 +378,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_09_obj_geometry/main.cpp
+++ b/projects/sample_09_obj_geometry/main.cpp
@@ -36,6 +36,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -173,6 +174,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -283,12 +286,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_10_cube_map/main.cpp
+++ b/projects/sample_10_cube_map/main.cpp
@@ -42,6 +42,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
         grfx::QueryPtr         timestampQuery;
     };
@@ -256,6 +257,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -416,12 +419,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void ProjApp::DrawGui()

--- a/projects/sample_11_compressed_texture/main.cpp
+++ b/projects/sample_11_compressed_texture/main.cpp
@@ -53,6 +53,7 @@ private:
         ppx::grfx::CommandBufferPtr cmd;
         ppx::grfx::SemaphorePtr     imageAcquiredSemaphore;
         ppx::grfx::FencePtr         imageAcquiredFence;
+        ppx::grfx::SemaphorePtr     renderCompleteSemaphore;
         ppx::grfx::FencePtr         renderCompleteFence;
     };
 
@@ -214,6 +215,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -355,12 +358,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/projects/sample_12_shadows/main.cpp
+++ b/projects/sample_12_shadows/main.cpp
@@ -42,6 +42,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -420,6 +421,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -572,12 +575,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void ProjApp::DrawGui()

--- a/projects/sample_13_normal_map/main.cpp
+++ b/projects/sample_13_normal_map/main.cpp
@@ -40,6 +40,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
 
@@ -334,6 +335,8 @@ void ProjApp::Setup()
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
 
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
+
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
 
@@ -453,12 +456,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 void ProjApp::DrawGui()

--- a/projects/text_draw/main.cpp
+++ b/projects/text_draw/main.cpp
@@ -36,6 +36,7 @@ private:
         grfx::CommandBufferPtr cmd;
         grfx::SemaphorePtr     imageAcquiredSemaphore;
         grfx::FencePtr         imageAcquiredFence;
+        grfx::SemaphorePtr     renderCompleteSemaphore;
         grfx::FencePtr         renderCompleteFence;
     };
     std::vector<PerFrame> mPerFrame;
@@ -67,6 +68,8 @@ void ProjApp::Setup()
 
         grfx::FenceCreateInfo fenceCreateInfo = {};
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.imageAcquiredFence));
+
+        PPX_CHECKED_CALL(GetDevice()->CreateSemaphore(&semaCreateInfo, &frame.renderCompleteSemaphore));
 
         fenceCreateInfo = {true}; // Create signaled
         PPX_CHECKED_CALL(GetDevice()->CreateFence(&fenceCreateInfo, &frame.renderCompleteFence));
@@ -198,12 +201,12 @@ void ProjApp::Render()
     submitInfo.waitSemaphoreCount   = 1;
     submitInfo.ppWaitSemaphores     = &frame.imageAcquiredSemaphore;
     submitInfo.signalSemaphoreCount = 1;
-    submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
+    submitInfo.ppSignalSemaphores   = &frame.renderCompleteSemaphore;
     submitInfo.pFence               = frame.renderCompleteFence;
 
     PPX_CHECKED_CALL(GetGraphicsQueue()->Submit(&submitInfo));
 
-    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &GetSwapchain()->GetPresentationReadySemaphore(imageIndex)));
+    PPX_CHECKED_CALL(swapchain->Present(imageIndex, 1, &frame.renderCompleteSemaphore));
 }
 
 SETUP_APPLICATION(ProjApp)

--- a/src/ppx/grfx/dx12/dx12_swapchain.cpp
+++ b/src/ppx/grfx/dx12/dx12_swapchain.cpp
@@ -409,7 +409,6 @@ Result Swapchain::Resize(uint32_t width, uint32_t height)
     }
 
     // Destroy these to make sure there's no reference before resizing
-    DestroySemaphores();
     DestroyRenderPasses();
     DestroyRenderTargets();
     DestroyDepthImages();
@@ -461,8 +460,6 @@ Result Swapchain::Resize(uint32_t width, uint32_t height)
 
     // Create render passes
     CreateRenderPasses();
-
-    CreateSemaphores();
 
     return ppx::SUCCESS;
 }

--- a/src/ppx/grfx/grfx_swapchain.cpp
+++ b/src/ppx/grfx/grfx_swapchain.cpp
@@ -92,11 +92,6 @@ Result Swapchain::Create(const grfx::SwapchainCreateInfo* pCreateInfo)
         return ppxres;
     }
 
-    ppxres = CreateSemaphores();
-    if (Failed(ppxres)) {
-        return ppxres;
-    }
-
     if (IsHeadless()) {
         // Set mCurrentImageIndex to (imageCount - 1) so that the first
         // AcquireNextImage call acquires the first image at index 0.
@@ -122,8 +117,6 @@ Result Swapchain::Create(const grfx::SwapchainCreateInfo* pCreateInfo)
 
 void Swapchain::Destroy()
 {
-    DestroySemaphores();
-
     DestroyRenderPasses();
 
     DestroyRenderTargets();
@@ -357,35 +350,6 @@ void Swapchain::DestroyRenderPasses()
     mLoadRenderPasses.clear();
 }
 
-Result Swapchain::CreateSemaphores()
-{
-    uint32_t imageCount = CountU32(mColorImages);
-    PPX_ASSERT_MSG((imageCount > 0), "No color images found for swapchain semaphores");
-
-    for (size_t i = 0; i < imageCount; ++i) {
-        grfx::SemaphorePtr        semaphore;
-        grfx::SemaphoreCreateInfo createInfo = {};
-        auto                      ppxres     = GetDevice()->CreateSemaphore(&createInfo, &semaphore);
-        if (Failed(ppxres)) {
-            PPX_ASSERT_MSG(false, "grfx::Swapchain::CreateSemaphores() failed");
-            return ppxres;
-        }
-        mPresentationReadySemaphores.push_back(semaphore);
-    }
-
-    return ppx::SUCCESS;
-}
-
-void Swapchain::DestroySemaphores()
-{
-    for (auto& elem : mPresentationReadySemaphores) {
-        if (elem) {
-            GetDevice()->DestroySemaphore(elem);
-        }
-    }
-    mPresentationReadySemaphores.clear();
-}
-
 bool Swapchain::IsHeadless() const
 {
 #if defined(PPX_BUILD_XR)
@@ -455,15 +419,6 @@ Result Swapchain::GetDepthStencilView(uint32_t imageIndex, grfx::AttachmentLoadO
     return ppx::SUCCESS;
 }
 
-Result Swapchain::GetPresentationReadySemaphore(uint32_t imageIndex, grfx::Semaphore** ppSemaphore) const
-{
-    if (!IsIndexInRange(imageIndex, mPresentationReadySemaphores)) {
-        return ppx::ERROR_OUT_OF_RANGE;
-    }
-    *ppSemaphore = mPresentationReadySemaphores[imageIndex];
-    return ppx::SUCCESS;
-}
-
 grfx::ImagePtr Swapchain::GetColorImage(uint32_t imageIndex) const
 {
     grfx::ImagePtr object;
@@ -496,13 +451,6 @@ grfx::DepthStencilViewPtr Swapchain::GetDepthStencilView(uint32_t imageIndex, gr
 {
     grfx::DepthStencilViewPtr object;
     GetDepthStencilView(imageIndex, loadOp, &object);
-    return object;
-}
-
-grfx::SemaphorePtr Swapchain::GetPresentationReadySemaphore(uint32_t imageIndex) const
-{
-    grfx::SemaphorePtr object;
-    GetPresentationReadySemaphore(imageIndex, &object);
     return object;
 }
 


### PR DESCRIPTION
Reverts google/bigwheels#565

This is causing issues in some internal tests. Revert while we investigate why.