### PR TITLE
Document running samples like gltf_basic_materials

### DIFF
--- a/docs/building_and_running.md
+++ b/docs/building_and_running.md
@@ -2,7 +2,14 @@
 The recommended build system is CMake (version 3.20 and above). This repo supports both in-tree, and out-of-tree builds.
 The recommended generator is `Visual Studio 2022` for Windows and `Ninja` for Linux, but others are also supported.
 
-Binaries are written to `<build-dir>/bin` and libraries to `<build-dir>/lib`.
+Binaries and libraries are written to slightly different directories depending on whether you're using a multi-config generator or not:
+
+* For multi-config generators like Visual Studio:
+  * Binaries are written to `<build-dir>/bin/Debug` or `<build-dir>/bin/Release` depending on the chosen configuration
+  * Libraries are written to `<build-dir>/lib/Debug` or `<build-dir>/lib/Release` depending on the chosen configuration
+* For non-multi-config generators like Ninja:
+  * Binaries are written to `<build-dir>/bin`
+  * Libraries are written to `<build-dir>/lib`
 
 Shaders are also written to `<build-dir>`, but prefixed with their path and the format. For example:
 
@@ -16,6 +23,8 @@ Binaries have prefixes indicating the target graphics API and shader format:
    * Shaders are compiled with DXC/SPIR-V
 
 Build instructions vary slightly depending on the host and target platforms.
+
+Binaries are prefixed with `vk_` when compiling with Vulkan support enabled and `dx12_` when compiling with DirectX12 support enabled.
 
 ## Prerequisites
 
@@ -70,7 +79,7 @@ cmake -B build -G "Visual Studio 16 2019" -A x64
 
 Open `build\BigWheels.sln` and build.
 
-Built binaries are written to `build\bin`.
+Built binaries are written to `build\bin\Debug` or `build\bin\Release` depending on your configuration.
 
 **Note: there is an outstanding [issue](https://github.com/google/bigwheels/issues/97) around duplicate targets in VS solutions which may cause build failures when building many shader targets in parallel. As a temporary workaround, you can re-trigger the build and it will eventually work.**
 

--- a/projects/gltf_basic_materials/README.md
+++ b/projects/gltf_basic_materials/README.md
@@ -1,0 +1,21 @@
+# gltf_basic_materials
+
+This sample loads a scene with `ppx::scene::GltfLoader` and rendering it.
+
+After building, run `gltf_basic_materials` for the desired API in your build directory. E.g. for Vulkan:
+
+```sh
+vk_gltf_basic_materials
+```
+
+By default, this will load `//assets/scene_renderer/scenes/tests/gltf_test_basic_materials.glb`. You can change which scene to load using the `--gltf-scene-asset` option:
+
+```sh
+vk_gltf_basic_materials --gltf-scene-asset basic/models/altimeter/altimeter.gltf
+```
+
+This loads and renders `//assets/basic/models/altimeter/altimeter.gltf`. Notice that the provided path must be relative to one of the following directories:
+
+* `//assets/`
+* `//third_party/assets/`
+* Any path provided via `--extra-assets-path`

--- a/projects/gltf_basic_materials/README.md
+++ b/projects/gltf_basic_materials/README.md
@@ -1,6 +1,6 @@
 # gltf_basic_materials
 
-This sample loads a scene with `ppx::scene::GltfLoader` and rendering it.
+This sample loads a scene with `ppx::scene::GltfLoader` and renders it.
 
 After building, run `gltf_basic_materials` for the desired API in your build directory. E.g. for Vulkan:
 

--- a/projects/gltf_basic_materials/README.md
+++ b/projects/gltf_basic_materials/README.md
@@ -19,3 +19,24 @@ This loads and renders `//assets/basic/models/altimeter/altimeter.gltf`. Notice 
 * `//assets/`
 * `//third_party/assets/`
 * Any path provided via `--extra-assets-path`
+
+## glTF-Sample-Assets
+
+Since BigWheels does not provide many glTF scenes, it is recommended to test changes against [KhronosGroup/gltf-Sample-Assets](https://github.com/KhronosGroup/glTF-Sample-Assets).
+
+First, clone the repository. This does not have to be in the BigWheels checkout:
+
+```sh
+git clone https://github.com/KhronosGroup/glTF-Sample-Assets
+```
+
+Second, run `gltf_basic_materials` with the desired scene.
+
+```sh
+vk_gltf_basic_materials --gltf-scene-asset Box/glTF/Box.gltf --extra-assets-path some/path/to/glTF-Sample-Assets/Models
+```
+
+Notice that we provide:
+
+* `--extra-assets-path` which points to the `Models` directory in the location of the glTF-Sample-Assets clone
+* `--gltf-scene-asset` to load the Box model.

--- a/src/ppx/scene/README.md
+++ b/src/ppx/scene/README.md
@@ -1,0 +1,7 @@
+# Scene Graph
+
+This directory contains implementations for scene graph loading and rendering.
+
+Of note is the `GltfLoader` class in `scene_gltf_loader.cpp`. This class can parse a `.gltf` file and return a renderable `Scene`.
+
+To test changes to this implementation, run the `gltf_basic_materials` sample in `//projects/gltf_basic_materials`.


### PR DESCRIPTION
The building and running instructions didn't note:

* The difference between multi-config and non-multi-config generators
* The binary API prefix

Additionally, gltf_basic_materials has some extra knobs that are useful for those wishing to effectively run the sample. These have been documented in a project-specific README