### PR TITLE
Fix asset lookup for multi-config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,9 +183,10 @@ set(PPX_3P_ASSET_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/assets")
 
 # Determine relative path from binary location to the build root.
 cmake_path(SET BUILD_DIRECTORY NORMALIZE "${CMAKE_BINARY_DIR}")
-if (CMAKE_GENERATOR MATCHES "Visual Studio")
-    # Visual Studio doesn't follow CMAKE_RUNTIME_OUTPUT_DIRECTORY, but
-    # creates a subdirectory with the config name.
+get_property(PPX_GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if (PPX_GENERATOR_IS_MULTI_CONFIG)
+    # Multi-config generators place executables in a per-config subdirectory
+    # below CMAKE_RUNTIME_OUTPUT_DIRECTORY (for example: bin/Debug).
     cmake_path(SET EXECUTABLE_DIRECTORY NORMALIZE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/subfolder")
 else ()
     cmake_path(SET EXECUTABLE_DIRECTORY NORMALIZE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
@@ -286,4 +287,3 @@ if (PPX_BUILD_BENCHMARKS)
     message("Building benchmarks projects")
     add_subdirectory(benchmarks)
 endif()
-


### PR DESCRIPTION
## Problem

BigWheels computes `RELATIVE_PATH_TO_PROJECT_ROOT` from the runtime output
directory so applications can find `assets/` at runtime.

That logic only treated Visual Studio as a multi-config generator. With
generators like `Ninja Multi-Config`, executables are also emitted under
`bin/<Config>/`, so the computed relative path is too shallow and samples
fail to locate assets at runtime.

Fixes https://github.com/google/BigWheels/issues/563

## Solution

Use CMake's `GENERATOR_IS_MULTI_CONFIG` global property instead of matching
only `CMAKE_GENERATOR` against Visual Studio.

This keeps the existing single-config behavior unchanged and correctly
accounts for all multi-config generators when deriving the path back to
the build root.

## Testing

I could not run a full configure/build in this environment because `cmake`
was not installed.

I did verify the path math for the affected layouts:
- single-config `bin` resolves back to the build root with `..`
- multi-config `bin/Debug` resolves back to the build root with `../..`
