### PR TITLE
Document clang-format-16 in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ your changes:
 
 *   Ensure the code follows the
     [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
-    Running `clang-format -style=file -i [modified-files]` can help.
+*   Format modified C++ files with clang-format-16: `clang-format-16 -style=file -i [modified-files]`
 *   Code should target C++17
 *   Create a pull request (PR) with your patch.
 *   1 PR = 1 change. If you want to add 3 features, that's 3 PRs.


### PR DESCRIPTION
Code must be formatted with clang-format-16. Document this in CONTRIBUTING.