### PR TITLE
  Implement glTF COLOR_0 vertex color support in StandardMaterial and UnlitMaterial

### DIFF
--- a/assets/scene_renderer/shaders/DebugMaterial.hlsl
+++ b/assets/scene_renderer/shaders/DebugMaterial.hlsl
@@ -15,6 +15,7 @@
 #define ENABLE_VTX_ATTR_TEXCOORD
 #define ENABLE_VTX_ATTR_NORMAL
 #define ENABLE_VTX_ATTR_TANGENT
+#define ENABLE_VTX_ATTR_COLOR
 
 #include "MaterialInterface.hlsli"
 
@@ -34,6 +35,9 @@ float4 psmain(StandardVertexOutput input) : SV_TARGET
     }
     else if(Draw.dbgVtxAttrIndex == DBG_VTX_ATTR_INDEX_TANGENT) {
         color = mul(Instances[Draw.instanceIndex].modelMatrix, float4(input.Tangent.xyz, 0)).xyz;
+    }
+    else if(Draw.dbgVtxAttrIndex == DBG_VTX_ATTR_INDEX_COLOR) {
+        color = input.Color;
     }
 
     return float4(normalize(color), 1);

--- a/assets/scene_renderer/shaders/MaterialInterface.hlsli
+++ b/assets/scene_renderer/shaders/MaterialInterface.hlsli
@@ -65,6 +65,7 @@ struct DrawParams {
 #define DBG_VTX_ATTR_INDEX_TEXCOORD 1
 #define DBG_VTX_ATTR_INDEX_NORMAL   2
 #define DBG_VTX_ATTR_INDEX_TANGENT  3
+#define DBG_VTX_ATTR_INDEX_COLOR    4
 
 #if defined(__spirv__)
 [[vk::push_constant]]

--- a/assets/scene_renderer/shaders/MaterialVertex.hlsl
+++ b/assets/scene_renderer/shaders/MaterialVertex.hlsl
@@ -15,6 +15,7 @@
 #define ENABLE_VTX_ATTR_TEXCOORD
 #define ENABLE_VTX_ATTR_NORMAL
 #define ENABLE_VTX_ATTR_TANGENT
+#define ENABLE_VTX_ATTR_COLOR
 #include "MaterialInterface.hlsli"
 
 StandardVertexOutput vsmain(StandardVertexInput input)
@@ -29,5 +30,6 @@ StandardVertexOutput vsmain(StandardVertexInput input)
     output.TexCoord   = input.TexCoord;
     output.Normal     = input.Normal;
     output.Tangent    = input.Tangent;
+    output.Color      = input.Color;
     return output;
 }

--- a/assets/scene_renderer/shaders/StandardMaterial.hlsl
+++ b/assets/scene_renderer/shaders/StandardMaterial.hlsl
@@ -15,6 +15,7 @@
 #define ENABLE_VTX_ATTR_TEXCOORD
 #define ENABLE_VTX_ATTR_NORMAL
 #define ENABLE_VTX_ATTR_TANGENT
+#define ENABLE_VTX_ATTR_COLOR
 #include "MaterialInterface.hlsli"
 
 #include "ppx/PBR.hlsli"
@@ -46,6 +47,7 @@ float4 psmain(StandardVertexOutput input) : SV_TARGET
 
         baseColor =  baseColor * float4(RemoveGamma(color.rgb, 2.2), color.a);
     }
+    baseColor.rgb *= input.Color;
 
     // Metal/roughness
     float metallic  = material.metallicFactor;

--- a/assets/scene_renderer/shaders/UnlitMaterial.hlsl
+++ b/assets/scene_renderer/shaders/UnlitMaterial.hlsl
@@ -15,6 +15,7 @@
 #define ENABLE_VTX_ATTR_TEXCOORD
 #define ENABLE_VTX_ATTR_NORMAL
 #define ENABLE_VTX_ATTR_TANGENT
+#define ENABLE_VTX_ATTR_COLOR
 #include "MaterialInterface.hlsli"
 
 // -------------------------------------------------------------------------------------------------
@@ -38,6 +39,7 @@ float4 psmain(StandardVertexOutput input) : SV_TARGET
         float4 value = tex.Sample(sam, uv);
         color = color * value;
     }
+    color.rgb *= input.Color;
 
     return color;
 }

--- a/src/ppx/scene/scene_gltf_loader.cpp
+++ b/src/ppx/scene/scene_gltf_loader.cpp
@@ -1658,12 +1658,24 @@ ppx::Result GltfLoader::LoadMeshData(
                 std::vector<glm::float3> colors;
                 if (loadParams.requiredVertexAttributes.bits.colors && !IsNull(gltflAccessors.pColors)) {
                     PPX_ASSERT_MSG((colorFormat == targetColorFormat), "GLTF: vertex colors format is not supported");
-                    colors = UnpackFloat3s(*gltflAccessors.pColors);
+                    if (gltflAccessors.pColors->type == cgltf_type_vec3) {
+                        colors = UnpackFloat3s(*gltflAccessors.pColors);
+                    }
+                    else if (gltflAccessors.pColors->type == cgltf_type_vec4) {
+                        auto colors4 = UnpackFloat4s(*gltflAccessors.pColors);
+                        for (auto& c : colors4) {
+                            colors.push_back(glm::float3(c.r, c.g, c.b));
+                        }
+                    }
+                    else {
+                        PPX_ASSERT_MSG(false, "GLTF: vertex colors format must be VEC3 or VEC4");
+                    }
                 }
 
                 // Process vertex data
                 for (cgltf_size i = 0; i < gltflAccessors.pPositions->count; ++i) {
                     TriMeshVertexData vertexData = {};
+                    vertexData.color            = glm::float3(1, 1, 1);
 
                     vertexData.position = positions[i];
                     if (loadParams.requiredVertexAttributes.bits.normals && !normals.empty()) {

--- a/src/ppx/scene/scene_gltf_loader.cpp
+++ b/src/ppx/scene/scene_gltf_loader.cpp
@@ -1675,7 +1675,7 @@ ppx::Result GltfLoader::LoadMeshData(
                 // Process vertex data
                 for (cgltf_size i = 0; i < gltflAccessors.pPositions->count; ++i) {
                     TriMeshVertexData vertexData = {};
-                    vertexData.color            = glm::float3(1, 1, 1);
+                    vertexData.color = glm::float3(1, 1, 1);
 
                     vertexData.position = positions[i];
                     if (loadParams.requiredVertexAttributes.bits.normals && !normals.empty()) {


### PR DESCRIPTION
---

 ## Description
  Implement glTF COLOR_0 vertex color support in the scene renderer.

  According to the glTF 2.0 specification (Section 3.9.2):
  > In addition to the material properties, if a primitive specifies a vertex color using the attribute
  semantic property COLOR_0, then this value acts as an additional linear multiplier to base color.

  Previously, while GltfLoader would load the COLOR_0 accessor, the data was not being utilized by the
  StandardMaterial or UnlitMaterial shaders. This PR enables the vertex color attribute across the scene
  renderer's shader pipeline and applies it as a linear multiplier to the base color.

## Problem
  Vertex colors provided in glTF assets were being ignored during shading, resulting in incorrect
  rendering for models that rely on COLOR_0 for tinting, baked effects, or specific material tests.

## Solution
   1. Shader Pipeline Updates:
       * Modified MaterialVertex.hlsl to define ENABLE_VTX_ATTR_COLOR and pass the color attribute from
         vertex input to the pixel shader.
       * Updated StandardMaterial.hlsl and UnlitMaterial.hlsl to multiply the calculated baseColor by
         input.Color.
   2. GltfLoader Enhancements:
       * Updated GltfLoader::LoadMeshData in scene_gltf_loader.cpp to correctly handle both VEC3 and VEC4
         glTF vertex color formats.
       * Ensured the default vertex color is set to white (1, 1, 1) when the attribute is missing,
         preventing unintended darkening.
   3. Debug Support:
       * Added DBG_VTX_ATTR_INDEX_COLOR to MaterialInterface.hlsli.
       * Updated DebugMaterial.hlsl to allow visualizing vertex colors for debugging purposes.
## Verification Results
  These changes enable correct rendering for several glTF-Sample-Assets, including:
   * BoxVertexColor
   * CompareBaseColor
   * IridescentDishWithOlives
   * PrimitiveModeNormalsTest
   * RecursiveSkeleton
   * SheenWoodLeatherSofa
   * VertexColorTest

  ---