### PR TITLE
Remove commented code in obj_ptr.h

### DIFF
--- a/include/ppx/obj_ptr.h
+++ b/include/ppx/obj_ptr.h
@@ -69,26 +69,11 @@ public:
         return mPtrRef;
     }
 
-    //// clang-format off
-    // operator ObjectT** ()
-    //{
-    //     return mPtrRef;
-    // }
-    //// clang-format on
-    //
-    //// clang-format off
-    // operator const ObjectT* const* ()
-    //{
-    //     return mPtrRef;
-    // }
-    //// clang-format on
-
 private:
     virtual void Set(void** ppObj) override
     {
         *mPtrRef = reinterpret_cast<ObjectT*>(*ppObj);
     }
-    // clang-format on
 
 private:
     ObjectT** mPtrRef = nullptr;


### PR DESCRIPTION
This adds no value. If required in the future, it can be retrieved from git history