### PR TITLE
[glTF] Require normals, texcoords, and tangents

### DIFF
--- a/projects/gltf_basic_materials/GltfBasicMaterials.cpp
+++ b/projects/gltf_basic_materials/GltfBasicMaterials.cpp
@@ -15,6 +15,7 @@
 #include "GltfBasicMaterials.h"
 #include "ppx/scene/scene_gltf_loader.h"
 #include "ppx/graphics_util.h"
+#include "ppx/scene/scene_loader.h"
 
 namespace {
 
@@ -92,7 +93,9 @@ void GltfBasicMaterialsApp::Setup()
         //
         PPX_CHECKED_CALL(scene::GltfLoader::Create(GetAssetPath(mSceneAssetKnob->GetValue()), /*pMaterialSelector=*/nullptr, &pLoader));
 
-        PPX_CHECKED_CALL(pLoader->LoadScene(GetDevice(), 0, &mScene));
+        // Currently, all pipelines use MaterialVertex.vs which requires normals, tangents, and texcoords.
+        auto loadOptions = scene::LoadOptions().SetRequiredAttributes(scene::VertexAttributeFlags().Normals().Tangents().TexCoords());
+        PPX_CHECKED_CALL(pLoader->LoadScene(GetDevice(), 0, &mScene, loadOptions));
         if (mScene->GetCameraNodeCount() == 0) {
             PPX_LOG_WARN("Scene doesn't have a camera node. Using a default camera");
             mDefaultCamera = ArcballCamera();


### PR DESCRIPTION
If they are not present, the attributes are allocated and filled with 0s. This allows us to use the pipelines that we already have.

This allows us to render Unlit Test scene

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/dc8ea671-2c30-45b6-b5e0-366a9f1e4df2" />
