### PR TITLE
Prevent stack-use-after-scope with ref-qualifier

### DIFF
--- a/include/ppx/obj_ptr.h
+++ b/include/ppx/obj_ptr.h
@@ -151,7 +151,7 @@ public:
         return mPtr;
     }
 
-    ObjPtrRef<ObjectT> operator&()
+    ObjPtrRef<ObjectT> operator&() &
     {
         return ObjPtrRef<ObjectT>(&mPtr);
     }


### PR DESCRIPTION
Tell the compiler that `ObjPtr<T>::operator&` can only be called on lvalues (not temporaries). This would have prevented #565 from compiling:

```
/usr/local/google/home/hitchens/git/bigwheels/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp:1151:43: error: taking the address of a temporary object of type 'grfx::SemaphorePtr' (aka 'ObjPtr<Semaphore>') [-Waddress-of-temporary]
 1151 |         submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
      |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/google/home/hitchens/git/bigwheels/benchmarks/graphics_pipeline/GraphicsBenchmarkApp.cpp:1151:43: error: incompatible pointer types assigning to 'grfx::Semaphore **' from 'grfx::SemaphorePtr *' (aka 'ObjPtr<Semaphore> *')
 1151 |         submitInfo.ppSignalSemaphores   = &GetSwapchain()->GetPresentationReadySemaphore(imageIndex);
      |
```