### PR TITLE
gltf: Create a default sampler when missing

### DIFF
--- a/src/ppx/scene/scene_gltf_loader.cpp
+++ b/src/ppx/scene/scene_gltf_loader.cpp
@@ -359,8 +359,8 @@ ppx::Result ValidateAccessorIndexType(const cgltf_accessor* pGltfAccessor, grfx:
     return ppx::ERROR_SCENE_INVALID_SOURCE_GEOMETRY_INDEX_TYPE;
 }
 
-// The GLTF 2.0 spec 3.8.2 says "When texture.source is undefined, the image SHOULD be provided by
-// an extension or application-specific means, otherwise the texture object is undefined"
+// The GLTF 2.0 spec 3.8.2 says "When texture.sampler is undefined, a sampler with repeat wrapping
+// (in both directions) and auto filtering MUST be used"
 //
 // "Auto filtering" is ambiguous but 3.8.4.1 may provide some clarity: "Client implementations
 // SHOULD follow specified filtering modes. When the latter are undefined, client implementations


### PR DESCRIPTION
GLTF 2.0 spec 3.8.2 says: "When texture.sampler is undefined, a sampler with repeat wrapping (in both directions) and auto filtering MUST be used."

This allows us to load more glTF-Sample-Assets.

Fixes #451

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/6547aaad-4ab9-48bc-aa05-fbf88afe21cc" />

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/ce99c241-5cfb-4050-af1f-71e0a8360bbb" />

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/c07dcbf4-924b-49c1-8983-fb39572e104c" />

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/39271ebd-b425-4132-832a-3c5f5b73dbc3" />

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/6c44f3a7-0720-403b-a414-4140488776d1" />
