### PR TITLE
platform: Add AArch64 CPU feature detection

### DIFF
--- a/include/ppx/platform.h
+++ b/include/ppx/platform.h
@@ -103,16 +103,16 @@ public:
     CpuInfo() {}
     ~CpuInfo() {}
 
-    const char*     GetBrandString() const { return mBrandString.c_str(); }
-    const char*     GetVendorString() const { return mVendorString.c_str(); }
-    const char*     GetMicroarchitectureString() const { return mMicroarchitectureString.c_str(); }
-    uint32_t        GetL1CacheSize() const { return mL1CacheSize; }
-    uint32_t        GetL2CacheSize() const { return mL2CacheSize; }
-    uint32_t        GetL3CacheSize() const { return mL3CacheSize; }
-    uint32_t        GetL1CacheLineSize() const { return mL1CacheLineSize; }
-    uint32_t        GetL2CacheLineSize() const { return mL2CacheLineSize; }
-    uint32_t        GetL3CacheLineSize() const { return mL3CacheLineSize; }
-    const Features& GetFeatures() const { return mFeatures; }
+    const char*            GetBrandString() const { return mBrandString.c_str(); }
+    const char*            GetVendorString() const { return mVendorString.c_str(); }
+    const char*            GetMicroarchitectureString() const { return mMicroarchitectureString.c_str(); }
+    uint32_t               GetL1CacheSize() const { return mL1CacheSize; }
+    uint32_t               GetL2CacheSize() const { return mL2CacheSize; }
+    uint32_t               GetL3CacheSize() const { return mL3CacheSize; }
+    uint32_t               GetL1CacheLineSize() const { return mL1CacheLineSize; }
+    uint32_t               GetL2CacheLineSize() const { return mL2CacheLineSize; }
+    uint32_t               GetL3CacheLineSize() const { return mL3CacheLineSize; }
+    const Features&        GetFeatures() const { return mFeatures; }
     const AArch64Features& GetAArch64Features() const { return mAArch64Features; }
 
 private:
@@ -123,15 +123,15 @@ private:
 #endif
 
 private:
-    std::string mBrandString;
-    std::string mVendorString;
-    std::string mMicroarchitectureString;
-    uint32_t    mL1CacheSize     = 0;
-    uint32_t    mL2CacheSize     = 0;
-    uint32_t    mL3CacheSize     = 0;
-    uint32_t    mL1CacheLineSize = 0;
-    uint32_t    mL2CacheLineSize = 0;
-    uint32_t    mL3CacheLineSize = 0;
+    std::string     mBrandString;
+    std::string     mVendorString;
+    std::string     mMicroarchitectureString;
+    uint32_t        mL1CacheSize     = 0;
+    uint32_t        mL2CacheSize     = 0;
+    uint32_t        mL3CacheSize     = 0;
+    uint32_t        mL1CacheLineSize = 0;
+    uint32_t        mL2CacheLineSize = 0;
+    uint32_t        mL3CacheLineSize = 0;
     Features        mFeatures        = {};
     AArch64Features mAArch64Features = {};
 };

--- a/include/ppx/platform.h
+++ b/include/ppx/platform.h
@@ -64,6 +64,40 @@ public:
         bool amx_int8            = false;
     };
 
+    struct AArch64Features
+    {
+        bool fp       = false;
+        bool asimd    = false;
+        bool aes      = false;
+        bool pmull    = false;
+        bool sha1     = false;
+        bool sha2     = false;
+        bool sha512   = false;
+        bool sha3     = false;
+        bool crc32    = false;
+        bool atomics  = false;
+        bool fphp     = false;
+        bool asimdhp  = false;
+        bool asimdrdm = false;
+        bool asimddp  = false;
+        bool asimdfhm = false;
+        bool fcma     = false;
+        bool lrcpc    = false;
+        bool dcpop    = false;
+        bool dit      = false;
+        bool ssbs     = false;
+        bool bti      = false;
+        bool paca     = false;
+        bool pacg     = false;
+        bool rng      = false;
+        bool mte      = false;
+        bool sve      = false;
+        bool sve2     = false;
+        bool i8mm     = false;
+        bool bf16     = false;
+        bool sme      = false;
+    };
+
     // ---------------------------------------------------------------------------------------------
 
     CpuInfo() {}
@@ -79,9 +113,14 @@ public:
     uint32_t        GetL2CacheLineSize() const { return mL2CacheLineSize; }
     uint32_t        GetL3CacheLineSize() const { return mL3CacheLineSize; }
     const Features& GetFeatures() const { return mFeatures; }
+    const AArch64Features& GetAArch64Features() const { return mAArch64Features; }
 
 private:
+#if defined(__aarch64__) || defined(_M_ARM64)
+    friend CpuInfo GetAArch64CpuInfo();
+#else
     friend CpuInfo GetX86CpuInfo();
+#endif
 
 private:
     std::string mBrandString;
@@ -93,7 +132,8 @@ private:
     uint32_t    mL1CacheLineSize = 0;
     uint32_t    mL2CacheLineSize = 0;
     uint32_t    mL3CacheLineSize = 0;
-    Features    mFeatures        = {0};
+    Features        mFeatures        = {};
+    AArch64Features mAArch64Features = {};
 };
 
 class Platform

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 project(projects)
 
-if (!PPX_ANDROID)
+if (NOT PPX_ANDROID)
   add_subdirectory(sample_00_ppx_info)
 endif ()
 

--- a/projects/sample_00_ppx_info/main.cpp
+++ b/projects/sample_00_ppx_info/main.cpp
@@ -92,6 +92,7 @@ int main(int argc, char** argv)
         PPX_ASSERT_MSG(false, "grfx::CreateInstance failed");
         return EXIT_FAILURE;
     }
+    PPX_LOG_INFO("Graphics instance and devices created successfully.");
 
     grfx::DestroyInstance(instance);
 

--- a/projects/sample_00_ppx_info/main.cpp
+++ b/projects/sample_00_ppx_info/main.cpp
@@ -21,8 +21,66 @@ const grfx::Api kApi = grfx::API_DX_12_0;
 const grfx::Api kApi = grfx::API_VK_1_1;
 #endif
 
+static void LogCpuInfo()
+{
+    const CpuInfo& cpu = Platform::GetCpuInfo();
+    // clang-format off
+    PPX_LOG_INFO("Platform         : " << Platform::GetPlatformString());
+    PPX_LOG_INFO("CPU vendor       : " << cpu.GetVendorString());
+    PPX_LOG_INFO("CPU microarch    : " << cpu.GetMicroarchitectureString());
+#if defined(__aarch64__) || defined(_M_ARM64)
+    const CpuInfo::AArch64Features& f = cpu.GetAArch64Features();
+    PPX_LOG_INFO("   fp            : " << f.fp);
+    PPX_LOG_INFO("   asimd         : " << f.asimd);
+    PPX_LOG_INFO("   aes           : " << f.aes);
+    PPX_LOG_INFO("   pmull         : " << f.pmull);
+    PPX_LOG_INFO("   sha1          : " << f.sha1);
+    PPX_LOG_INFO("   sha2          : " << f.sha2);
+    PPX_LOG_INFO("   sha512        : " << f.sha512);
+    PPX_LOG_INFO("   sha3          : " << f.sha3);
+    PPX_LOG_INFO("   crc32         : " << f.crc32);
+    PPX_LOG_INFO("   atomics       : " << f.atomics);
+    PPX_LOG_INFO("   fphp          : " << f.fphp);
+    PPX_LOG_INFO("   asimdhp       : " << f.asimdhp);
+    PPX_LOG_INFO("   asimdrdm      : " << f.asimdrdm);
+    PPX_LOG_INFO("   asimddp       : " << f.asimddp);
+    PPX_LOG_INFO("   asimdfhm      : " << f.asimdfhm);
+    PPX_LOG_INFO("   fcma          : " << f.fcma);
+    PPX_LOG_INFO("   lrcpc         : " << f.lrcpc);
+    PPX_LOG_INFO("   dcpop         : " << f.dcpop);
+    PPX_LOG_INFO("   dit           : " << f.dit);
+    PPX_LOG_INFO("   ssbs          : " << f.ssbs);
+    PPX_LOG_INFO("   bti           : " << f.bti);
+    PPX_LOG_INFO("   paca          : " << f.paca);
+    PPX_LOG_INFO("   pacg          : " << f.pacg);
+    PPX_LOG_INFO("   rng           : " << f.rng);
+    PPX_LOG_INFO("   mte           : " << f.mte);
+    PPX_LOG_INFO("   sve           : " << f.sve);
+    PPX_LOG_INFO("   sve2          : " << f.sve2);
+    PPX_LOG_INFO("   i8mm          : " << f.i8mm);
+    PPX_LOG_INFO("   bf16          : " << f.bf16);
+    PPX_LOG_INFO("   sme           : " << f.sme);
+#else
+    const CpuInfo::Features& f = cpu.GetFeatures();
+    PPX_LOG_INFO("   SSE           : " << f.sse);
+    PPX_LOG_INFO("   SSE2          : " << f.sse2);
+    PPX_LOG_INFO("   SSE3          : " << f.sse3);
+    PPX_LOG_INFO("   SSSE3         : " << f.ssse3);
+    PPX_LOG_INFO("   SSE4_1        : " << f.sse4_1);
+    PPX_LOG_INFO("   SSE4_2        : " << f.sse4_2);
+    PPX_LOG_INFO("   SSE4A         : " << f.sse4a);
+    PPX_LOG_INFO("   AVX           : " << f.avx);
+    PPX_LOG_INFO("   AVX2          : " << f.avx2);
+#endif
+    // clang-format on
+}
+
 int main(int argc, char** argv)
 {
+    ppx::Log::Initialize(LOG_MODE_CONSOLE);
+
+    LogCpuInfo();
+
     grfx::InstanceCreateInfo createInfo = {};
     createInfo.api                      = kApi;
     createInfo.createDevices            = true; // Tells the instance to automatically create a device for each GPU it finds.
@@ -30,13 +88,10 @@ int main(int argc, char** argv)
 
     grfx::InstancePtr instance;
     Result            ppxres = grfx::CreateInstance(&createInfo, &instance);
-    if (ppxres != ppx::SUCCESS) {
+    if (Failed(ppxres)) {
         PPX_ASSERT_MSG(false, "grfx::CreateInstance failed");
         return EXIT_FAILURE;
     }
-
-    ppx::Log::Initialize(LOG_MODE_CONSOLE);
-    PPX_LOG_INFO("Graphics instance and devices created successfully.");
 
     grfx::DestroyInstance(instance);
 

--- a/src/ppx/platform.cpp
+++ b/src/ppx/platform.cpp
@@ -37,7 +37,9 @@ static Platform sPlatform = Platform();
 #if defined(PPX_ANDROID)
 // TODO: Fill out ANDROID-specific info
 #elif defined(__aarch64__) || defined(_M_ARM64)
-static const char* GetAArch64VendorName(int implementer)
+namespace {
+
+const char* GetAArch64VendorName(int implementer)
 {
     // Implementer codes from Linux kernel arch/arm64/include/asm/cputype.h (ARM_CPU_IMP_*).
     switch (implementer) {
@@ -57,142 +59,190 @@ static const char* GetAArch64VendorName(int implementer)
     return "Unknown";
 }
 
-static const char* GetAArch64MicroarchitectureName(int implementer, int part)
+const char* GetAArch64ArmMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0xD03: return "Cortex-A53";
+        case 0xD04: return "Cortex-A35";
+        case 0xD05: return "Cortex-A55";
+        case 0xD07: return "Cortex-A57";
+        case 0xD08: return "Cortex-A72";
+        case 0xD09: return "Cortex-A73";
+        case 0xD0A: return "Cortex-A75";
+        case 0xD0B: return "Cortex-A76";
+        case 0xD0C: return "Neoverse-N1";
+        case 0xD0D: return "Cortex-A77";
+        case 0xD0E: return "Cortex-A76AE";
+        case 0xD40: return "Neoverse-V1";
+        case 0xD41: return "Cortex-A78";
+        case 0xD42: return "Cortex-A78AE";
+        case 0xD44: return "Cortex-X1";
+        case 0xD46: return "Cortex-A510";
+        case 0xD47: return "Cortex-A710";
+        case 0xD48: return "Cortex-X2";
+        case 0xD49: return "Neoverse-N2";
+        case 0xD4B: return "Cortex-A78C";
+        case 0xD4C: return "Cortex-X1C";
+        case 0xD4D: return "Cortex-A715";
+        case 0xD4E: return "Cortex-X3";
+        case 0xD4F: return "Neoverse-V2";
+        case 0xD80: return "Cortex-A520";
+        case 0xD81: return "Cortex-A720";
+        case 0xD82: return "Cortex-X4";
+        case 0xD83: return "Neoverse-V3AE";
+        case 0xD84: return "Neoverse-V3";
+        case 0xD85: return "Cortex-X925";
+        case 0xD87: return "Cortex-A725";
+        case 0xD89: return "Cortex-A720AE";
+        case 0xD8E: return "Neoverse-N3";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64BroadcomMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0x100: return "Brahma-B53";
+        case 0x516: return "Vulcan";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64CaviumMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0x0A1: return "ThunderX";
+        case 0x0A2: return "ThunderX 81xx";
+        case 0x0A3: return "ThunderX 83xx";
+        case 0x0AF: return "ThunderX2";
+        case 0x0B1: return "OcteonTX2 98xx";
+        case 0x0B2: return "OcteonTX2 96xx";
+        case 0x0B3: return "OcteonTX2 95xx";
+        case 0x0B4: return "OcteonTX2 95xxN";
+        case 0x0B5: return "OcteonTX2 95xxMM";
+        case 0x0B6: return "OcteonTX2 95xxO";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64FujitsuMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0x001: return "A64FX";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64HiSiliconMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0xD01: return "TSV110";
+        case 0xD02: return "HIP09";
+        case 0xD06: return "HIP12";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64NvidiaMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0x003: return "Denver";
+        case 0x004: return "Carmel";
+        case 0x010: return "Olympus";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64ApmMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0x000: return "X-Gene";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64QualcommMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0x001: return "Oryon X1";
+        case 0x200: return "Kryo";
+        case 0x800: return "Falkor V1";
+        case 0x801: return "Kryo 2xx Silver";
+        case 0x802: return "Kryo 3xx Gold";
+        case 0x803: return "Kryo 3xx Silver";
+        case 0x804: return "Kryo 4xx Gold";
+        case 0x805: return "Kryo 4xx Silver";
+        case 0xC00: return "Falkor";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64AppleMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0x022: return "M1 Icestorm";
+        case 0x023: return "M1 Firestorm";
+        case 0x024: return "M1 Icestorm Pro";
+        case 0x025: return "M1 Firestorm Pro";
+        case 0x028: return "M1 Icestorm Max";
+        case 0x029: return "M1 Firestorm Max";
+        case 0x032: return "M2 Blizzard";
+        case 0x033: return "M2 Avalanche";
+        case 0x034: return "M2 Blizzard Pro";
+        case 0x035: return "M2 Avalanche Pro";
+        case 0x038: return "M2 Blizzard Max";
+        case 0x039: return "M2 Avalanche Max";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64MicrosoftMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0xD49: return "Azure Cobalt 100";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64AmpereMicroarchitectureName(int part)
+{
+    switch (part) {
+        case 0xAC3: return "Ampere1";
+        case 0xAC4: return "Ampere1A";
+        default: break;
+    }
+    return nullptr;
+}
+
+const char* GetAArch64MicroarchitectureName(int implementer, int part)
 {
     // Part numbers from Linux kernel arch/arm64/include/asm/cputype.h (*_CPU_PART_*).
-    if (implementer == 0x41) { // ARM
-        switch (part) {
-            case 0xD03: return "Cortex-A53";
-            case 0xD04: return "Cortex-A35";
-            case 0xD05: return "Cortex-A55";
-            case 0xD07: return "Cortex-A57";
-            case 0xD08: return "Cortex-A72";
-            case 0xD09: return "Cortex-A73";
-            case 0xD0A: return "Cortex-A75";
-            case 0xD0B: return "Cortex-A76";
-            case 0xD0C: return "Neoverse-N1";
-            case 0xD0D: return "Cortex-A77";
-            case 0xD0E: return "Cortex-A76AE";
-            case 0xD40: return "Neoverse-V1";
-            case 0xD41: return "Cortex-A78";
-            case 0xD42: return "Cortex-A78AE";
-            case 0xD44: return "Cortex-X1";
-            case 0xD46: return "Cortex-A510";
-            case 0xD47: return "Cortex-A710";
-            case 0xD48: return "Cortex-X2";
-            case 0xD49: return "Neoverse-N2";
-            case 0xD4B: return "Cortex-A78C";
-            case 0xD4C: return "Cortex-X1C";
-            case 0xD4D: return "Cortex-A715";
-            case 0xD4E: return "Cortex-X3";
-            case 0xD4F: return "Neoverse-V2";
-            case 0xD80: return "Cortex-A520";
-            case 0xD81: return "Cortex-A720";
-            case 0xD82: return "Cortex-X4";
-            case 0xD83: return "Neoverse-V3AE";
-            case 0xD84: return "Neoverse-V3";
-            case 0xD85: return "Cortex-X925";
-            case 0xD87: return "Cortex-A725";
-            case 0xD89: return "Cortex-A720AE";
-            case 0xD8E: return "Neoverse-N3";
-            default: break;
-        }
+    const char* name = nullptr;
+    switch (implementer) {
+        case 0x41: name = GetAArch64ArmMicroarchitectureName(part); break;
+        case 0x42: name = GetAArch64BroadcomMicroarchitectureName(part); break;
+        case 0x43: name = GetAArch64CaviumMicroarchitectureName(part); break;
+        case 0x46: name = GetAArch64FujitsuMicroarchitectureName(part); break;
+        case 0x48: name = GetAArch64HiSiliconMicroarchitectureName(part); break;
+        case 0x4e: name = GetAArch64NvidiaMicroarchitectureName(part); break;
+        case 0x50: name = GetAArch64ApmMicroarchitectureName(part); break;
+        case 0x51: name = GetAArch64QualcommMicroarchitectureName(part); break;
+        case 0x61: name = GetAArch64AppleMicroarchitectureName(part); break;
+        case 0x6d: name = GetAArch64MicrosoftMicroarchitectureName(part); break;
+        case 0xc0: name = GetAArch64AmpereMicroarchitectureName(part); break;
+        default: break;
     }
-    else if (implementer == 0x42) { // Broadcom
-        switch (part) {
-            case 0x100: return "Brahma-B53";
-            case 0x516: return "Vulcan";
-            default: break;
-        }
-    }
-    else if (implementer == 0x43) { // Cavium
-        switch (part) {
-            case 0x0A1: return "ThunderX";
-            case 0x0A2: return "ThunderX 81xx";
-            case 0x0A3: return "ThunderX 83xx";
-            case 0x0AF: return "ThunderX2";
-            case 0x0B1: return "OcteonTX2 98xx";
-            case 0x0B2: return "OcteonTX2 96xx";
-            case 0x0B3: return "OcteonTX2 95xx";
-            case 0x0B4: return "OcteonTX2 95xxN";
-            case 0x0B5: return "OcteonTX2 95xxMM";
-            case 0x0B6: return "OcteonTX2 95xxO";
-            default: break;
-        }
-    }
-    else if (implementer == 0x46) { // Fujitsu
-        switch (part) {
-            case 0x001: return "A64FX";
-            default: break;
-        }
-    }
-    else if (implementer == 0x48) { // HiSilicon
-        switch (part) {
-            case 0xD01: return "TSV110";
-            case 0xD02: return "HIP09";
-            case 0xD06: return "HIP12";
-            default: break;
-        }
-    }
-    else if (implementer == 0x4e) { // NVIDIA
-        switch (part) {
-            case 0x003: return "Denver";
-            case 0x004: return "Carmel";
-            case 0x010: return "Olympus";
-            default: break;
-        }
-    }
-    else if (implementer == 0x50) { // APM
-        switch (part) {
-            case 0x000: return "X-Gene";
-            default: break;
-        }
-    }
-    else if (implementer == 0x51) { // Qualcomm
-        switch (part) {
-            case 0x001: return "Oryon X1";
-            case 0x200: return "Kryo";
-            case 0x800: return "Falkor V1";
-            case 0x801: return "Kryo 2xx Silver";
-            case 0x802: return "Kryo 3xx Gold";
-            case 0x803: return "Kryo 3xx Silver";
-            case 0x804: return "Kryo 4xx Gold";
-            case 0x805: return "Kryo 4xx Silver";
-            case 0xC00: return "Falkor";
-            default: break;
-        }
-    }
-    else if (implementer == 0x61) { // Apple
-        switch (part) {
-            case 0x022: return "M1 Icestorm";
-            case 0x023: return "M1 Firestorm";
-            case 0x024: return "M1 Icestorm Pro";
-            case 0x025: return "M1 Firestorm Pro";
-            case 0x028: return "M1 Icestorm Max";
-            case 0x029: return "M1 Firestorm Max";
-            case 0x032: return "M2 Blizzard";
-            case 0x033: return "M2 Avalanche";
-            case 0x034: return "M2 Blizzard Pro";
-            case 0x035: return "M2 Avalanche Pro";
-            case 0x038: return "M2 Blizzard Max";
-            case 0x039: return "M2 Avalanche Max";
-            default: break;
-        }
-    }
-    else if (implementer == 0x6d) { // Microsoft
-        switch (part) {
-            case 0xD49: return "Azure Cobalt 100";
-            default: break;
-        }
-    }
-    else if (implementer == 0xc0) { // Ampere
-        switch (part) {
-            case 0xAC3: return "Ampere1";
-            case 0xAC4: return "Ampere1A";
-            default: break;
-        }
-    }
-    return "Unknown AArch64";
+    return name ? name : "Unknown AArch64";
 }
 
 CpuInfo GetAArch64CpuInfo()
@@ -237,7 +287,11 @@ CpuInfo GetAArch64CpuInfo()
 
     return cpuInfo;
 }
+
+} // namespace
 #else
+namespace {
+
 const char* GetX86LongMicroarchitectureName(cpu_features::X86Microarchitecture march)
 {
     // clang-format off
@@ -317,6 +371,8 @@ CpuInfo GetX86CpuInfo()
 
     return cpuInfo;
 }
+
+} // namespace
 #endif
 
 // -------------------------------------------------------------------------------------------------

--- a/src/ppx/platform.cpp
+++ b/src/ppx/platform.cpp
@@ -17,6 +17,8 @@
 
 #if defined(PPX_ANDROID)
 // TODO: Fill out ANDROID-specific header
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#include "cpuinfo_aarch64.h"
 #else
 #include "cpuinfo_x86.h"
 #endif
@@ -34,6 +36,207 @@ static Platform sPlatform = Platform();
 // -------------------------------------------------------------------------------------------------
 #if defined(PPX_ANDROID)
 // TODO: Fill out ANDROID-specific info
+#elif defined(__aarch64__) || defined(_M_ARM64)
+static const char* GetAArch64VendorName(int implementer)
+{
+    // Implementer codes from Linux kernel arch/arm64/include/asm/cputype.h (ARM_CPU_IMP_*).
+    switch (implementer) {
+        case 0x41: return "ARM";
+        case 0x42: return "Broadcom";
+        case 0x43: return "Cavium";
+        case 0x46: return "Fujitsu";
+        case 0x48: return "HiSilicon";
+        case 0x4e: return "NVIDIA";
+        case 0x50: return "APM";
+        case 0x51: return "Qualcomm";
+        case 0x61: return "Apple";
+        case 0x6d: return "Microsoft";
+        case 0xc0: return "Ampere";
+        default: break;
+    }
+    return "Unknown";
+}
+
+static const char* GetAArch64MicroarchitectureName(int implementer, int part)
+{
+    // Part numbers from Linux kernel arch/arm64/include/asm/cputype.h (*_CPU_PART_*).
+    if (implementer == 0x41) { // ARM
+        switch (part) {
+            case 0xD03: return "Cortex-A53";
+            case 0xD04: return "Cortex-A35";
+            case 0xD05: return "Cortex-A55";
+            case 0xD07: return "Cortex-A57";
+            case 0xD08: return "Cortex-A72";
+            case 0xD09: return "Cortex-A73";
+            case 0xD0A: return "Cortex-A75";
+            case 0xD0B: return "Cortex-A76";
+            case 0xD0C: return "Neoverse-N1";
+            case 0xD0D: return "Cortex-A77";
+            case 0xD0E: return "Cortex-A76AE";
+            case 0xD40: return "Neoverse-V1";
+            case 0xD41: return "Cortex-A78";
+            case 0xD42: return "Cortex-A78AE";
+            case 0xD44: return "Cortex-X1";
+            case 0xD46: return "Cortex-A510";
+            case 0xD47: return "Cortex-A710";
+            case 0xD48: return "Cortex-X2";
+            case 0xD49: return "Neoverse-N2";
+            case 0xD4B: return "Cortex-A78C";
+            case 0xD4C: return "Cortex-X1C";
+            case 0xD4D: return "Cortex-A715";
+            case 0xD4E: return "Cortex-X3";
+            case 0xD4F: return "Neoverse-V2";
+            case 0xD80: return "Cortex-A520";
+            case 0xD81: return "Cortex-A720";
+            case 0xD82: return "Cortex-X4";
+            case 0xD83: return "Neoverse-V3AE";
+            case 0xD84: return "Neoverse-V3";
+            case 0xD85: return "Cortex-X925";
+            case 0xD87: return "Cortex-A725";
+            case 0xD89: return "Cortex-A720AE";
+            case 0xD8E: return "Neoverse-N3";
+            default: break;
+        }
+    }
+    else if (implementer == 0x42) { // Broadcom
+        switch (part) {
+            case 0x100: return "Brahma-B53";
+            case 0x516: return "Vulcan";
+            default: break;
+        }
+    }
+    else if (implementer == 0x43) { // Cavium
+        switch (part) {
+            case 0x0A1: return "ThunderX";
+            case 0x0A2: return "ThunderX 81xx";
+            case 0x0A3: return "ThunderX 83xx";
+            case 0x0AF: return "ThunderX2";
+            case 0x0B1: return "OcteonTX2 98xx";
+            case 0x0B2: return "OcteonTX2 96xx";
+            case 0x0B3: return "OcteonTX2 95xx";
+            case 0x0B4: return "OcteonTX2 95xxN";
+            case 0x0B5: return "OcteonTX2 95xxMM";
+            case 0x0B6: return "OcteonTX2 95xxO";
+            default: break;
+        }
+    }
+    else if (implementer == 0x46) { // Fujitsu
+        switch (part) {
+            case 0x001: return "A64FX";
+            default: break;
+        }
+    }
+    else if (implementer == 0x48) { // HiSilicon
+        switch (part) {
+            case 0xD01: return "TSV110";
+            case 0xD02: return "HIP09";
+            case 0xD06: return "HIP12";
+            default: break;
+        }
+    }
+    else if (implementer == 0x4e) { // NVIDIA
+        switch (part) {
+            case 0x003: return "Denver";
+            case 0x004: return "Carmel";
+            case 0x010: return "Olympus";
+            default: break;
+        }
+    }
+    else if (implementer == 0x50) { // APM
+        switch (part) {
+            case 0x000: return "X-Gene";
+            default: break;
+        }
+    }
+    else if (implementer == 0x51) { // Qualcomm
+        switch (part) {
+            case 0x001: return "Oryon X1";
+            case 0x200: return "Kryo";
+            case 0x800: return "Falkor V1";
+            case 0x801: return "Kryo 2xx Silver";
+            case 0x802: return "Kryo 3xx Gold";
+            case 0x803: return "Kryo 3xx Silver";
+            case 0x804: return "Kryo 4xx Gold";
+            case 0x805: return "Kryo 4xx Silver";
+            case 0xC00: return "Falkor";
+            default: break;
+        }
+    }
+    else if (implementer == 0x61) { // Apple
+        switch (part) {
+            case 0x022: return "M1 Icestorm";
+            case 0x023: return "M1 Firestorm";
+            case 0x024: return "M1 Icestorm Pro";
+            case 0x025: return "M1 Firestorm Pro";
+            case 0x028: return "M1 Icestorm Max";
+            case 0x029: return "M1 Firestorm Max";
+            case 0x032: return "M2 Blizzard";
+            case 0x033: return "M2 Avalanche";
+            case 0x034: return "M2 Blizzard Pro";
+            case 0x035: return "M2 Avalanche Pro";
+            case 0x038: return "M2 Blizzard Max";
+            case 0x039: return "M2 Avalanche Max";
+            default: break;
+        }
+    }
+    else if (implementer == 0x6d) { // Microsoft
+        switch (part) {
+            case 0xD49: return "Azure Cobalt 100";
+            default: break;
+        }
+    }
+    else if (implementer == 0xc0) { // Ampere
+        switch (part) {
+            case 0xAC3: return "Ampere1";
+            case 0xAC4: return "Ampere1A";
+            default: break;
+        }
+    }
+    return "Unknown AArch64";
+}
+
+CpuInfo GetAArch64CpuInfo()
+{
+    cpu_features::Aarch64Info info = cpu_features::GetAarch64Info();
+
+    CpuInfo cpuInfo                  = {};
+    cpuInfo.mVendorString            = GetAArch64VendorName(info.implementer);
+    cpuInfo.mMicroarchitectureString = GetAArch64MicroarchitectureName(info.implementer, info.part);
+    // cpu_features::Aarch64Info does not carry a brand string, so mBrandString is left empty.
+
+    cpuInfo.mAArch64Features.fp       = static_cast<bool>(info.features.fp);
+    cpuInfo.mAArch64Features.asimd    = static_cast<bool>(info.features.asimd);
+    cpuInfo.mAArch64Features.aes      = static_cast<bool>(info.features.aes);
+    cpuInfo.mAArch64Features.pmull    = static_cast<bool>(info.features.pmull);
+    cpuInfo.mAArch64Features.sha1     = static_cast<bool>(info.features.sha1);
+    cpuInfo.mAArch64Features.sha2     = static_cast<bool>(info.features.sha2);
+    cpuInfo.mAArch64Features.sha512   = static_cast<bool>(info.features.sha512);
+    cpuInfo.mAArch64Features.sha3     = static_cast<bool>(info.features.sha3);
+    cpuInfo.mAArch64Features.crc32    = static_cast<bool>(info.features.crc32);
+    cpuInfo.mAArch64Features.atomics  = static_cast<bool>(info.features.atomics);
+    cpuInfo.mAArch64Features.fphp     = static_cast<bool>(info.features.fphp);
+    cpuInfo.mAArch64Features.asimdhp  = static_cast<bool>(info.features.asimdhp);
+    cpuInfo.mAArch64Features.asimdrdm = static_cast<bool>(info.features.asimdrdm);
+    cpuInfo.mAArch64Features.asimddp  = static_cast<bool>(info.features.asimddp);
+    cpuInfo.mAArch64Features.asimdfhm = static_cast<bool>(info.features.asimdfhm);
+    cpuInfo.mAArch64Features.fcma     = static_cast<bool>(info.features.fcma);
+    cpuInfo.mAArch64Features.lrcpc    = static_cast<bool>(info.features.lrcpc);
+    cpuInfo.mAArch64Features.dcpop    = static_cast<bool>(info.features.dcpop);
+    cpuInfo.mAArch64Features.dit      = static_cast<bool>(info.features.dit);
+    cpuInfo.mAArch64Features.ssbs     = static_cast<bool>(info.features.ssbs);
+    cpuInfo.mAArch64Features.bti      = static_cast<bool>(info.features.bti);
+    cpuInfo.mAArch64Features.paca     = static_cast<bool>(info.features.paca);
+    cpuInfo.mAArch64Features.pacg     = static_cast<bool>(info.features.pacg);
+    cpuInfo.mAArch64Features.rng      = static_cast<bool>(info.features.rng);
+    cpuInfo.mAArch64Features.mte      = static_cast<bool>(info.features.mte);
+    cpuInfo.mAArch64Features.sve      = static_cast<bool>(info.features.sve);
+    cpuInfo.mAArch64Features.sve2     = static_cast<bool>(info.features.sve2);
+    cpuInfo.mAArch64Features.i8mm     = static_cast<bool>(info.features.i8mm);
+    cpuInfo.mAArch64Features.bf16     = static_cast<bool>(info.features.bf16);
+    cpuInfo.mAArch64Features.sme      = static_cast<bool>(info.features.sme);
+
+    return cpuInfo;
+}
 #else
 const char* GetX86LongMicroarchitectureName(cpu_features::X86Microarchitecture march)
 {
@@ -122,7 +325,9 @@ CpuInfo GetX86CpuInfo()
 Platform::Platform()
 {
 #if defined(PPX_ANDROID)
-    // Call ANDROID-specific function
+    // TODO: Call ANDROID-specific function
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    mCpuInfo = GetAArch64CpuInfo();
 #else
     mCpuInfo = GetX86CpuInfo();
 #endif

--- a/src/ppx/platform.cpp
+++ b/src/ppx/platform.cpp
@@ -245,6 +245,8 @@ const char* GetAArch64MicroarchitectureName(int implementer, int part)
     return name ? name : "Unknown AArch64";
 }
 
+} // namespace
+
 CpuInfo GetAArch64CpuInfo()
 {
     cpu_features::Aarch64Info info = cpu_features::GetAarch64Info();
@@ -288,7 +290,6 @@ CpuInfo GetAArch64CpuInfo()
     return cpuInfo;
 }
 
-} // namespace
 #else
 namespace {
 
@@ -326,6 +327,8 @@ const char* GetX86LongMicroarchitectureName(cpu_features::X86Microarchitecture m
     // clang-format on
     return "Unknown X86 Architecture";
 }
+
+} // namespace
 
 CpuInfo GetX86CpuInfo()
 {
@@ -372,7 +375,6 @@ CpuInfo GetX86CpuInfo()
     return cpuInfo;
 }
 
-} // namespace
 #endif
 
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This all started because I got myself an ARM laptop and tried to build BigWheels on it under Windows and WSL2.

`CpuInfo` only supported x86. On AArch64 the platform-detection code did not compile, `Platform::GetCpuInfo()` returned an empty struct, and `sample_00_ppx_info` did not build.

This PR adds AArch64 support to the CPU detection layer.

1. Add `CpuInfo::AArch64Features` to `platform.h`. It exposes 31 feature flags populated from `cpu_features::GetAarch64Info()`.
2. Add `GetAArch64CpuInfo()` to `platform.cpp`, gated on  `__aarch64__ || _M_ARM64`. Vendor and microarchitecture strings are
   resolved from the `implementer`/`part` fields using codes from the Linux kernel (`arch/arm64/include/asm/cputype.h`).
3. Update `sample_00_ppx_info` to print the AArch64 feature set on AArch64 and the x86 feature set otherwise.
4. Fix `!PPX_ANDROID` to `NOT PPX_ANDROID` in `projects/CMakeLists.txt`. The original expression always evaluated to true, so `sample_00_ppx_info` was always added regardless of the Android target.

Tested on a Snapdragon X Elite (Qualcomm Oryon X1) running Linux AArch64 and Windows 11.

NOTE: On Linux I still cannot get samples to work (they all fail with `VK_ERROR_INCOMPATIBLE_DRIVER`). I think Mesa drivers don't yet support my hardware (Qualcomm(R) Adreno(TM) X1-85 GPU). Or maybe I've not configured it properly.

All the samples work fine on Windows, though. Both in Vulkan and DX12 mode.